### PR TITLE
Use non-canonical path in source manager and search parser.

### DIFF
--- a/parser/src/sourcemanager.cpp
+++ b/parser/src/sourcemanager.cpp
@@ -151,29 +151,22 @@ model::FilePtr SourceManager::getCreateFileEntry(
 
 model::FilePtr SourceManager::getFile(const std::string& path_)
 {
-  //--- Create canonical form of the path ---//
-
-  boost::system::error_code ec;
-  boost::filesystem::path canonicalPath
-    = boost::filesystem::canonical(path_, ec);
-
   //--- If the file can't be found on disk then return nullptr ---//
 
-  bool fileExists = true;
-  if (ec)
-  {
-    LOG(debug) << "File doesn't exist: " << path_;
-    fileExists = false;
-  }
+  bool fileExists = boost::filesystem::exists(path_);
+
+  if (!fileExists)
+    LOG(warning) << "File doesn't exist: " << path_;
 
   //--- Create file entry ---//
 
-  std::string canonical = ec ? path_ : canonicalPath.native();
+  boost::filesystem::path path(path_);
+  std::string filePath = fileExists ? path_ : path.native();
 
-  model::FilePtr file = getCreateFileEntry(canonical, fileExists);
+  model::FilePtr file = getCreateFileEntry(filePath, fileExists);
 
   _createFileMutex.lock();
-  _files[canonical] = file;
+  _files[filePath] = file;
   _createFileMutex.unlock();
 
   return file;

--- a/plugins/search/parser/src/searchparser.cpp
+++ b/plugins/search/parser/src/searchparser.cpp
@@ -56,7 +56,7 @@ SearchParser::SearchParser(ParserContext& ctx_) : AbstractParser(ctx_),
     for (const std::string& path
       : _ctx.options["search-skip-directory"].as<std::vector<std::string>>())
     {
-      _skipDirectories.push_back(fs::canonical(fs::absolute(path)).string());
+      _skipDirectories.push_back(fs::absolute(path).string());
     }
 
   try
@@ -134,10 +134,8 @@ util::DirIterCallback SearchParser::getParserCallback(const std::string& path_)
   {
     if (fs::is_directory(currPath_))
     {
-      fs::path canonicalPath = fs::canonical(currPath_);
-
       if (std::find(_skipDirectories.begin(), _skipDirectories.end(),
-            canonicalPath) != _skipDirectories.end())
+        currPath_) != _skipDirectories.end())
       {
         LOG(info) << "Skipping " << currPath_ << " because it was listed in "
           "the skipping directory flag of the search parser.";


### PR DESCRIPTION
Use non-canonical path in source manager and search parser.