### PR TITLE
Get absolute path of the cpp parser compile command output file.

### DIFF
--- a/plugins/cpp/parser/src/cppparser.cpp
+++ b/plugins/cpp/parser/src/cppparser.cpp
@@ -165,7 +165,10 @@ std::map<std::string, std::string> CppParser::extractInputOutputs(
   {
     if (state == OParam)
     {
-      output = arg;
+      boost::filesystem::path absolutePath =
+        boost::filesystem::absolute(arg, command_.Directory);
+
+      output = absolutePath.native();
       state = None;
     }
     else if (isSourceFile(arg))


### PR DESCRIPTION
Get absolute path of the cpp parser compile command output file.