### PR TITLE
Skip macro expansion that asserts if macro contains an annotation

### DIFF
--- a/plugins/cpp/parser/src/ppmacrocallback.cpp
+++ b/plugins/cpp/parser/src/ppmacrocallback.cpp
@@ -112,7 +112,18 @@ void PPMacroCallback::MacroExpands(
         expansion += ' ';
 
     // Escape any special characters in the token text.
-    expansion += _pp.getSpelling(tok);
+    if (!tok.isAnnotation())
+      // getSpelling calls getLength() on the token, which is not viable if the
+      // token isAnnotation().
+      // FIXME: Revise how the preprocessor/lexer of Clang could be improved to
+      // handle annotation expansions properly, if possible.
+      expansion += _pp.getSpelling(tok);
+    else
+    {
+      expansion += "/*< FIXME: ";
+      expansion += tok.getName();
+      expansion += " token not expanded. >*/";
+    }
     _pp.Lex(tok);
   }
 


### PR DESCRIPTION
Skip macro expansion that asserts if macro contains an annotation

Parsing LLVM/Clang fails on some build actions (~15-20 out of the ~2800) due to an assertion

    CodeCompass_parser: /large/whisperity/llvm/tools/clang/include/clang/Lex/Token.h:128: unsigned int clang::Token::getLength() const: Assertion `!isAnnotation() && "Annotation tokens have no length field"' failed.

The files where these are found are like `LLVM/lib/ProfileData/Coverage/CoverageMapping.cpp`, but the common point of the failing source files is the inclusion of the header `LLVM/lib/ProfileData/Coverage/CoverageMapping.cpp`.

This header, as of LLVM 7.0 (but this error was present with LLVM 3.8, both with CodeCompass Flash **and Earhart**), contains the following macro at around line 688:

https://github.com/llvm-mirror/llvm/blob/5365e8b41893d044805a280c862c6a9a8732f3cc/include/llvm/ProfileData/Coverage/CoverageMapping.h#L680-L693

```c++
// [Encoded Region Mapping Data]
LLVM_PACKED_START
template <class IntPtrT> struct CovMapFunctionRecordV1 {
#define COVMAP_V1
#define COVMAP_FUNC_RECORD(Type, LLVMType, Name, Init) Type Name;
#include "llvm/ProfileData/InstrProfData.inc"
#undef COVMAP_V1
```

The culprit is `LLVM_PACKED_START` which is defined in `include/llvm/Support/Compiler.h`, as follows:

```c++
 /// \macro LLVM_PACKED
 /// \brief Used to specify a packed structure.
 /// LLVM_PACKED(
 ///    struct A {
 ///      int i;
 ///      int j;
 ///      int k;
 ///      long long l;
 ///   });
 ///
 /// LLVM_PACKED_START
 /// struct B {
 ///   int i;
 ///   int j;
 ///   int k;
 ///   long long l;
 /// };
 /// LLVM_PACKED_END
 #ifdef _MSC_VER
 # define LLVM_PACKED(d) __pragma(pack(push, 1)) d __pragma(pack(pop))
 # define LLVM_PACKED_START __pragma(pack(push, 1))
 # define LLVM_PACKED_END   __pragma(pack(pop))
 #else
 # define LLVM_PACKED(d) d __attribute__((packed))
 # define LLVM_PACKED_START _Pragma("pack(push, 1)")
 # define LLVM_PACKED_END   _Pragma("pack(pop)")
 #endif
```

After macro expansions by the preprocessor (using the `-E` compiler option), this is expanded like this: `#pragma pack(push, 1)`, which is a `pragma_pack` **annotation**:

https://github.com/llvm-mirror/clang/blob/ea7b75a952203b9a2baedad66ec3e3397bb74386/include/clang/Basic/TokenKinds.def#L721-L724

```c++
// Annotation for #pragma pack...
// The lexer produces these so that they only take effect when the parser
// handles them.
ANNOTATION(pragma_pack)
```

Annotation-kind tokens are defined to have a "sema-specific data pointer" inside them, and the `getLength()` call on such tokens are non-applicable, an assertion happens.

The relevant part of such stack trace is:

```
#4  0x00007fffe880baa3 in clang::Token::getLength (this=0x7fffe0953068) at /large/whisperity/llvm/tools/clang/include/clang/Lex/Token.h:128
#5  0x00007fffe87fc545 in clang::Lexer::getSpelling[abi:cxx11](clang::Token const&, clang::SourceManager const&, clang::LangOptions const&, bool*) (Tok=..., 
    SourceMgr=..., LangOpts=..., Invalid=0x0) at /large/whisperity/llvm/tools/clang/lib/Lex/Lexer.cpp:359
#6  0x00007fffec4fe7d4 in clang::Preprocessor::getSpelling[abi:cxx11](clang::Token const&, bool*) const (this=0x7fffd806f4a0, Tok=..., Invalid=0x0)
    at /large/whisperity/LLVM/tools/clang/include/clang/Lex/Preprocessor.h:1543
#7  0x00007fffec4fc8f1 in cc::parser::PPMacroCallback::MacroExpands (this=0x7fffd808b420, macroNameTok_=..., md_=..., range_=...)
    at /large/whisperity/CodeCompass/CodeCompass/plugins/cpp/parser/src/ppmacrocallback.cpp:115
#8  0x00007fffe886ebc6 in clang::PPChainedCallbacks::MacroExpands (this=0x7fffd807a1d0, MacroNameTok=..., MD=..., Range=..., Args=0x0)
    at /large/whisperity/llvm/tools/clang/include/clang/Lex/PPCallbacks.h:474
#9  0x00007fffe886ebfc in clang::PPChainedCallbacks::MacroExpands (this=0x7fffd807a040, MacroNameTok=..., MD=..., Range=..., Args=0x0)
    at /large/whisperity/llvm/tools/clang/include/clang/Lex/PPCallbacks.h:475
#10 0x00007fffe88aacff in clang::Preprocessor::HandleMacroExpandedIdentifier (this=0x7fffd806f4a0, Identifier=..., M=...)
    at /large/whisperity/llvm/tools/clang/lib/Lex/PPMacroExpansion.cpp:530
#11 0x00007fffe88ecc1b in clang::Preprocessor::HandleIdentifier (this=0x7fffd806f4a0, Identifier=...)
    at /large/whisperity/llvm/tools/clang/lib/Lex/Preprocessor.cpp:699
#12 0x00007fffe88026ba in clang::Lexer::LexIdentifier (this=0x7fffd80ed350, Result=..., 
    CurPtr=0x7fffdf598c3a "\ntemplate <class IntPtrT> struct CovMapFunctionRecordV1 {\n#define COVMAP_V1\n#define COVMAP_FUNC_RECORD(Type, LLVMType, Name, Init) Type 
Name;\n#include \"llvm/ProfileData/InstrProfData.inc\"\n#undef COVMA"...) at /large/whisperity/llvm/tools/clang/lib/Lex/Lexer.cpp:1652
```

CodeCompass tries to call into the `getSpelling()` of the token in our own macro callback class.

This pull request silences this issue and makes LLVM/Clang parseable by not expanding into macros that are annotations.
(Even though the macro is not expanded, the user can still navigate properly to the definition of the macro in the Web GUI.)

**This patch most likely results in some dimension of information being lost! An issue will be opened for the later investigation of this behaviour!**