### PR TITLE
CodeCompass build break fix: update libgit2 version, turn off SSL dep…

### DIFF
--- a/parser/gitparser/src/gitdiff.cpp
+++ b/parser/gitparser/src/gitdiff.cpp
@@ -219,6 +219,7 @@ std::vector<GitDiff::GitDiffDelta> GitDiff::getDeltaList()
     gitdiff_getDeltaList_file_cb,
     nullptr, 
     nullptr,
+    nullptr,
     &ret
   );
   GitException::hadleError(error);

--- a/scripts/build_deps.sh
+++ b/scripts/build_deps.sh
@@ -332,7 +332,7 @@ compile_libgit2()
   CC="$CCMP_DEPS/bin/gcc"
   CXX="$CCMP_DEPS/bin/g++"
   CMAKE_PREFIX_PATH="$CCMP_DEPS"
-  $CCMP_DEPS/bin/cmake .. -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DBUILD_CLAR=OFF -DTHREADSAFE=ON -DUSE_SSH=OFF -DCMAKE_INSTALL_PREFIX=$CCMP_DEPS -DOPENSSL_SSL_LIBRARY=$CCMP_DEPS
+  $CCMP_DEPS/bin/cmake .. -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DBUILD_CLAR=OFF -DTHREADSAFE=ON -DUSE_SSH=OFF -DCMAKE_INSTALL_PREFIX=$CCMP_DEPS -DCMAKE_USE_OPENSSL=OFF -DCURL=OFF -DUSE_OPENSSL=OFF
   
   echo_info "Making $src_dir"
   make PREFIX=$CCMP_DEPS -j$cpu_count || exit -1
@@ -629,8 +629,8 @@ build_libgit2()
   dep openssl
   dep pkgconfig
   
-  download https://github.com/libgit2/libgit2/archive/v0.22.2.tar.gz libgit2-v0.22.2.tar.gz --no-check-certificate
-  compile libgit2 libgit2-0.22.2 lib/libgit2.so
+  download https://github.com/libgit2/libgit2/archive/v0.25.1.tar.gz libgit2-v0.25.1.tar.gz --no-check-certificate
+  compile libgit2 libgit2-0.25.1 lib/libgit2.so
 }
 
 build_libodb()
@@ -880,15 +880,6 @@ build_doxygen()
 
   download http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.9.1.src.tar.gz
   compile doxygen doxygen-1.8.9.1 bin/doxygen "--english-only --static"
-}
-
-build_tcsh()
-{
-  dep gcc
-  dep ncurses
-
-  download ftp://ftp.astron.com/pub/tcsh/tcsh-6.18.01.tar.gz
-  CFLAGS="-O1" compile generic tcsh-6.18.01 bin/tcsh --disable-nls --disable-nls-catalogs
 }
 
 build_python2()


### PR DESCRIPTION
### CodeCompass build break fix: update libgit2 version, turn off SSL dependency for libgit2, remove tcsh dependency

After pulling the dependencies, when building the GitHub version of Earhart for the first time, the build failed with the following error:

```
libtool: link: g++ -Wno-unknown-pragmas -O2 -std=gnu++14 -Wall -Wno-unknown-pragmas -o parser/bin/.libs/parse parser/parser/src/parser_bin_parse-parse.o  -L/mnt/data/CodeCompass-Earhart/CodeCompass-deps/usr/lib64 -L/mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib64 -L/mnt/data/CodeCompass-Earhart/CodeCompass-deps/usr/lib -L/mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib ./lib/.libs/libprojectparser.so /mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/libxerces-c.so ./lib/.libs/libparser.so -lboost_thread /mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/libmagic.so ./lib/.libs/libfileparser.so ./lib/.libs/libcxxparser.a ./lib/.libs/libgrockerutil.so ./lib/.libs/libmodel.so ./lib/.libs/libgitparser.a -lgit2 -lboost_filesystem ./lib/.libs/libsearchparser.a -lclangFrontend -lclangParse -lclangSema -lclangStaticAnalyzerFrontend -lclangStaticAnalyzerCheckers -lclangStaticAnalyzerCore -lclangDriver -lclangEdit -lclangAnalysis -lclangSerialization -lclangAST -lclangLex -lclangBasic -lclangTooling -lLLVMLTO -lLLVMObjCARCOpts -lLLVMLinker -lLLVMBitWriter -lLLVMIRReader -lLLVMAsmParser -lLLVMR600CodeGen -lLLVMipo -lLLVMVectorize -lLLVMR600AsmParser -lLLVMR600Desc -lLLVMR600Info -lLLVMR600AsmPrinter -lLLVMSystemZDisassembler -lLLVMSystemZCodeGen -lLLVMSystemZAsmParser -lLLVMSystemZDesc -lLLVMSystemZInfo -lLLVMSystemZAsmPrinter -lLLVMHexagonDisassembler -lLLVMHexagonCodeGen -lLLVMHexagonDesc -lLLVMHexagonInfo -lLLVMNVPTXCodeGen -lLLVMNVPTXDesc -lLLVMNVPTXInfo -lLLVMNVPTXAsmPrinter -lLLVMCppBackendCodeGen -lLLVMCppBackendInfo -lLLVMMSP430CodeGen -lLLVMMSP430Desc -lLLVMMSP430Info -lLLVMMSP430AsmPrinter -lLLVMXCoreDisassembler -lLLVMXCoreCodeGen -lLLVMXCoreDesc -lLLVMXCoreInfo -lLLVMXCoreAsmPrinter -lLLVMMipsDisassembler -lLLVMMipsCodeGen -lLLVMMipsAsmParser -lLLVMMipsDesc -lLLVMMipsInfo -lLLVMMipsAsmPrinter -lLLVMAArch64Disassembler -lLLVMAArch64CodeGen -lLLVMAArch64AsmParser -lLLVMAArch64Desc -lLLVMAArch64Info -lLLVMAArch64AsmPrinter -lLLVMAArch64Utils -lLLVMARMDisassembler -lLLVMARMCodeGen -lLLVMARMAsmParser -lLLVMARMDesc -lLLVMARMInfo -lLLVMARMAsmPrinter -lLLVMPowerPCDisassembler -lLLVMPowerPCCodeGen -lLLVMPowerPCAsmParser -lLLVMPowerPCDesc -lLLVMPowerPCInfo -lLLVMPowerPCAsmPrinter -lLLVMSparcDisassembler -lLLVMSparcCodeGen -lLLVMSparcAsmParser -lLLVMSparcDesc -lLLVMSparcInfo -lLLVMSparcAsmPrinter -lLLVMTableGen -lLLVMDebugInfo -lLLVMOption -lLLVMX86Disassembler -lLLVMX86AsmParser -lLLVMX86CodeGen -lLLVMSelectionDAG -lLLVMAsmPrinter -lLLVMX86Desc -lLLVMMCDisassembler -lLLVMX86Info -lLLVMX86AsmPrinter -lLLVMX86Utils -lLLVMMCJIT -lLLVMLineEditor -lLLVMInstrumentation -lLLVMInterpreter -lLLVMExecutionEngine -lLLVMRuntimeDyld -lLLVMCodeGen -lLLVMScalarOpts -lLLVMProfileData -lLLVMObject -lLLVMMCParser -lLLVMBitReader -lLLVMInstCombine -lLLVMTransformUtils -lLLVMipa -lLLVMAnalysis -lLLVMTarget -lLLVMMC -lLLVMCore -lLLVMSupport /mnt/data/CodeCompass-Earhart/CodeCompass/lib/.libs/libsearch_indexer-api.so ./lib/.libs/libjavaparser.a /mnt/data/CodeCompass-Earhart/CodeCompass/lib/.libs/libjavaparser-api.so /mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/libthrift.so -lrt ./lib/.libs/libmetricsparser.a /mnt/data/CodeCompass-Earhart/CodeCompass/lib/.libs/libgrockerutil.so /mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/libgvc.so /usr/lib/x86_64-linux-gnu/libltdl.so /mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/libxdot.so /mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/libpathplan.so -lz /mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/libcgraph.so /mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/libcdt.so -lboost_regex /mnt/data/CodeCompass-Earhart/CodeCompass/lib/.libs/libmodel.so /mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/libodb-pgsql.so -lpq -lboost_date_time -lboost_system /mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/libodb.so -lpthread /mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/libldap.so /mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/liblber.so /mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/libsasl2.so -ldl -lresolv -lssl -lcrypto /mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/../lib64/libstdc++.so -lm -lboost_program_options -Wl,-rpath -Wl,/mnt/data/CodeCompass-Earhart/CodeCompass-install/lib -Wl,-rpath -Wl,/mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib -Wl,-rpath -Wl,/mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/../lib64
/mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/libgit2.so: undefined reference to `SSL_CTX_set_options'
/mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/libgit2.so: undefined reference to `OPENSSL_init_ssl'
/mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/libgit2.so: undefined reference to `TLS_method'
/mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/libgit2.so: undefined reference to `OPENSSL_sk_num'
/mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/libgit2.so: undefined reference to `OPENSSL_sk_value'
collect2: error: ld returned 1 exit status
Makefile:5314: recipe for target 'parser/bin/query' failed
make[1]: *** [parser/bin/query] Error 1
make[1]: *** Waiting for unfinished jobs....
/mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/libgit2.so: undefined reference to `SSL_CTX_set_options'
/mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/libgit2.so: undefined reference to `OPENSSL_init_ssl'
/mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/libgit2.so: undefined reference to `TLS_method'
/mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/libgit2.so: undefined reference to `OPENSSL_sk_num'
/mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/libgit2.so: undefined reference to `OPENSSL_sk_value'
collect2: error: ld returned 1 exit status
Makefile:5300: recipe for target 'parser/bin/dumpclangast' failed
make[1]: *** [parser/bin/dumpclangast] Error 1
/mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/libgit2.so: undefined reference to `SSL_CTX_set_options'
/mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/libgit2.so: undefined reference to `OPENSSL_init_ssl'
/mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/libgit2.so: undefined reference to `TLS_method'
/mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/libgit2.so: undefined reference to `OPENSSL_sk_num'
/mnt/data/CodeCompass-Earhart/CodeCompass-deps/lib/libgit2.so: undefined reference to `OPENSSL_sk_value'
collect2: error: ld returned 1 exit status
Makefile:5307: recipe for target 'parser/bin/parse' failed
make[1]: *** [parser/bin/parse] Error 1
make[1]: Leaving directory '/mnt/data/CodeCompass-Earhart/CodeCompass'
Makefile:3776: recipe for target 'all' failed
make: *** [all] Error 2
```

It seemed that libgit2.so was unable to find OpenSSL. OpenSSL support was turned off in the dependency script for Flash, therefore I used those CMake flags to turn off SSL for libgit2, but the CMakeLists.txt of libgit2-0.22.2 did not contain those CMake variables.

```
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_USE_OPENSSL
    CURL
    USE_OPENSSL
```

Therefore I switched to the libgit2 version used by Flash, libgit2-0.25.1. The CMake variables were recognized, but the newer libgit2 version was breaking the code.

```
parser/gitparser/src/gitdiff.cpp: In member function ‘std::vector<cc::parser::GitDiff::GitDiffDelta> cc::parser::GitDiff::getDeltaList()’:
parser/gitparser/src/gitdiff.cpp:223:3: error: cannot convert ‘std::vector<cc::parser::GitDiff::GitDiffDelta>*’ to ‘git_diff_line_cb {aka int (*)(const git_diff_delta*, const git_diff_hunk*, const git_diff_line*, void*)}’ for argument ‘5’ to ‘int git_diff_foreach(git_diff*, git_diff_file_cb, git_diff_binary_cb, git_diff_hunk_cb, git_diff_line_cb, void*)’
   );
   ^
Makefile:6420: recipe for target 'parser/gitparser/src/lib_libgitparser_la-gitdiff.lo' failed
make[1]: *** [parser/gitparser/src/lib_libgitparser_la-gitdiff.lo] Error 1
```

Turns out that  ``git_diff_foreach()`` function in libgit2 API just slightly changed with an additional number of parameter. Therefore I just gave a ``nullptr`` to that new one. After the change, the code was successfully built.
https://libgit2.github.com/libgit2/#HEAD/group/diff/git_diff_foreach

Before the commit, I created a new database, workdir and parsed tinyxml from scratch. I was able to access the CodeCompass server and browse tinyxml in it.

And tcsh was taken in the original CodeCompass-gsd repo by me, due to not being able to build and not used anywhere.