### PR TITLE
Fix properties of template members and add signature as astValue.

### DIFF
--- a/plugins/cpp/service/include/service/cppservice.h
+++ b/plugins/cpp/service/include/service/cppservice.h
@@ -53,8 +53,8 @@ public:
     const core::AstNodeId& astNodeId_) override;
 
   void getProperties(
-    std::map<core::AstNodeId, std::map<std::string, std::string>>& return_,
-    const std::vector<core::AstNodeId>& astNodeIds_) override;
+    std::map<std::string, std::string>& return_,
+    const core::AstNodeId& astNodeId_) override;
 
   void getDiagramTypes(
     std::map<std::string, std::int32_t>& return_,

--- a/plugins/cpp/service/src/diagram.cpp
+++ b/plugins/cpp/service/src/diagram.cpp
@@ -329,14 +329,11 @@ std::string Diagram::getDetailedClassNodeLabel(const AstNodeInfo& nodeInfo_)
   _cppHandler.getReferences(nodes, nodeInfo_.id,
     CppServiceHandler::DATA_MEMBER, {});
 
-  std::map<core::AstNodeId, std::map<std::string, std::string>> props
-    = getProperties(nodes);
-
   for (auto it = nodes.begin(); it != nodes.end(); ++it)
   {
     std::string visibility = visibilityToHtml(*it);
     std::string content = memberContentToHtml(*it,
-      util::escapeHtml(it->astNodeValue + " : " + props[it->id]["Type"]));
+      util::escapeHtml(it->astNodeValue + " : " + getProperty(it->id, "Type")));
 
     std::string attr = colAttr;
     if (it == nodes.end() - 1)
@@ -354,14 +351,12 @@ std::string Diagram::getDetailedClassNodeLabel(const AstNodeInfo& nodeInfo_)
   _cppHandler.getReferences(nodes, nodeInfo_.id,
     CppServiceHandler::METHOD, {});
 
-  props = getProperties(nodes);
-
   for (const AstNodeInfo& node : nodes)
   {
     std::string visibility = visibilityToHtml(node);
 
     // TODO: Constructor and Destructor signatures can be empty.
-    std::string signature = props[node.id]["Signature"];
+    std::string signature = getProperty(node.id, "Signature");
 
     if (!signature.empty())
     {
@@ -413,20 +408,13 @@ std::string Diagram::memberContentToHtml(
   return startTags + util::escapeHtml(content_) + endTags;
 }
 
-std::map<core::AstNodeId, std::map<std::string, std::string>>
-Diagram::getProperties(const std::vector<AstNodeInfo>& astNodes_)
+std::string Diagram::getProperty(
+  const core::AstNodeId& astNodeId_,
+  const std::string& property_)
 {
-  std::vector<core::AstNodeId> astNodeIds;
-  std::transform(
-    astNodes_.begin(),
-    astNodes_.end(),
-    std::back_inserter(astNodeIds),
-    [](const AstNodeInfo& nodeInfo) { return nodeInfo.id; });
-
-  std::map<core::AstNodeId, std::map<std::string, std::string>> properties;
-  _cppHandler.getProperties(properties, astNodeIds);
-
-  return properties;
+  std::map<std::string, std::string> properties;
+  _cppHandler.getProperties(properties, astNodeId_);
+  return properties[property_];
 }
 
 util::Graph::Node Diagram::addNode(

--- a/plugins/cpp/service/src/diagram.h
+++ b/plugins/cpp/service/src/diagram.h
@@ -103,10 +103,11 @@ private:
     const std::string& content_);
 
   /**
-   * This function returns properties for each AST node.
+   * This function returns the property of an AST node.
    */
-  std::map<core::AstNodeId, std::map<std::string, std::string>> getProperties(
-    const std::vector<AstNodeInfo>& astNodeId_);
+  std::string getProperty(
+    const core::AstNodeId& astNodeId_,
+    const std::string& property_);
 
   /**
    * This function decorates a graph node.

--- a/plugins/cpp/test/src/cpppropertiesservicetest.cpp
+++ b/plugins/cpp/test/src/cpppropertiesservicetest.cpp
@@ -37,17 +37,15 @@ public:
   void checkProperties(model::FileId fid_, int line_, int col_,
     std::map<std::string, std::string>& expectedLines_)
   {
-    std::map<cc::service::core::AstNodeId,
-      std::map<std::string, std::string>> properties;
+    std::map<std::string, std::string> props;
 
     AstNodeInfo anFrom = _helper.getAstNodeInfoByPos(line_, col_, fid_);
 
     _transaction([&, this]()
     {
-      _cppservice->getProperties(properties, {anFrom.id});
+      _cppservice->getProperties(props, anFrom.id);
     });
 
-    std::map<std::string, std::string>& props = properties[anFrom.id];
     if (props.size() < expectedLines_.size())
       LOG(debug) << "Position: " << line_ << ":" << col_;
 

--- a/plugins/cpp/webgui/js/cppInfoTree.js
+++ b/plugins/cpp/webgui/js/cppInfoTree.js
@@ -34,26 +34,17 @@ function (model, viewHandler, util) {
     return label + '<span class="reference-count">(' + count + ')</span>';
   }
 
-  function createLabel(astNodeInfo, props) {
+  function createLabel(astNodeInfo) {
     var labelClass = '';
 
     if (astNodeInfo.tags.indexOf('implicit') > -1)
       labelClass = 'label-implicit';
 
-    var labelValue = astNodeInfo.astNodeValue;
-    if (astNodeInfo.symbolType === 'Function' && props)
-    {
-      // TODO: This "if" won't be necessary when the parser is fixed. Currently
-      // no signature is generated for implicit functions.
-      if (props['Signature'])
-        labelValue = props['Signature'];
-    }
-
     var label = createTagLabels(astNodeInfo.tags)
       + '<span class="' + labelClass + '">'
       + astNodeInfo.range.range.startpos.line   + ':'
       + astNodeInfo.range.range.startpos.column + ': '
-      + labelValue
+      + astNodeInfo.astNodeValue
       + '</span>';
 
     return label;
@@ -120,13 +111,7 @@ function (model, viewHandler, util) {
         parentNode.refType === refTypes['Data member'])
       return groupReferencesByVisibilities(references, parentNode, nodeInfo);
 
-    if (references[0] && references[0].symbolType === 'Function')
-      var nodesProps = model.cppservice.getProperties(
-        references.map(function (ref) { return ref.id; }));
-
     references.forEach(function (reference) {
-      var props = nodesProps ? nodesProps[reference.id] : null;
-
       if (parentNode.refType === refTypes['Caller'] ||
           parentNode.refType === refTypes['Usage']) {
 
@@ -158,7 +143,7 @@ function (model, viewHandler, util) {
               if (parentNode.refType === refTypes['Caller']) {
                 res.push({
                   id          : reference.id,
-                  name        : createLabel(reference, props),
+                  name        : createLabel(reference),
                   nodeInfo    : reference,
                   refType     : parentNode.refType,
                   cssClass    : 'icon icon-Method',
@@ -193,7 +178,7 @@ function (model, viewHandler, util) {
                       if (call.mangledNameHash ===
                           nodeInfo.mangledNameHash)
                         res.push({
-                          name        : createLabel(call, props),
+                          name        : createLabel(call),
                           refType     : parentNode.refType,
                           nodeInfo    : call,
                           hasChildren : false,
@@ -206,7 +191,7 @@ function (model, viewHandler, util) {
               } else if (parentNode.refType === refTypes['Usage']) {
                 res.push({
                   id          : fileGroupsId[fileId] + reference.id,
-                  name        : createLabel(reference, props),
+                  name        : createLabel(reference),
                   refType     : parentNode.refType,
                   nodeInfo    : reference,
                   hasChildren : false,
@@ -219,7 +204,7 @@ function (model, viewHandler, util) {
         });
       } else {
         res.push({
-          name        : createLabel(reference, props),
+          name        : createLabel(reference),
           refType     : parentNode.refType,
           nodeInfo    : reference,
           hasChildren : false,
@@ -242,17 +227,9 @@ function (model, viewHandler, util) {
       parentNode.nodeInfo.id,
       parentNode.refType);
 
-    // For functions we get the properties because for these nodes we show their
-    // signatures which can be gathered from properties.
-    if (references[0] && references[0].symbolType === 'Function')
-      var nodesProps = model.cppservice.getProperties(
-        references.map(function (ref) { return ref.id; }));
-
     references.forEach(function (reference) {
-      var props = nodesProps ? nodesProps[reference.id] : null;
-
       res.push({
-        name        : createLabel(reference, props),
+        name        : createLabel(reference),
         refType     : parentNode.refType,
         nodeInfo    : reference,
         hasChildren : false,
@@ -303,7 +280,7 @@ function (model, viewHandler, util) {
       if (elementInfo instanceof AstNodeInfo) {
         //--- Properties ---//
 
-        var nodesProps = model.cppservice.getProperties([elementInfo.id]);
+        var nodesProps = model.cppservice.getProperties(elementInfo.id);
         var props = nodesProps[elementInfo.id];
 
         for (var propName in props) {

--- a/service/language/language.thrift
+++ b/service/language/language.thrift
@@ -64,16 +64,14 @@ service LanguageService
     throws (1:common.InvalidId ex)
 
   /**
-   * Returns a set of properties for each AST node.
-   * @param astNodeIds IDs of the AST nodes.
-   * @return A collection which maps the AST node ID to a property (key, value)
-   * pair.
+   * Returns a set of properties which can be known about the given AST node.
+   * @param astNodeId ID of an AST node.
+   * @return A collection which maps the property name to the property value.
    * @exception common.InvalidId Exception is thrown if no AST node belongs to
-   * a given node ID.
+   * the given ID.
    */
-  map<common.AstNodeId, map<string, string>> getProperties(
-    1:list<common.AstNodeId> astNodeIds)
-      throws (1:common.InvalidId ex)
+  map<string, string> getProperties(1:common.AstNodeId astNodeIds)
+    throws (1:common.InvalidId ex)
 
   /**
    * Returns the diagram types which can be passed to getDiagram() function for


### PR DESCRIPTION
If a template class has a method then its definition also has to
be visited so we can jump on it and get its mangled name.

Moreover for function we add the signature as astValue. We use
astValue for textual representation of an AST node. This way we don't
need to get the properties of a function just to get its signature.