### PR TITLE
Fix urlhandler init state

### DIFF
--- a/webgui/scripts/codecompass/urlHandler.js
+++ b/webgui/scripts/codecompass/urlHandler.js
@@ -170,7 +170,7 @@ function (lang, hash, topic, model) {
 
   //--- Init state by url ---//
 
-  urlHandler.setState(urlHandler.getState());
+  state = urlHandler.getState();
 
   /**
    * When "browser back" or "browser forward" button is pressed, then the global


### PR DESCRIPTION
`urlHandler.setState()` function calls the `_cacheDbInformation` function. This function uses the model which is empty at this moment. So we have to set only the state and don't call the cache update function.