### PR TITLE
Fix git service no version directory in the data directory.

### DIFF
--- a/plugins/git/service/src/gitservice.cpp
+++ b/plugins/git/service/src/gitservice.cpp
@@ -85,7 +85,10 @@ void GitServiceHandler::getRepositoryList(std::vector<GitRepository>& return_)
 {
   namespace fs = ::boost::filesystem;
 
-  std::string versionDataDir = *_datadir + "/version";
+  fs::path versionDataDir(*_datadir + "/version");
+
+  if (!fs::is_directory(versionDataDir))
+    return;
 
   fs::directory_iterator endIter;
   for (fs::directory_iterator dirIter(versionDataDir);


### PR DESCRIPTION
Version directory not found in the data directory if we skip the git parser.

This commit resolves #122 issue.