### PR TITLE
Fix file manager shortcut.

### DIFF
--- a/webgui/scripts/codecompass/view/fileManager.js
+++ b/webgui/scripts/codecompass/view/fileManager.js
@@ -292,6 +292,36 @@ function (on, query, dom, style, domConstruct, topic, declare, Memory,
       this._setFilePath(item.fileInfo.path);
     },
 
+    /**
+     * Iterate over the shortcut and call callback function on each directory.
+     * {String } shortcut Directory path.
+     * {Function} cb Callback function.
+     */
+    shortcutVisitor : function (shortcut, cb) {
+      var that = this;
+
+      var currentNode = this.getChildren()[0];
+
+      var path = shortcut.split('/');
+      path[0] = '/';
+
+      path.forEach(function (directory) {
+        if (!directory.length)
+          return;
+
+        children = currentNode.getChildren();
+        index = util.findIf(children, function (child) {
+          return child.label.match(
+            /(<[^>]*>)?([^<]*)(<[^>]*>)?/)[2] === directory;
+        });
+        currentNode = children[index];
+
+        cb(currentNode);
+      });
+
+      return currentNode;
+    },
+
     onClick : function (item, node, event) {
       var that = this;
 
@@ -305,33 +335,19 @@ function (on, query, dom, style, domConstruct, topic, declare, Memory,
         if (this._previousPath === item.shortcut)
           return;
 
-        this._previousPath = item.shortcut;
-
-        var currentNode = this.getChildren()[0];
-
-        var path = item.shortcut.split('/');
-        path[0] = '/';
-
-        path.forEach(function (directory) {
-          if (!directory.length)
-            return;
-
-          children = currentNode.getChildren();
-          index = util.findIf(children, function (child) {
-            return child.label.match(
-              /(<[^>]*>)?([^<]*)(<[^>]*>)?/)[2] === directory;
+        if (this._previousPath)
+          this.shortcutVisitor(this._previousPath, function (node) {
+            that._collapseNode(node);
           });
-          currentNode = children[index];
-          that._expandNode(currentNode);
+
+        var currentNode = this.shortcutVisitor(item.shortcut, function (node) {
+          that._expandNode(node);
         });
 
         var children = currentNode.getChildren();
-        children.forEach(function (child){
-          that._collapseNode(child);
-        });
-
         this._displayElements(children, true);
         this._setFilePath(item.shortcut);
+        this._previousPath = item.shortcut;
       } else {
         this.inherited(arguments);
       }

--- a/webgui/scripts/codecompass/view/fileManager.js
+++ b/webgui/scripts/codecompass/view/fileManager.js
@@ -293,11 +293,11 @@ function (on, query, dom, style, domConstruct, topic, declare, Memory,
     },
 
     /**
-     * Iterate over the shortcut and call callback function on each directory.
-     * {String } shortcut Directory path.
-     * {Function} cb Callback function.
+     * Iterate over the path and call callback function on each directory.
+     * @param {String} shortcut Directory path.
+     * @param {Function} cb Callback function.
      */
-    shortcutVisitor : function (shortcut, cb) {
+    pathVisitor : function (shortcut, cb) {
       var that = this;
 
       var currentNode = this.getChildren()[0];
@@ -336,11 +336,11 @@ function (on, query, dom, style, domConstruct, topic, declare, Memory,
           return;
 
         if (this._previousPath)
-          this.shortcutVisitor(this._previousPath, function (node) {
+          this.pathVisitor(this._previousPath, function (node) {
             that._collapseNode(node);
           });
 
-        var currentNode = this.shortcutVisitor(item.shortcut, function (node) {
+        var currentNode = this.pathVisitor(item.shortcut, function (node) {
           that._expandNode(node);
         });
 


### PR DESCRIPTION
The error occurred when the parent of two label(`/a/b/` - see in the example) was the same:
```
label1=/a/b/c/
label2=/a/b/d/
```