### PR TITLE
No mark when selection

### DIFF
--- a/webgui/scripts/codecompass/view/component/Text.js
+++ b/webgui/scripts/codecompass/view/component/Text.js
@@ -544,11 +544,13 @@ function (declare, domClass, dom, style, query, topic, ContentPane, Dialog,
       var that = this;
       this.selection = range;
 
+      this.clearAllMarks();
+
       setTimeout(function () {
         var fl = that._codeMirror.options.firstLineNumber;
         that._codeMirror.doc.setSelection(
           { line : range[2] - fl, ch : range[3] - 1 },
-          { line : range[0] - fl, ch : range[1] - 1 })
+          { line : range[0] - fl, ch : range[1] - 1 });
       }, 0);
     },
 


### PR DESCRIPTION
In the web GUI the highlight of usages of a symbol have to be cleared
before selection otherwise selection is not shown e.g. in case of a
click in InfoTree.