### PR TITLE
Cpp tags

### DIFF
--- a/plugins/cpp/model/include/model/common.h
+++ b/plugins/cpp/model/include/model/common.h
@@ -15,12 +15,35 @@ enum Visibility
   Public
 };
 
+enum Tag
+{
+  Constructor = 0,
+  Destructor = 1,
+  Virtual = 2,
+  Static  = 3,
+  Implicit = 4,
+  Global = 5,
+  Constant = 6
+};
+
 inline std::string visibilityToString(Visibility v_)
 {
   return
     v_ == Private   ? "private" :
     v_ == Protected ? "protected" :
     v_ == Public    ? "public" : "";
+}
+
+inline std::string tagToString(Tag t_)
+{
+  return
+    t_ == Constructor   ? "constructor" :
+    t_ == Destructor    ? "destructor" :
+    t_ == Virtual       ? "virtual" :
+    t_ == Static        ? "static" :
+    t_ == Implicit      ? "implicit" :
+    t_ == Global        ? "global" :
+    t_ == Constant      ? "constant" : "";
 }
 
 }

--- a/plugins/cpp/model/include/model/cppastnode.h
+++ b/plugins/cpp/model/include/model/cppastnode.h
@@ -145,10 +145,14 @@ inline std::string CppAstNode::toString() const
     .append("\nastValue = ").append(astValue)
     .append("\nmangledName = ").append(mangledName)
     .append("\nlocation = ").append(location.file->path).append(" (")
-    .append(std::to_string(location.range.start.line)).append(":")
-    .append(std::to_string(location.range.start.column)).append(" - ")
-    .append(std::to_string(location.range.end.line)).append(":")
-    .append(std::to_string(location.range.end.column)).append(")")
+    .append(std::to_string(
+      static_cast<signed>(location.range.start.line))).append(":")
+    .append(std::to_string(
+      static_cast<signed>(location.range.start.column))).append(" - ")
+    .append(std::to_string(
+      static_cast<signed>(location.range.end.line))).append(":")
+    .append(std::to_string(
+      static_cast<signed>(location.range.end.column))).append(")")
     .append("\nsymbolType = ").append(symbolTypeToString(symbolType))
     .append("\nastType = ").append(astTypeToString(astType));
 }

--- a/plugins/cpp/model/include/model/cppentity.h
+++ b/plugins/cpp/model/include/model/cppentity.h
@@ -6,6 +6,7 @@
 #include <odb/nullable.hxx>
 
 #include "cppastnode.h"
+#include "common.h"
 
 namespace cc
 {
@@ -29,6 +30,8 @@ struct CppEntity
 
   std::string name;
   std::string qualifiedName;
+
+  std::set<Tag> tags;
 
 #ifndef NO_INDICES
   #pragma db index member(mangledNameHash)

--- a/plugins/cpp/model/include/model/cppenum.h
+++ b/plugins/cpp/model/include/model/cppenum.h
@@ -15,11 +15,22 @@ struct CppEnumConstant : CppEntity
 
   std::string toString() const
   {
-    return std::string("CppEnumConstant")
+    std::string ret("CppEnumConstant");
+
+    ret
       .append("\nid = ").append(std::to_string(id))
       .append("\nmangledNameHash = ").append(std::to_string(mangledNameHash))
       .append("\nqualifiedName = ").append(qualifiedName)
       .append("\nvalue = ").append(std::to_string(value));
+
+    if (!tags.empty())
+    {
+      ret.append("\ntags =");
+      for (const Tag& tag : tags)
+        ret.append(' ' + tagToString(tag));
+    }
+
+    return ret;
   }
 };
 
@@ -32,10 +43,21 @@ struct CppEnum : CppEntity
 
   std::string toString() const
   {
-    return std::string("CppEnum")
+    std::string ret("CppEnum");
+
+    ret
       .append("\nid = ").append(std::to_string(id))
       .append("\nmangledNameHash = ").append(std::to_string(mangledNameHash))
       .append("\nqualifiedName = ").append(qualifiedName);
+
+    if (!tags.empty())
+    {
+      ret.append("\ntags =");
+      for (const Tag& tag : tags)
+        ret.append(' ' + tagToString(tag));
+    }
+
+    return ret;
   }
 };
 

--- a/plugins/cpp/model/include/model/cppfunction.h
+++ b/plugins/cpp/model/include/model/cppfunction.h
@@ -17,16 +17,13 @@ struct CppFunction : CppTypedEntity
   std::vector<odb::lazy_shared_ptr<CppVariable>> parameters;
   std::vector<odb::lazy_shared_ptr<CppVariable>> locals;
 
-  bool isVirtual = false;
-
   std::string toString() const
   {
     return std::string("CppFunction")
       .append("\nid = ").append(std::to_string(id))
       .append("\nmangledNameHash = ").append(std::to_string(mangledNameHash))
       .append("\nqualifiedName = ").append(qualifiedName)
-      .append("\nqualifiedType = ").append(qualifiedType)
-      .append("\nisVirtual = ").append(std::to_string(isVirtual));
+      .append("\nqualifiedType = ").append(qualifiedType);
   }
 };
 

--- a/plugins/cpp/model/include/model/cppnamespace.h
+++ b/plugins/cpp/model/include/model/cppnamespace.h
@@ -13,10 +13,21 @@ struct CppNamespace : CppEntity
 {
   std::string toString() const
   {
-    return std::string("CppNamespace")
+    std::string ret("CppNamespace");
+
+    ret
       .append("\nid = ").append(std::to_string(id))
       .append("\nmangledNameHash = ").append(std::to_string(mangledNameHash))
       .append("\nqualifiedName = ").append(qualifiedName);
+
+    if (!tags.empty())
+    {
+      ret.append("\ntags =");
+      for (const Tag& tag : tags)
+        ret.append(' ' + tagToString(tag));
+    }
+
+    return ret;
   }
 };
 

--- a/plugins/cpp/model/include/model/cpptype.h
+++ b/plugins/cpp/model/include/model/cpptype.h
@@ -32,8 +32,6 @@ struct CppMemberType
   Kind kind;
   Visibility visibility;
 
-  bool isStatic = false;
-
   std::string toString() const
   {
     return std::string("CppMemberType")
@@ -41,8 +39,7 @@ struct CppMemberType
       .append("\ntypeHash = ").append(std::to_string(typeHash))
       .append("\nmemberTypeHash = ").append(std::to_string(memberTypeHash))
       .append("\nkind = ").append(kind == Field ? "Field" : "Method")
-      .append("\nvisibility = ").append(visibilityToString(visibility))
-      .append("\nisStatic = ").append(std::to_string(isStatic));
+      .append("\nvisibility = ").append(visibilityToString(visibility));
   }
 };
 

--- a/plugins/cpp/model/include/model/cpptype.h
+++ b/plugins/cpp/model/include/model/cpptype.h
@@ -53,11 +53,23 @@ struct CppType : CppEntity
 
   std::string toString() const
   {
-    return std::string("id = ").append(std::to_string(id))
+    std::string ret("CppType");
+
+    ret
+      .append("\nid = ").append(std::to_string(id))
       .append("\nmangledNameHash = ").append(std::to_string(mangledNameHash))
       .append("\nqualifiedName = ").append(qualifiedName)
       .append("\nisAbstract = ").append(std::to_string(isAbstract))
       .append("\nisPOD = ").append(std::to_string(isPOD));
+
+    if (!tags.empty())
+    {
+      ret.append("\ntags =");
+      for (const Tag& tag : tags)
+        ret.append(' ' + tagToString(tag));
+    }
+
+    return ret;
   }
 };
 

--- a/plugins/cpp/model/include/model/cppvariable.h
+++ b/plugins/cpp/model/include/model/cppvariable.h
@@ -11,16 +11,13 @@ namespace model
 #pragma db object
 struct CppVariable : CppTypedEntity
 {
-  bool isGlobal = false;
-
   std::string toString() const
   {
     return std::string("CppVariable")
       .append("\nid = ").append(std::to_string(id))
       .append("\nmangledNameHash = ").append(std::to_string(mangledNameHash))
       .append("\nqualifiedName = ").append(qualifiedName)
-      .append("\nqualifiedType = ").append(qualifiedType)
-      .append("\nisGlobal = ").append(std::to_string(isGlobal));
+      .append("\nqualifiedType = ").append(qualifiedType);
   }
 };
 

--- a/plugins/cpp/service/include/service/cppservice.h
+++ b/plugins/cpp/service/include/service/cppservice.h
@@ -219,6 +219,13 @@ private:
     const model::CppAstNode& rhs);
 
   /**
+   * This function compares AST nodes alphabetically.
+   */
+  static bool compareByValue(
+    const model::CppAstNode& lhs,
+    const model::CppAstNode& rhs);
+
+  /**
    * This function returns the corresponding model::CppAstNode to the given AST
    * node.
    */

--- a/plugins/cpp/webgui/js/cppInfoTree.js
+++ b/plugins/cpp/webgui/js/cppInfoTree.js
@@ -11,20 +11,31 @@ function (model, viewHandler, util) {
 
     var label = '';
     if (tags.indexOf('static') > -1)
-      label += '<span class="tag tag-static">S</span>';
+      label += '<span class="tag tag-static" title="Static">S</span>';
     if (tags.indexOf('constructor') > -1)
-      label += '<span class="tag tag-constructor">C</span>';
-    if (tags.indexOf('generated') > -1)
-      label += '<span class="tag tag-generated">G</span>';
+      label += '<span class="tag tag-constructor" title="Constructor">C</span>';
+    if (tags.indexOf('destructor') > -1)
+      label += '<span class="tag tag-destructor" title="Destructor">D</span>';
+    if (tags.indexOf('implicit') > -1)
+      label += '<span class="tag tag-implicit" title="Implicit">I</span>';
     if (tags.indexOf('inherited') > -1)
-      label += '<span class="tag tag-inherited">I</span>';
+      label += '<span class="tag tag-inherited" title="Inherited">I</span>';
     if (tags.indexOf('virtual') > -1)
-      label += '<span class="tag tag-virtual">V</span>';
+      label += '<span class="tag tag-virtual" title="Virtual">V</span>';
+    if (tags.indexOf('global') > -1)
+      label += '<span class="tag tag-global" title="Global">G</span>';
+
+    var labelClass = '';
+
+    if (tags.indexOf('implicit') > -1)
+      labelClass = 'label-implicit';
 
     label
-      += astNodeInfo.range.range.startpos.line   + ':'
+      += '<span class="' + labelClass + '">'
+      +  astNodeInfo.range.range.startpos.line   + ':'
       +  astNodeInfo.range.range.startpos.column + ': '
-      +  astNodeInfo.astNodeValue;
+      +  astNodeInfo.astNodeValue
+      +  '</span>';
 
     return label;
   }

--- a/webgui/style/codecompass.css
+++ b/webgui/style/codecompass.css
@@ -188,14 +188,28 @@ svg {
   color: #fff;
 }
 
-.tag-generated{
-  background-color: #7e8c8d;
+.tag-destructor{
+  background-color: #000000;
+  color: #fff;
+}
+
+.tag-implicit{
+  background-color: #b1b1b1;
   color: #fff;
 }
 
 .tag-inherited{
   background-color: #9a59b5;
   color: #fff;
+}
+
+.tag-global{
+  background-color: #34496c;
+  color: #fff;
+}
+
+.label-implicit {
+  color: grey;
 }
 
 .dijitTreeRowHover, .dijitTreeContent:hover{


### PR DESCRIPTION
Store extra meta information for cpp entitiy if it is a constructor, destructor, compiler generated etc.

This commit resolves #44 issue.