### PR TITLE
Disable clang ast visitor to visit template instantatiations.

### DIFF
--- a/plugins/cpp/parser/src/clangastvisitor.h
+++ b/plugins/cpp/parser/src/clangastvisitor.h
@@ -104,7 +104,7 @@ public:
   }
 
   bool shouldVisitImplicitCode() const { return true; }
-  bool shouldVisitTemplateInstantiations() const { return true; }
+  bool shouldVisitTemplateInstantiations() const { return false; }
 
   bool TraverseDecl(clang::Decl* decl_)
   {


### PR DESCRIPTION
We don't handle the cpp template instances correctly, so we should disable to visit it for now.