### PR TITLE
Use -j command line option for number of cores instead of -t

### DIFF
--- a/parser/src/parser.cpp
+++ b/parser/src/parser.cpp
@@ -57,7 +57,7 @@ po::options_description commandLineArguments()
       po::value<trivial::severity_level>()->default_value(trivial::info),
       "Logging legel of the parser. Possible values are: debug, info, warning, "
       "error, critical.")
-    ("threads,t", po::value<int>()->default_value(4),
+    ("jobs,j", po::value<int>()->default_value(4),
       "Number of threads the parsers can use.")
     ("skip,s", po::value<std::vector<std::string>>(),
       "This is a list of parsers which will be omitted during the parsing "

--- a/plugins/cpp/parser/src/cppparser.cpp
+++ b/plugins/cpp/parser/src/cppparser.cpp
@@ -314,7 +314,7 @@ bool CppParser::parse()
     : _ctx.options["input"].as<std::vector<std::string>>())
     if (boost::filesystem::is_regular_file(input))
       success
-        = success && parseByJson(input, _ctx.options["threads"].as<int>());
+        = success && parseByJson(input, _ctx.options["jobs"].as<int>());
 
   VisitorActionFactory::cleanUp();
   _parsedCommandHashes.clear();

--- a/webserver/src/webserver.cpp
+++ b/webserver/src/webserver.cpp
@@ -35,7 +35,7 @@ po::options_description commandLineArguments()
       po::value<trivial::severity_level>()->default_value(trivial::info),
       "Logging level of the parser. Possible values are: debug, info, warning, "
       "error, critical")
-    ("threads,t", po::value<int>()->default_value(4),
+    ("jobs,j", po::value<int>()->default_value(4),
       "Number of worker threads.");
 
   return desc;
@@ -116,7 +116,7 @@ int main(int argc, char* argv[])
 
   //--- Start mongoose server ---//
 
-  cc::webserver::ThreadedMongoose server(vm["threads"].as<int>());
+  cc::webserver::ThreadedMongoose server(vm["jobs"].as<int>());
   server.setOption("listening_port", std::to_string(vm["port"].as<int>()));
   server.setOption("document_root", vm["webguiDir"].as<std::string>());
 


### PR DESCRIPTION
Use -j command line option for number of cores instead of -t.

This commit resolves #78 issue.