### PR TITLE
Cpp Plugin get reference count

### DIFF
--- a/plugins/cpp/model/include/model/cppastnode.h
+++ b/plugins/cpp/model/include/model/cppastnode.h
@@ -228,6 +228,13 @@ struct AstCountGroupByFiles
   std::size_t count;
 };
 
+#pragma db view object(CppAstNode)
+struct CppAstCount
+{
+  #pragma db column("count(" + CppAstNode::id + ")")
+  std::size_t count;
+};
+
 }
 }
 

--- a/plugins/cpp/model/include/model/cppenum.h
+++ b/plugins/cpp/model/include/model/cppenum.h
@@ -63,6 +63,14 @@ struct CppEnum : CppEntity
 
 typedef std::shared_ptr<CppEnum> CppEnumPtr;
 
+#pragma db view \
+  object(CppEnum) object(CppEnumConstant = EnumConst : CppEnum::enumConstants)
+struct CppEnumConstantsCount
+{
+  #pragma db column("count(" + EnumConst::id + ")")
+  std::size_t count;
+};
+
 }
 }
 

--- a/plugins/cpp/model/include/model/cppfriendship.h
+++ b/plugins/cpp/model/include/model/cppfriendship.h
@@ -33,6 +33,13 @@ struct CppFriendship
 
 typedef std::shared_ptr<CppFriendship> CppFriendshipPtr;
 
+#pragma db view object(CppFriendship)
+struct CppFriendshipCount
+{
+  #pragma db column("count(" + CppFriendship::id + ")")
+  std::size_t count;
+};
+
 }
 }
 

--- a/plugins/cpp/model/include/model/cppfunction.h
+++ b/plugins/cpp/model/include/model/cppfunction.h
@@ -29,6 +29,22 @@ struct CppFunction : CppTypedEntity
 
 typedef std::shared_ptr<CppFunction> CppFunctionPtr;
 
+#pragma db view \
+  object(CppFunction) object(CppVariable = Parameters : CppFunction::parameters)
+struct CppFunctionParamCount
+{
+  #pragma db column("count(" + Parameters::id + ")")
+  std::size_t count;
+};
+
+#pragma db view \
+  object(CppFunction) object(CppVariable = Locals : CppFunction::locals)
+struct CppFunctionLocalCount
+{
+  #pragma db column("count(" + Locals::id + ")")
+  std::size_t count;
+};
+
 }
 }
 

--- a/plugins/cpp/model/include/model/cppinheritance.h
+++ b/plugins/cpp/model/include/model/cppinheritance.h
@@ -39,6 +39,13 @@ struct CppInheritance
 
 typedef std::shared_ptr<CppInheritance> CppInheritancePtr;
 
+#pragma db view object(CppInheritance)
+struct CppInheritanceCount
+{
+  #pragma db column("count(" + CppInheritance::id + ")")
+  std::size_t count;
+};
+
 }
 }
 

--- a/plugins/cpp/model/include/model/cppmacroexpansion.h
+++ b/plugins/cpp/model/include/model/cppmacroexpansion.h
@@ -41,6 +41,13 @@ struct CppMacroExpansion
 
 typedef std::shared_ptr<CppMacroExpansion> CppMacroExpansionPtr;
 
+#pragma db view object(CppMacroExpansion)
+struct CppMacroExpansionCount
+{
+  #pragma db column("count(" + CppMacroExpansion::id + ")")
+  std::size_t count;
+};
+
 } // model
 } // cc
 

--- a/plugins/cpp/model/include/model/cpprelation.h
+++ b/plugins/cpp/model/include/model/cpprelation.h
@@ -46,6 +46,13 @@ struct CppRelation
 
 typedef std::shared_ptr<CppRelation> CppRelationPtr;
 
+#pragma db view object(CppRelation)
+struct CppRelationCount
+{
+  #pragma db column("count(" + CppRelation::id + ")")
+  std::size_t count;
+};
+
 }
 }
 

--- a/plugins/cpp/model/include/model/cpptype.h
+++ b/plugins/cpp/model/include/model/cpptype.h
@@ -75,6 +75,20 @@ struct CppType : CppEntity
 
 typedef std::shared_ptr<CppType> CppTypePtr;
 
+#pragma db view object(CppMemberType)
+struct CppMemberTypeCount
+{
+  #pragma db column("count(" + CppMemberType::id + ")")
+  std::size_t count;
+};
+
+#pragma db view object(CppType)
+struct CppTypeCount
+{
+  #pragma db column("count(" + CppType::id + ")")
+  std::size_t count;
+};
+
 }
 }
 

--- a/plugins/cpp/model/include/model/cpptypedef.h
+++ b/plugins/cpp/model/include/model/cpptypedef.h
@@ -23,6 +23,13 @@ struct CppTypedef : CppTypedEntity
 
 typedef std::shared_ptr<CppTypedef> CppTypedefPtr;
 
+#pragma db view object(CppTypedef)
+struct CppTypedefCount
+{
+  #pragma db column("count(" + CppTypedef::id + ")")
+  std::size_t count;
+};
+
 }
 }
 

--- a/plugins/cpp/service/include/service/cppservice.h
+++ b/plugins/cpp/service/include/service/cppservice.h
@@ -92,6 +92,10 @@ public:
     const std::int32_t referenceId_,
     const std::vector<std::string>& tags_) override;
 
+  std::int32_t getReferenceCount(
+    const core::AstNodeId& astNodeId_,
+    const std::int32_t referenceId_) override;
+
   void getReferencesInFile(
     std::vector<AstNodeInfo>& return_,
     const core::AstNodeId& astNodeId_,
@@ -252,14 +256,14 @@ private:
     const odb::query<model::CppAstNode>& query_
       = odb::query<model::CppAstNode>(true));
 
-    /**
-     * This function returns the model::CppAstNode objects which meet the
-     * requirements of the given query in the given file.
-     */
-    std::vector<model::CppAstNode> queryCppAstNodesInFile(
-      const core::FileId& fileId_,
-      const odb::query<model::CppAstNode>& query_
-        = odb::query<model::CppAstNode>(true));
+  /**
+   * This function returns the model::CppAstNode objects which meet the
+   * requirements of the given query in the given file.
+   */
+  std::vector<model::CppAstNode> queryCppAstNodesInFile(
+    const core::FileId& fileId_,
+    const odb::query<model::CppAstNode>& query_
+      = odb::query<model::CppAstNode>(true));
 
   /**
    * This function returns the model::CppAstNode objects which have the same
@@ -270,6 +274,13 @@ private:
    */
   std::vector<model::CppAstNode> queryDefinitions(
     const core::AstNodeId& astNodeId_);
+
+  /**
+   * This function returns an AST query to get the function calls in the given
+   * function.
+   */
+  odb::query<model::CppAstNode> astCallsQuery(
+    const model::CppAstNode& astNode_);
 
   /**
    * This function returns the function calls in a given function.
@@ -303,6 +314,31 @@ private:
    */
   std::map<model::CppAstNodeId, std::vector<std::string>> getTags(
     const std::vector<model::CppAstNode>& nodes_);
+
+  /*
+   * This function returns the number of corresponding model::CppAstNode objects
+   * to the given AST which meet the given query condition.
+   */
+  std::size_t queryCppAstNodeCount(
+    const core::AstNodeId& astNodeId_,
+    const odb::query<model::CppAstNode>& query_
+      = odb::query<model::CppAstNode>(true));
+
+  /**
+   * This function returns the number of function calls in a given function.
+   * @param astNodeId_ An AST node ID which belongs to a function.
+   */
+  std::size_t queryCallsCount(
+    const core::AstNodeId& astNodeId_);
+
+  /**
+   * This function returns the number of functions which override the given one.
+   * @param reverse_ If this parameter is true then the function returns the
+   * functions number which are overriden by the given one.
+   */
+  std::size_t queryOverridesCount(
+    const core::AstNodeId& astNodeId_,
+    bool reverse_ = false);
 
   std::shared_ptr<odb::database> _db;
   util::OdbTransaction _transaction;

--- a/service/language/language.thrift
+++ b/service/language/language.thrift
@@ -152,6 +152,17 @@ service LanguageService
     throws (1:common.InvalidId ex)
 
   /**
+   * Returns reference count to the AST node identified by astNodeId.
+   * @param astNodeId The AST node to be queried.
+   * @param referenceId Reference type (such as derivedClasses, definition,
+   * usages etc.). Possible values can be queried by getReferenceTypes().
+   * @return Number of rereferences
+   */
+  i32 getReferenceCount(
+    1:common.AstNodeId astNodeId,
+    2:i32 referenceId)
+
+  /**
    * Returns references to the AST node identified by astNodeId.
    * @param astNodeId The AST node to be queried.
    * @param referenceId Reference type (such as derivedClasses, definition,

--- a/webgui/style/codecompass.css
+++ b/webgui/style/codecompass.css
@@ -144,6 +144,15 @@ svg {
   color: #8D2222;
 }
 
+#infotree .reference-count {
+  font-size: .83em;
+  line-height: 0.5em;
+  vertical-align: baseline;
+  position: relative;
+  top: -0.4em;
+  color: grey;
+}
+
 #infotree .icon,
 #filemanager .icon,
 #queryresult .icon,


### PR DESCRIPTION
Get reference count language support. Remove empty nodes from info tree.
This commit fixes #40 issue.