### PR TITLE
Fixing ubuntu packaged LLVM compilation

### DIFF
--- a/plugins/cpp/parser/CMakeLists.txt
+++ b/plugins/cpp/parser/CMakeLists.txt
@@ -1,7 +1,5 @@
 find_package(Clang REQUIRED CONFIG)
 
-llvm_map_components_to_libnames(llvm_libs support core irreader)
-
 include_directories(
   include
   ${CMAKE_SOURCE_DIR}/parser/include
@@ -41,9 +39,7 @@ target_link_libraries(cppparser
   clangLex
   clangBasic
   clang
-  LLVMMCParser
-  LLVMOption
-  ${llvm_libs})
+  )
 
 target_compile_options(cppparser PUBLIC -Wno-unknown-pragmas)
 

--- a/plugins/cpp_reparse/service/CMakeLists.txt
+++ b/plugins/cpp_reparse/service/CMakeLists.txt
@@ -1,7 +1,5 @@
 find_package(Clang REQUIRED CONFIG)
 
-llvm_map_components_to_libnames(llvm_libs support core irreader)
-
 include_directories(
   include
   gen-cpp
@@ -75,7 +73,7 @@ target_link_libraries(cppreparseservice
   clangBasic
   clangAST
   clang
-  ${llvm_libs})
+  )
 
 install(TARGETS cppreparseservice DESTINATION ${INSTALL_SERVICE_DIR})
 install_js_thrift(gen-js/)


### PR DESCRIPTION
Some libraries contain global variables registering command line options.
Accidentally linking to these libraries multiple times results in llvm errors:

: CommandLine Error: Option '<some-option>` registered more than once!
LLVM ERROR: inconsistency in registered CommandLine options

As these libraries aren't used directly by the parser, bur are only used by clang, they can be safely removed.

With these changes, codecompass can be built and run with the Clang binaries from the llvm apt repository / from the Ubuntu repository in case of bionic.

See docker repository for example: https://github.com/dutow/CodeCompass-Docker/commit/8b693880140809a19068e205eee591beb62ee999