### PR TITLE
Don't start webserver without parsed projects.

### DIFF
--- a/webserver/include/webserver/pluginhelper.h
+++ b/webserver/include/webserver/pluginhelper.h
@@ -88,6 +88,10 @@ inline void registerPluginSimple(
         << " in workspace " << project;
     }
   }
+
+  if (pluginHandler_->getImplementationMap().empty())
+    throw std::runtime_error(
+      "There are no parsed projects in the given workspace directory.");
 }
 
 #define CODECOMPASS_SERVICE_FACTORY_WITH_CFG(serviceName, nspace) \

--- a/webserver/src/webserver.cpp
+++ b/webserver/src/webserver.cpp
@@ -22,9 +22,7 @@ po::options_description commandLineArguments()
     ("help,h",
       "Prints this help message.")
     ("workspace,w", po::value<std::string>()->required(),
-      "Path to a workspace directory which contains the parsed projects and an "
-      "INI-like format workspace.cfg file with information of the parsed "
-      "projects.")
+      "Path to a workspace directory which contains the parsed projects.")
     ("database,d", po::value<std::string>()->required(),
       // TODO: Provide a full connection string example.
       "A connection string to the relational database with the following "


### PR DESCRIPTION
The WebGUI displays a blank page with an error message on its console
when the workspace directory contains to parsed projects.
Fixes #29