### PR TITLE
Fix absolute path resolution of relative Java sources, add explanatory comments

### DIFF
--- a/parser/logger/src/ldlogger-tool.c
+++ b/parser/logger/src/ldlogger-tool.c
@@ -114,6 +114,7 @@ int loggerCollectActionsByProgName(
   const char* const argv_[],
   LoggerVector* actions_)
 {
+  /* Get program name */
   const char* toolName = strrchr(prog_, '/');
   if (toolName)
   {
@@ -126,6 +127,7 @@ int loggerCollectActionsByProgName(
     toolName = prog_;
   }
 
+  /* Collect actions based on tool */
   if (matchToProgramList("CC_LOGGER_GCC_LIKE", toolName))
   {
     int ret;


### PR DESCRIPTION
Before the fix, there was a bug that prevented the logger to recognize relative source file paths from javac argument list. For example this did not work:

`javac HelloWorld.java`

instead, this had to be used for example:

`javac /home/user/cc/projects/hello_java/HelloWorld.java`

Now it resolves relative sources to absolute, like how it works in the GCC variant. The fix was tested with javac compilation with one or multiple sources and ant compilation with one or multiple sources. During the walkthrough of the code, I added some comments for more understandability.