### PR TITLE
Upgrade CodeCompass to use LLVM 6.0 and fix as many warnings as possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.4.3)
 project(CodeCompass)
 
 # Common config variables and settings

--- a/doc/deps.md
+++ b/doc/deps.md
@@ -3,18 +3,19 @@ We build CodeCompass under Linux. It is recommended to use a 64-bit operating
 system.
 
 # Dependencies
-CodeCompass uses some 3rd party dependencies. These can be installed from the
+CodeCompass uses some third-party dependencies. These can be installed from the
 official repository of the given Linux distribution. In Ubuntu 16.04 LTS the
 following packages are necessary for building CodeCompass:
 
 - **git**: For fetching and managing CodeCompass source code.
-- **cmake**: For building CodeCompass.
-- **make**: For building CodeCompass.
-- **g++**: For compiling CodeCompass. We use C++14 features, so the compiler
-  has to be able to compile it.
+- **cmake** and **make**: For building CodeCompass.
+- **g++**: For compiling CodeCompass. A version which supports C++14 features
+  is required. (Alternatively, you can compile with Clang.)
 - **libboost-all-dev**: Boost can be used during the development.
-- **llvm-3.8-dev**, **libclang-3.8-dev**: C++ parser uses LLVM/Clang for
-  parsing the source code. Version 3.8 is required.
+- **llvm-6.0**, **clang-6.0**: For compiling CodeCompass with Clang instead of
+  G++.
+- **llvm-6.0-dev**, **libclang-6.0-dev**: C++ parser uses LLVM/Clang for
+  parsing the source code. Version 6.0 or newer is required.
   ***See [Known issues](#known-issues)!***
 - **odb**, **libodb-dev**, **libodb-sqlite-dev**, **libodb-pgsql-dev**: For
   persistence ODB can be used which is an Object Relation Mapping (ORM) system.
@@ -22,12 +23,11 @@ following packages are necessary for building CodeCompass:
 - **openjdk-8-jdk**: For search parsing CodeCompass uses an indexer written in
   Java.
 - **libssl-dev**: OpenSSL libs are required by Thrift.
-- **libsqlite3-dev**: SQLite can be used for persistence. This is needed only if
-  you choose SQLite as a database system.
 - **libgraphviz-dev**: GraphViz is used for generating diagram visualitaions.
 - **libmagic-dev**: For detecting file types.
 - **libgit2-dev**: For compiling Git plugin in CodeCompass.
-- **npm**: For handling JavaScript dependencies for CodeCompass web GUI.
+- **npm** and **nodejs-legacy**: For handling JavaScript dependencies for
+  CodeCompass web GUI.
 - **ctags**: For search parsing.
 - **libgtest-dev**: For testing CodeCompass.
   ***See [Known issues](#known-issues)!***
@@ -35,10 +35,12 @@ following packages are necessary for building CodeCompass:
 The following command installs the packages except for those which have some
 known issues:
 ```bash
-sudo apt-get install git cmake make g++ libboost-all-dev openjdk-8-jdk libssl-dev libsqlite3-dev libgraphviz-dev libmagic-dev libgit2-dev npm ctags libgtest-dev
+sudo apt-get install git cmake make g++ libboost-all-dev openjdk-8-jdk \
+  libssl-dev libgraphviz-dev libmagic-dev libgit2-dev npm \
+  nodejs-legacy ctags libgtest-dev
 ```
 
-CodeCompass needs [Thrift](httos://thrift.apache.org/) which provides Remote
+CodeCompass needs [Thrift](https://thrift.apache.org/) which provides Remote
 Procedure Call (RPC) between the server and the client. Thrift is not part of
 the official Ubuntu 16.04 LTS repositories, but you can download it and build
 from source:
@@ -53,20 +55,29 @@ sudo apt-get install byacc flex
 
 tar -xvf ./thrift-<version>.tar.gz
 cd thrift-<version>
-./configure --prefix=<thrift_install_dir>
+
+./configure --prefix=<thrift_install_dir> --with-python=NO --with-php=NO
 # Thrift can generate stubs for many programming languages. The configure script
 # looks at the development environment and if it finds the environment for a
 # given language then it'll use it. For example in the previous step npm was
 # installed which requires NodeJS. If NodeJS can be found on your machine then
 # the corresponding stub will also compile. If you don't need it then you can
 # turn it off: ./configure --witout-nodejs.
+#
+# In certain cases, installation may fail if development libraries for languages
+# are not installed on the target machine. E.g. if Python is installed but the
+# Python development headers are not, Thrift will unable to install.
+# Python, PHP and such other Thrift builds are NOT required by CodeCompass.
+
 make install
 ```
 
 ## Known issues
 - In Ubuntu 16.04 LTS the LLVM/Clang has some packaging issues, i.e. some libs
   are searched in `/usr/lib` however the package has these in
-  `/usr/lib/llvm-3.8/lib` (see http://stackoverflow.com/questions/38171543/error-when-using-cmake-with-llvm).
+  `/usr/lib/llvm-3.8/lib` (see
+  [http://stackoverflow.com/questions/38171543/error-when-using-cmake-with-llvm](http://stackoverflow.com/questions/38171543/error-when-using-cmake-with-llvm)
+  . Also, LLVM version 6.0 is not available as a package.
   This problem causes an error when emitting `cmake` command during CodeCompass
   build. A solution would be to download a prebuilt package from the LLVM/Clang
   webpage but another issue is that the prebuilt packages don't use RTTI which
@@ -74,19 +85,22 @@ make install
   RTTI manually:
 
 ```bash
-wget http://releases.llvm.org/3.8.0/llvm-3.8.0.src.tar.xz
-tar -xvf llvm-3.8.0.src.tar.xz
-cd llvm-3.8.0.src/tools
-wget http://releases.llvm.org/3.8.0/cfe-3.8.0.src.tar.xz
-tar -xvf cfe-3.8.0.src.tar.xz
-mv cfe-3.8.0.src clang
-rm cfe-3.8.0.src.tar.xz
+wget http://github.com/llvm-mirror/llvm/archive/release_60.zip
+unzip release_60.zip
+rm release_60.zip
+cd llvm-release_60/tools
+wget http://github.com/llvm-mirror/clang/archive/release_60.zip
+unzip release_60.zip
+mv clang-release_60 clang
+rm release_60.zip
 cd ../..
 
 mkdir build
 cd build
 export REQUIRES_RTTI=1
-cmake -G "Unix Makefiles" -DLLVM_ENABLE_RTTI=ON ../llvm-3.8.0.src -DCMAKE_INSTALL_PREFIX=<clang_install_dir>
+cmake -G "Unix Makefiles" -DLLVM_ENABLE_RTTI=ON \
+  -DCMAKE_INSTALL_PREFIX=<clang_install_dir> \
+  ../llvm-release_60
 # This make step takes a while. If you have more CPUs then you can compile on
 # several threads with -j<number_of_threads> flag.
 make install
@@ -109,28 +123,34 @@ cd libodb-2.4.0
 make install
 cd ..
 
-# If you use SQLite
+#
+# If you use SQLite:
+#
+sudo apt-get install libsqlite3-dev # Needed for this step.
 wget http://www.codesynthesis.com/download/odb/2.4/libodb-sqlite-2.4.0.tar.gz
 tar -xvf libodb-sqlite-2.4.0.tar.gz
 cd libodb-sqlite-2.4.0
-./configure --prefix=<odb_install_dir>
+./configure --prefix=<odb_install_dir> \
+  --with-libodb="$(readlink -f ../libodb-2.4.0)"
 make install
 cd ..
 
-# If you use PostgreSQL
-sudo apt-get install postgresql-server-dev-<version> # Needed for this step
+#
+# If you use PostgreSQL:
+#
+sudo apt-get install postgresql-server-dev-<version> # Needed for this step.
 wget http://www.codesynthesis.com/download/odb/2.4/libodb-pgsql-2.4.0.tar.gz
 tar -xvf libodb-pgsql-2.4.0.tar.gz
 cd libodb-pgsql-2.4.0
-./configure --prefix=<odb_install_dir>
+./configure --prefix=<odb_install_dir> \
+  --with-libodb="$(readlink -f ../libodb-2.4.0)"
 make install
 cd ..
 
-sudo apt-get install gcc-<version>-plugin-dev
-sudo apt-get install libcutl-dev
+sudo apt-get install gcc-<version>-plugin-dev libcutl-dev libexpat1-dev
 wget http://www.codesynthesis.com/download/odb/2.4/odb-2.4.0.tar.gz
 tar -xvf odb-2.4.0.tar.gz
-cd odb-2.4.0.tar.gz
+cd odb-2.4.0
 ./configure --prefix=<odb_install_dir>
 make install
 cd ..
@@ -141,20 +161,23 @@ cd ..
   copy the libs to the right place:
 
 ```bash
-cd /usr/src/gtest
-sudo cmake .
-sudo make
-sudo cp libgtest.a libgtest_main.a /usr/lib
+mkdir <gtest_install_dir>
+cp -R /usr/src/gtest <gtest_install_dir>
+cmake .
+make
+mkdir <gtest_install_dir>/lib
+mv libgtest.a libgtest_main.a <gtest_install_dir>/lib/
 ```
 
 # Build CodeCompass
 
-The dependencies which are installed manually because of known issues have to be
-seen by CMake build system:
+The dependencies which are installed manually because of known issues have to
+be seen by CMake build system:
 
 ```bash
+export GTEST_ROOT=<gtest_install_dir>
 export CMAKE_PREFIX_PATH=<thrift_install_dir>:$CMAKE_PREFIX_PATH
-export CMAKE_PREFIX_PATH=<clang_install_dir>/share/llvm/cmake:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=<clang_install_dir>:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=<odb_install_dir>:$CMAKE_PREFIX_PATH
 export PATH=<thrift_install_dir>/bin:$PATH
 export PATH=<odb_install_dir>/bin:$PATH
@@ -194,4 +217,4 @@ during compilation.
 | `CMAKE_INSTALL_PREFIX` | Install directory. For more information see: https://cmake.org/cmake/help/v3.0/variable/CMAKE_INSTALL_PREFIX.html |
 | `CMAKE_BUILD_TYPE` | Specifies the build type on single-configuration generators. Possible values are empty, **Debug**, **Release**. For more information see: https://cmake.org/cmake/help/v3.0/variable/CMAKE_BUILD_TYPE.html |
 | `CMAKE_CXX_COMPILER` | If the official repository of your Linux distribution doesn't contain a C++ compiler which supports C++14 then you can install one manually and set to use it. For more information see: https://cmake.org/Wiki/CMake_Useful_Variables |
-| `DATABASE` | Database type. Possible values are **sqlite**, **pgsql**. The default value is sqlite. |
+| `DATABASE` | Database type. Possible values are **sqlite**, **pgsql**. The default value is `sqlite`. |

--- a/parser/CMakeLists.txt
+++ b/parser/CMakeLists.txt
@@ -11,6 +11,9 @@ add_executable(CodeCompass_parser
   src/sourcemanager.cpp
   src/parser.cpp)
 
+set_target_properties(CodeCompass_parser
+  PROPERTIES ENABLE_EXPORTS 1)
+
 target_link_libraries(CodeCompass_parser
   util
   model

--- a/parser/src/sourcemanager.cpp
+++ b/parser/src/sourcemanager.cpp
@@ -32,7 +32,7 @@ SourceManager::SourceManager(std::shared_ptr<odb::database> db_)
 
   //--- Initialize magic for plain text testing ---//
 
-  if (_magicCookie = ::magic_open(MAGIC_SYMLINK))
+  if ((_magicCookie = ::magic_open(MAGIC_SYMLINK)))
   {
     if (::magic_load(_magicCookie, 0) != 0)
     {

--- a/plugins/cpp/parser/CMakeLists.txt
+++ b/plugins/cpp/parser/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(Clang REQUIRED CONFIG)
+
 llvm_map_components_to_libnames(llvm_libs support core irreader)
 
 include_directories(
@@ -8,7 +10,8 @@ include_directories(
   ${PLUGIN_DIR}/model/include)
 
 include_directories(SYSTEM
-  ${LLVM_INCLUDE_DIRS})
+  ${LLVM_INCLUDE_DIRS}
+  ${CLANG_INCLUDE_DIRS})
 
 link_directories(${LLVM_LIBRARY_DIRS})
 

--- a/plugins/cpp/parser/src/cppparser.cpp
+++ b/plugins/cpp/parser/src/cppparser.cpp
@@ -113,7 +113,7 @@ private:
     }
 
     virtual bool BeginSourceFileAction(
-      clang::CompilerInstance& compiler_, llvm::StringRef) override
+      clang::CompilerInstance& compiler_) override
     {
       compiler_.createASTContext();
       auto& pp = compiler_.getPreprocessor();
@@ -296,10 +296,18 @@ int CppParser::worker(const clang::tooling::CompileCommand& command_)
 
   int argc = commandLine.size();
 
+  std::string compilationDbLoadError;
   std::unique_ptr<clang::tooling::FixedCompilationDatabase> compilationDb(
     clang::tooling::FixedCompilationDatabase::loadFromCommandLine(
       argc,
-      commandLine.data()));
+      commandLine.data(),
+      compilationDbLoadError));
+
+  if (!compilationDb)
+  {
+    LOG(error) << "Failed to create compilation database from command-line. " << compilationDbLoadError;
+    return 1;
+  }
 
   //--- Save build action ---//
 
@@ -358,7 +366,8 @@ bool CppParser::parseByJson(
 
   std::unique_ptr<clang::tooling::JSONCompilationDatabase> compDb
     = clang::tooling::JSONCompilationDatabase::loadFromFile(
-        jsonFile_, errorMsg);
+        jsonFile_, errorMsg,
+        clang::tooling::JSONCommandLineSyntax::Gnu);
 
   if (!errorMsg.empty())
   {
@@ -430,6 +439,8 @@ CppParser::~CppParser()
 {
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 extern "C"
 {
   boost::program_options::options_description getOptions()
@@ -447,6 +458,7 @@ extern "C"
     return std::make_shared<CppParser>(ctx_);
   }
 }
+#pragma clang diagnostic pop
 
 } // parser
 } // cc

--- a/plugins/cpp/parser/src/ppmacrocallback.cpp
+++ b/plugins/cpp/parser/src/ppmacrocallback.cpp
@@ -100,7 +100,7 @@ void PPMacroCallback::MacroExpands(
   _disabled = true;
   clang::DiagnosticsEngine *OldDiags = &_pp.getDiagnostics();
   _pp.setDiagnostics(TmpDiags);
-  _pp.EnterTokenStream(tokens.data(), tokens.size(), false, false);
+  _pp.EnterTokenStream(tokens, false);
 
   std::string expansion;
   _pp.Lex(tok);
@@ -165,7 +165,8 @@ void PPMacroCallback::MacroDefined(
 
 void PPMacroCallback::MacroUndefined(
   const clang::Token& macroNameTok_,
-  const clang::MacroDefinition& md_)
+  const clang::MacroDefinition& md_,
+  const clang::MacroDirective* undef_)
 {
   const clang::MacroInfo* mi = md_.getMacroInfo();
 

--- a/plugins/cpp/parser/src/ppmacrocallback.h
+++ b/plugins/cpp/parser/src/ppmacrocallback.h
@@ -46,7 +46,8 @@ public:
 
   virtual void MacroUndefined(
     const clang::Token& macroNameTok_,
-    const clang::MacroDefinition& md_) override;
+    const clang::MacroDefinition& md_,
+    const clang::MacroDirective* undef_) override;
 
 private:
 

--- a/plugins/cpp/service/src/plugin.cpp
+++ b/plugins/cpp/service/src/plugin.cpp
@@ -2,24 +2,25 @@
 
 #include <service/cppservice.h>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 extern "C"
 {
+  boost::program_options::options_description getOptions()
+  {
+    boost::program_options::options_description description("C++ Plugin");
+    return description;
+  }
 
-boost::program_options::options_description getOptions()
-{
-  boost::program_options::options_description description("C++ Plugin");
-  return description;
+  void registerPlugin(
+    const boost::program_options::variables_map& configuration,
+    cc::webserver::PluginHandler<cc::webserver::RequestHandler>* pluginHandler)
+  {
+    cc::webserver::registerPluginSimple(
+      configuration,
+      pluginHandler,
+      CODECOMPASS_LANGUAGE_SERVICE_FACTORY_WITH_CFG(Cpp),
+      "CppService");
+  }
 }
-
-void registerPlugin(
-  const boost::program_options::variables_map& configuration,
-  cc::webserver::PluginHandler<cc::webserver::RequestHandler>* pluginHandler)
-{
-  cc::webserver::registerPluginSimple(
-    configuration,
-    pluginHandler,
-    CODECOMPASS_LANGUAGE_SERVICE_FACTORY_WITH_CFG(Cpp),
-    "CppService");
-}
-
-}
+#pragma clang diagnostic pop

--- a/plugins/cpp/test/src/servicehelper.cpp
+++ b/plugins/cpp/test/src/servicehelper.cpp
@@ -21,7 +21,7 @@ namespace test
 ServiceHelper::ServiceHelper(
   std::shared_ptr<odb::database> db_,
   std::shared_ptr<CppServiceHandler> cppservice_) :
-    _db(db_), _transaction(_db), _cppservice(cppservice_)
+    _db(db_), _cppservice(cppservice_), _transaction(_db)
 {
 }
 

--- a/plugins/dummy/parser/src/dummyparser.cpp
+++ b/plugins/dummy/parser/src/dummyparser.cpp
@@ -42,6 +42,18 @@ DummyParser::~DummyParser()
 {
 }
 
+/* These two methods are used by the plugin manager to allow dynamic loading
+   of CodeCompass Parser plugins. Clang (>= version 6.0) gives a warning that
+   these C-linkage specified methods return types that are not proper from a
+   C code.
+
+   These codes are NOT to be called from any C code. The C linkage is used to
+   turn off the name mangling so that the dynamic loader can easily find the
+   symbol table needed to set the plugin up.
+*/
+// When writing a plugin, please do NOT copy this notice to your code.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 extern "C"
 {
   boost::program_options::options_description getOptions()
@@ -60,6 +72,7 @@ extern "C"
     return std::make_shared<DummyParser>(ctx_);
   }
 }
+#pragma clang diagnostic pop
 
 } // parser
 } // cc

--- a/plugins/git/parser/src/gitparser.cpp
+++ b/plugins/git/parser/src/gitparser.cpp
@@ -121,6 +121,8 @@ GitParser::~GitParser()
   git_libgit2_shutdown();
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 extern "C"
 {
   boost::program_options::options_description getOptions()
@@ -134,6 +136,7 @@ extern "C"
     return std::make_shared<GitParser>(ctx_);
   }
 }
+#pragma clang diagnostic pop
 
 } // parser
 } // cc

--- a/plugins/git/service/include/service/gitservice.h
+++ b/plugins/git/service/include/service/gitservice.h
@@ -54,7 +54,7 @@ public:
 
   virtual void getRepositoryByProjectPath(
     RepositoryByProjectPathResult& return_,
-    const std::string& path_);
+    const std::string& path_) override;
 
   virtual void getBlobOidByPath(
     std::string& return_,

--- a/plugins/git/service/src/plugin.cpp
+++ b/plugins/git/service/src/plugin.cpp
@@ -2,25 +2,26 @@
 
 #include <service/gitservice.h>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 extern "C"
 {
+  boost::program_options::options_description getOptions()
+  {
+    namespace po = boost::program_options;
+    po::options_description description("Git Plugin");
+    return description;
+  }
 
-boost::program_options::options_description getOptions()
-{
-  namespace po = boost::program_options;
-  po::options_description description("Git Plugin");
-  return description;
+  void registerPlugin(
+    const boost::program_options::variables_map& configuration,
+    cc::webserver::PluginHandler<cc::webserver::RequestHandler>* pluginHandler)
+  {
+    cc::webserver::registerPluginSimple(
+      configuration,
+      pluginHandler,
+      CODECOMPASS_SERVICE_FACTORY_WITH_CFG(Git, git),
+      "GitService");
+  }
 }
-
-void registerPlugin(
-  const boost::program_options::variables_map& configuration,
-  cc::webserver::PluginHandler<cc::webserver::RequestHandler>* pluginHandler)
-{
-  cc::webserver::registerPluginSimple(
-    configuration,
-    pluginHandler,
-    CODECOMPASS_SERVICE_FACTORY_WITH_CFG(Git, git),
-    "GitService");
-}
-
-}
+#pragma clang diagnostic pop

--- a/plugins/metrics/parser/src/metricsparser.cpp
+++ b/plugins/metrics/parser/src/metricsparser.cpp
@@ -280,6 +280,8 @@ void MetricsParser::persistLoc(const Loc& loc_, model::FileId file_)
   });
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 extern "C"
 {
   boost::program_options::options_description getOptions()
@@ -293,6 +295,7 @@ extern "C"
     return std::make_shared<MetricsParser>(ctx_);
   }
 }
+#pragma clang diagnostic pop
 
 }
 }

--- a/plugins/metrics/service/src/plugin.cpp
+++ b/plugins/metrics/service/src/plugin.cpp
@@ -2,23 +2,24 @@
 
 #include <metricsservice/metricsservice.h>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 extern "C"
 {
+  boost::program_options::options_description getOptions()
+  {
+    return boost::program_options::options_description("Metrics Plugin");
+  }
 
-boost::program_options::options_description getOptions()
-{
-  return boost::program_options::options_description("Metrics Plugin");
+  void registerPlugin(
+    const boost::program_options::variables_map& configuration,
+    cc::webserver::PluginHandler<cc::webserver::RequestHandler>* pluginHandler)
+  {
+    cc::webserver::registerPluginSimple(
+      configuration,
+      pluginHandler,
+      CODECOMPASS_SERVICE_FACTORY_WITH_CFG(Metrics, metrics),
+      "MetricsService");
+  }
 }
-
-void registerPlugin(
-  const boost::program_options::variables_map& configuration,
-  cc::webserver::PluginHandler<cc::webserver::RequestHandler>* pluginHandler)
-{
-  cc::webserver::registerPluginSimple(
-    configuration,
-    pluginHandler,
-    CODECOMPASS_SERVICE_FACTORY_WITH_CFG(Metrics, metrics),
-    "MetricsService");
-}
-
-}
+#pragma clang diagnostic pop

--- a/plugins/search/parser/src/searchparser.cpp
+++ b/plugins/search/parser/src/searchparser.cpp
@@ -85,6 +85,7 @@ std::vector<std::string> SearchParser::getDependentParsers() const
 bool SearchParser::parse()
 {
   if (fs::is_directory(_searchDatabase))
+  {
     if (_ctx.options.count("force"))
     {
       fs::remove_all(_searchDatabase);
@@ -97,6 +98,7 @@ bool SearchParser::parse()
            "Use -f flag for forcing reparse.";
       return true;
     }
+  }
 
   for (const std::string& path :
     _ctx.options["input"].as<std::vector<std::string>>())
@@ -240,6 +242,8 @@ SearchParser::~SearchParser()
     ::magic_close(_fileMagic);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 extern "C"
 {
   boost::program_options::options_description getOptions()
@@ -259,7 +263,7 @@ extern "C"
     return std::shared_ptr<SearchParser>(new SearchParser(ctx_));
   }
 }
-
+#pragma clang diagnostic pop
 
 } // parser
 } // cc

--- a/plugins/search/service/include/service/searchservice.h
+++ b/plugins/search/service/include/service/searchservice.h
@@ -37,7 +37,7 @@ public:
 
   void searchFile(
     FileSearchResult& _return,
-    const SearchParams&     params_);
+    const SearchParams&     params_) override;
 
   void getSearchTypes(std::vector<SearchType> & _return) override;
 

--- a/plugins/search/service/src/plugin.cpp
+++ b/plugins/search/service/src/plugin.cpp
@@ -1,24 +1,25 @@
 #include <webserver/pluginhelper.h>
 #include <service/searchservice.h>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 extern "C"
 {
+  boost::program_options::options_description getOptions()
+  {
+    boost::program_options::options_description description("Search Plugin");
+    return description;
+  }
 
-boost::program_options::options_description getOptions()
-{
-  boost::program_options::options_description description("Search Plugin");
-  return description;
+  void registerPlugin(
+    const boost::program_options::variables_map& configuration,
+    cc::webserver::PluginHandler<cc::webserver::RequestHandler>* pluginHandler)
+  {
+    cc::webserver::registerPluginSimple(
+      configuration,
+      pluginHandler,
+      CODECOMPASS_SERVICE_FACTORY_WITH_CFG(Search, search),
+      "SearchService");
+  }
 }
-
-void registerPlugin(
-  const boost::program_options::variables_map& configuration,
-  cc::webserver::PluginHandler<cc::webserver::RequestHandler>* pluginHandler)
-{
-  cc::webserver::registerPluginSimple(
-    configuration,
-    pluginHandler,
-    CODECOMPASS_SERVICE_FACTORY_WITH_CFG(Search, search),
-    "SearchService");
-}
-
-}
+#pragma clang diagnostic pop

--- a/service/plugin/src/plugin.cpp
+++ b/service/plugin/src/plugin.cpp
@@ -2,25 +2,26 @@
 #include <webserver/thrifthandler.h>
 #include <pluginservice/pluginservice.h>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 extern "C"
 {
+  boost::program_options::options_description getOptions()
+  {
+    boost::program_options::options_description description("Plugin Plugin");
 
-boost::program_options::options_description getOptions()
-{
-  boost::program_options::options_description description("Plugin Plugin");
+    return description;
+  }
 
-  return description;
+  void registerPlugin(
+    const boost::program_options::variables_map& config_,
+    cc::webserver::PluginHandler<cc::webserver::RequestHandler>* pluginHandler_)
+  {
+    std::shared_ptr<cc::webserver::RequestHandler> handler(
+      new cc::webserver::ThriftHandler<cc::service::plugin::PluginServiceProcessor>(
+        new cc::service::plugin::PluginServiceHandler(pluginHandler_, config_)));
+
+    pluginHandler_->registerImplementation("PluginService", handler);
+  }
 }
-
-void registerPlugin(
-  const boost::program_options::variables_map& config_,
-  cc::webserver::PluginHandler<cc::webserver::RequestHandler>* pluginHandler_)
-{
-  std::shared_ptr<cc::webserver::RequestHandler> handler(
-    new cc::webserver::ThriftHandler<cc::service::plugin::PluginServiceProcessor>(
-      new cc::service::plugin::PluginServiceHandler(pluginHandler_, config_)));
-
-  pluginHandler_->registerImplementation("PluginService", handler);
-}
-
-}
+#pragma clang diagnostic pop

--- a/service/project/src/plugin.cpp
+++ b/service/project/src/plugin.cpp
@@ -2,25 +2,26 @@
 
 #include <projectservice/projectservice.h>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 extern "C"
 {
+  boost::program_options::options_description getOptions()
+  {
+    boost::program_options::options_description description("Core Plugin");
 
-boost::program_options::options_description getOptions()
-{
-  boost::program_options::options_description description("Core Plugin");
+    return description;
+  }
 
-  return description;
+  void registerPlugin(
+    const boost::program_options::variables_map& configuration,
+    cc::webserver::PluginHandler<cc::webserver::RequestHandler>* pluginHandler)
+  {
+    cc::webserver::registerPluginSimple(
+      configuration,
+      pluginHandler,
+      CODECOMPASS_SERVICE_FACTORY_WITH_CFG(Project, core),
+      "ProjectService");
+  }
 }
-
-void registerPlugin(
-  const boost::program_options::variables_map& configuration,
-  cc::webserver::PluginHandler<cc::webserver::RequestHandler>* pluginHandler)
-{
-  cc::webserver::registerPluginSimple(
-    configuration,
-    pluginHandler,
-    CODECOMPASS_SERVICE_FACTORY_WITH_CFG(Project, core),
-    "ProjectService");
-}
-
-}
+#pragma clang diagnostic pop

--- a/service/workspace/src/plugin.cpp
+++ b/service/workspace/src/plugin.cpp
@@ -4,26 +4,27 @@
 #include <webserver/thrifthandler.h>
 #include <workspaceservice/workspaceservice.h>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 extern "C"
 {
+  boost::program_options::options_description getOptions()
+  {
+    boost::program_options::options_description description("Workspace Plugin");
 
-boost::program_options::options_description getOptions()
-{
-  boost::program_options::options_description description("Workspace Plugin");
+    return description;
+  }
 
-  return description;
+  void registerPlugin(
+    const boost::program_options::variables_map& vm_,
+    cc::webserver::PluginHandler<cc::webserver::RequestHandler>* pluginHandler_)
+  {
+    std::shared_ptr<cc::webserver::RequestHandler> handler(
+      new cc::webserver::ThriftHandler<cc::service::workspace::WorkspaceServiceProcessor>(
+        new cc::service::workspace::WorkspaceServiceHandler(
+          vm_["workspace"].as<std::string>())));
+
+    pluginHandler_->registerImplementation("WorkspaceService", handler);
+  }
 }
-
-void registerPlugin(
-  const boost::program_options::variables_map& vm_,
-  cc::webserver::PluginHandler<cc::webserver::RequestHandler>* pluginHandler_)
-{
-  std::shared_ptr<cc::webserver::RequestHandler> handler(
-    new cc::webserver::ThriftHandler<cc::service::workspace::WorkspaceServiceProcessor>(
-      new cc::service::workspace::WorkspaceServiceHandler(
-        vm_["workspace"].as<std::string>())));
-
-  pluginHandler_->registerImplementation("WorkspaceService", handler);
-}
-
-}
+#pragma clang diagnostic pop

--- a/util/include/util/graph.h
+++ b/util/include/util/graph.h
@@ -16,7 +16,7 @@ namespace cc
 namespace util 
 {
 
-class GraphPimpl;
+struct GraphPimpl;
 
 /**
  * This class helps in creating a graph. The built graph can be written to the

--- a/webserver/CMakeLists.txt
+++ b/webserver/CMakeLists.txt
@@ -3,6 +3,9 @@ add_executable(CodeCompass_webserver
   src/mainrequesthandler.cpp
   src/threadedmongoose.cpp )
 
+set_target_properties(CodeCompass_webserver
+  PROPERTIES ENABLE_EXPORTS 1)
+
 add_library(mongoose STATIC src/mongoose.c )
 
 target_include_directories(mongoose PUBLIC include)

--- a/webserver/include/webserver/thrifthandler.h
+++ b/webserver/include/webserver/thrifthandler.h
@@ -101,7 +101,7 @@ public:
   {
   }
 
-  std::string key() const
+  std::string key() const override
   {
     return "ThriftHandler";
   }


### PR DESCRIPTION
Updated the build information to download LLVM 6, and also fixed some various missing package issues that arise when the user tries to install on a bare Ubuntu 16.04(.1) LTS machine.

Upgraded the client code to use the interface available in LLVM 6.0. This required subtle changes as to how 3 or 4 functions are invoked.

Fixed as many warnings as possible reported by the compiler, such as missing `override` keywords.

`-Wreturn-type-c-linkage` is a Clang-specific warning. This is not appropriate for us as we don't call the library initialisers from pure C code, so it has been quelched.

Updated the blocks of `extern "C" {}` to have the same code layout.