### PR TITLE
Fix js jump to position

### DIFF
--- a/webgui/scripts/codecompass/view/component/Text.js
+++ b/webgui/scripts/codecompass/view/component/Text.js
@@ -526,8 +526,8 @@ function (declare, domClass, dom, style, query, topic, ContentPane, Dialog,
       setTimeout(function () {
         var fl = that._codeMirror.options.firstLineNumber;
         that._codeMirror.doc.setSelection(
-          { line : range[0] - fl, ch : range[1] - 1 },
-          { line : range[2] - fl, ch : range[3] - 1 });
+          { line : range[2] - fl, ch : range[3] - 1 },
+          { line : range[0] - fl, ch : range[1] - 1 })
       }, 0);
     },
 


### PR DESCRIPTION
https://codemirror.net/doc/manual.html

The first parameter of the `setSelection()` function is head. This function will **scroll atomatically** to head.