### PR TITLE
Fix segfault in CppServiceHandler::getTags()

### DIFF
--- a/plugins/cpp/service/src/cppservice.cpp
+++ b/plugins/cpp/service/src/cppservice.cpp
@@ -1044,10 +1044,14 @@ CppServiceHandler::getTags(const std::vector<model::CppAstNode>& nodes_)
 
         FuncResult funcNodes = _db->query<cc::model::CppFunction>(
           FuncQuery::mangledNameHash == defNode.mangledNameHash);
-        const model::CppFunction& funcNode = *funcNodes.begin();
 
-        for (const model::Tag& tag : funcNode.tags)
-          tags[node.id].push_back(model::tagToString(tag));
+        if (!funcNodes.empty())
+        {
+          const model::CppFunction& funcNode = *funcNodes.begin();
+
+          for (const model::Tag& tag : funcNode.tags)
+            tags[node.id].push_back(model::tagToString(tag));
+        }
 
         break;
       }
@@ -1071,10 +1075,14 @@ CppServiceHandler::getTags(const std::vector<model::CppAstNode>& nodes_)
 
         VarResult varNodes = _db->query<cc::model::CppVariable>(
           VarQuery::mangledNameHash == defNode.mangledNameHash);
-        const model::CppVariable& varNode = *varNodes.begin();
 
-        for (const model::Tag& tag : varNode.tags)
-          tags[node.id].push_back(model::tagToString(tag));
+        if (!varNodes.empty())
+        {
+          const model::CppVariable& varNode = *varNodes.begin();
+
+          for (const model::Tag& tag : varNode.tags)
+            tags[node.id].push_back(model::tagToString(tag));
+        }
 
         break;
       }


### PR DESCRIPTION
In case of navigating the InfoTree (e.g. the _Callers_ subtree) and the function is called by a function which is called by a function for which no database entry exists (such as `main()` in my little test project I encountered this bug), the webserver immediately segfaults because `*funcNodes.begin()` is actually an invalid dereference.