### PR TITLE
Move CppParser to the new threadpool

### DIFF
--- a/plugins/cpp/parser/include/cppparser/cppparser.h
+++ b/plugins/cpp/parser/include/cppparser/cppparser.h
@@ -2,9 +2,8 @@
 #define CC_PARSER_CXXPARSER_H
 
 #include <map>
-#include <vector>
 #include <unordered_set>
-#include <mutex>
+#include <vector>
 
 #include <clang/Tooling/JSONCompilationDatabase.h>
 #include <clang/Tooling/Tooling.h>
@@ -53,10 +52,29 @@ private:
   bool isSourceFile(const std::string& file_) const;
   bool isNonSourceFlag(const std::string& arg_) const;
   bool parseByJson(const std::string& jsonFile_, std::size_t threadNum_);
-  void worker();
+  int worker(const clang::tooling::CompileCommand& command_);
 
-  std::vector<clang::tooling::CompileCommand> _compileCommands;
-  std::size_t _index;
+  /**
+   * A single build command's cc::util::JobQueueThreadPool job.
+   */
+  struct ParseJob
+  {
+    /**
+     * The build command itself. This is given to CppParser::worker.
+     */
+    std::reference_wrapper<const clang::tooling::CompileCommand> command;
+
+    /**
+     * The # of the build command in the compilation command database.
+     */
+    std::size_t index;
+
+    ParseJob(const clang::tooling::CompileCommand& command, std::size_t index)
+      : command(command), index(index)
+    {}
+
+    ParseJob(const ParseJob&) = default;
+  };
 
   std::unordered_set<std::uint64_t> _parsedCommandHashes;
 };


### PR DESCRIPTION
Move the only part of CodeCompass, the C++ parser's worker, to the new threadpool introduced in #120.

Obviously depends on #120 getting merged.