### PR TITLE
Third party libs as system includes

### DIFF
--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -1,5 +1,7 @@
 include_directories(
-  include
+  include)
+
+include_directories(SYSTEM
   ${ODB_INCLUDE_DIRS})
 
 set(ODB_SOURCES

--- a/parser/CMakeLists.txt
+++ b/parser/CMakeLists.txt
@@ -1,8 +1,9 @@
 include_directories(
   include
   ${PROJECT_SOURCE_DIR}/util/include
-  ${PROJECT_SOURCE_DIR}/model/include
-  ${LLVM_INCLUDE_DIRS}
+  ${PROJECT_SOURCE_DIR}/model/include)
+
+include_directories(SYSTEM
   ${ODB_INCLUDE_DIRS})
 
 add_executable(CodeCompass_parser

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Common things
-include_directories(
+include_directories(SYSTEM
   ${ODB_INCLUDE_DIRS})
 
 # Add all subdirectories to the build

--- a/plugins/cpp/parser/CMakeLists.txt
+++ b/plugins/cpp/parser/CMakeLists.txt
@@ -5,7 +5,9 @@ include_directories(
   ${CMAKE_SOURCE_DIR}/parser/include
   ${CMAKE_SOURCE_DIR}/util/include
   ${CMAKE_SOURCE_DIR}/model/include
-  ${PLUGIN_DIR}/model/include
+  ${PLUGIN_DIR}/model/include)
+
+include_directories(SYSTEM
   ${LLVM_INCLUDE_DIRS})
 
 link_directories(${LLVM_LIBRARY_DIRS})

--- a/plugins/cpp/service/CMakeLists.txt
+++ b/plugins/cpp/service/CMakeLists.txt
@@ -6,7 +6,9 @@ include_directories(
   ${PROJECT_SOURCE_DIR}/service/language/gen-cpp
   ${PROJECT_SOURCE_DIR}/service/project/gen-cpp
   ${PROJECT_SOURCE_DIR}/service/project/include
-  ${PLUGIN_DIR}/model/include
+  ${PLUGIN_DIR}/model/include)
+
+include_directories(SYSTEM
   ${THRIFT_LIBTHRIFT_INCLUDE_DIRS})
 
 add_library(cppservice SHARED

--- a/plugins/cpp/test/CMakeLists.txt
+++ b/plugins/cpp/test/CMakeLists.txt
@@ -4,7 +4,9 @@ include_directories(
   ${PROJECT_SOURCE_DIR}/service/language/gen-cpp
   ${PROJECT_SOURCE_DIR}/service/project/gen-cpp
   ${PROJECT_SOURCE_DIR}/model/include
-  ${PROJECT_SOURCE_DIR}/util/include
+  ${PROJECT_SOURCE_DIR}/util/include)
+
+include_directories(SYSTEM
   ${THRIFT_LIBTHRIFT_INCLUDE_DIRS})
 
 add_executable(cpptest

--- a/plugins/dummy/parser/CMakeLists.txt
+++ b/plugins/dummy/parser/CMakeLists.txt
@@ -2,8 +2,7 @@ include_directories(
   include
   ${PROJECT_SOURCE_DIR}/model/include
   ${PROJECT_SOURCE_DIR}/util/include
-  ${PROJECT_SOURCE_DIR}/parser/include
-  ${LLVM_INCLUDE_DIRS})
+  ${PROJECT_SOURCE_DIR}/parser/include)
 
 set(SOURCES src/dummyparser.cpp)
 

--- a/plugins/dummy/service/CMakeLists.txt
+++ b/plugins/dummy/service/CMakeLists.txt
@@ -2,7 +2,9 @@ include_directories(
   include
   gen-cpp
   ${PROJECT_SOURCE_DIR}/util/include
-  ${PROJECT_SOURCE_DIR}/webserver/include
+  ${PROJECT_SOURCE_DIR}/webserver/include)
+
+include_directories(SYSTEM
   ${THRIFT_LIBTHRIFT_INCLUDE_DIRS})
 
 add_custom_command(

--- a/plugins/git/service/CMakeLists.txt
+++ b/plugins/git/service/CMakeLists.txt
@@ -3,7 +3,9 @@ include_directories(
   gen-cpp
   ${PROJECT_SOURCE_DIR}/util/include
   ${PROJECT_SOURCE_DIR}/webserver/include
-  ${PLUGIN_DIR}/model/include
+  ${PLUGIN_DIR}/model/include)
+
+include_directories(SYSTEM
   ${THRIFT_LIBTHRIFT_INCLUDE_DIRS})
 
 add_custom_command(

--- a/plugins/metrics/service/CMakeLists.txt
+++ b/plugins/metrics/service/CMakeLists.txt
@@ -5,7 +5,9 @@ include_directories(
   ${PROJECT_SOURCE_DIR}/service/project/include
   ${PLUGIN_DIR}/model/include
   ${PROJECT_SOURCE_DIR}/util/include
-  ${PROJECT_SOURCE_DIR}/webserver/include
+  ${PROJECT_SOURCE_DIR}/webserver/include)
+
+include_directories(SYSTEM
   ${THRIFT_LIBTHRIFT_INCLUDE_DIRS})
 
 add_custom_command(

--- a/plugins/search/indexer/CMakeLists.txt
+++ b/plugins/search/indexer/CMakeLists.txt
@@ -1,7 +1,9 @@
 include_directories(
   include
   gen-cpp
-  ${PROJECT_SOURCE_DIR}/util/include
+  ${PROJECT_SOURCE_DIR}/util/include)
+
+include_directories(SYSTEM
   ${THRIFT_LIBTHRIFT_INCLUDE_DIRS})
 
 add_custom_command(

--- a/plugins/search/parser/CMakeLists.txt
+++ b/plugins/search/parser/CMakeLists.txt
@@ -4,8 +4,9 @@ include_directories(
   ${PROJECT_SOURCE_DIR}/util/include
   ${PROJECT_SOURCE_DIR}/parser/include
   ${PLUGIN_DIR}/indexer/gen-cpp
-  ${PLUGIN_DIR}/indexer/include
-  ${LLVM_INCLUDE_DIRS}
+  ${PLUGIN_DIR}/indexer/include)
+
+include_directories(SYSTEM
   ${THRIFT_LIBTHRIFT_INCLUDE_DIRS})
 
 add_library(searchparser SHARED src/searchparser.cpp)

--- a/plugins/search/service/CMakeLists.txt
+++ b/plugins/search/service/CMakeLists.txt
@@ -6,7 +6,9 @@ include_directories(
   ${PROJECT_SOURCE_DIR}/model/include
   ${PROJECT_SOURCE_DIR}/service/language/gen-cpp
   ${PROJECT_SOURCE_DIR}/service/project/gen-cpp
-  ${PLUGIN_DIR}/model/include
+  ${PLUGIN_DIR}/model/include)
+
+include_directories(SYSTEM
   ${THRIFT_LIBTHRIFT_INCLUDE_DIRS})
 
 # Generate thrift files

--- a/service/language/CMakeLists.txt
+++ b/service/language/CMakeLists.txt
@@ -1,5 +1,7 @@
 include_directories(
-  ../project/gen-cpp
+  ../project/gen-cpp)
+
+include_directories(SYSTEM
   ${THRIFT_LIBTHRIFT_INCLUDE_DIRS})
 
 add_custom_command(

--- a/service/plugin/CMakeLists.txt
+++ b/service/plugin/CMakeLists.txt
@@ -2,7 +2,9 @@ include_directories(
   include
   gen-cpp
   ${PROJECT_SOURCE_DIR}/webserver/include
-  ${PROJECT_SOURCE_DIR}/util/include
+  ${PROJECT_SOURCE_DIR}/util/include)
+
+include_directories(SYSTEM
   ${THRIFT_LIBTHRIFT_INCLUDE_DIRS})
 
 add_custom_command(

--- a/service/project/CMakeLists.txt
+++ b/service/project/CMakeLists.txt
@@ -3,7 +3,9 @@ include_directories(
   gen-cpp
   ${PROJECT_SOURCE_DIR}/model/include
   ${PROJECT_SOURCE_DIR}/util/include
-  ${PROJECT_SOURCE_DIR}/webserver/include
+  ${PROJECT_SOURCE_DIR}/webserver/include)
+
+include_directories(SYSTEM
   ${THRIFT_LIBTHRIFT_INCLUDE_DIRS}
   ${ODB_INCLUDE_DIRS})
 

--- a/service/workspace/CMakeLists.txt
+++ b/service/workspace/CMakeLists.txt
@@ -2,7 +2,9 @@ include_directories(
   include
   gen-cpp
   ${PROJECT_SOURCE_DIR}/util/include
-  ${PROJECT_SOURCE_DIR}/webserver/include
+  ${PROJECT_SOURCE_DIR}/webserver/include)
+
+include_directories(SYSTEM
   ${THRIFT_LIBTHRIFT_INCLUDE_DIRS})
 
 add_custom_command(


### PR DESCRIPTION
Third party libraries should be added as system includes. This way the
warnings from these libs won't display.