### PR TITLE
Fix 'corethriftjava' failing to build when JAR is compiled earlier than Thrift generation

### DIFF
--- a/plugins/dummy/service/CMakeLists.txt
+++ b/plugins/dummy/service/CMakeLists.txt
@@ -17,11 +17,13 @@ add_custom_command(
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp/DummyService.h
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp
   COMMAND
-    thrift --gen cpp -o ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/dummy.thrift
+    thrift --gen cpp
+      -o ${CMAKE_CURRENT_SOURCE_DIR}
+      ${CMAKE_CURRENT_SOURCE_DIR}/dummy.thrift
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/dummy.thrift
   COMMENT
-    "Generate thrift for dummy.thrift")
+    "Generating Thrift for dummy.thrift")
 
 add_library(dummythrift STATIC
   gen-cpp/dummy_constants.cpp

--- a/plugins/git/service/CMakeLists.txt
+++ b/plugins/git/service/CMakeLists.txt
@@ -20,12 +20,15 @@ add_custom_command(
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp/GitService.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp/GitService.h
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-js
   COMMAND
-    thrift --gen cpp --gen js -o ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/git.thrift
+    thrift --gen cpp --gen js
+      -o ${CMAKE_CURRENT_SOURCE_DIR}
+      ${CMAKE_CURRENT_SOURCE_DIR}/git.thrift
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/git.thrift
   COMMENT
-    "Generate thrift for git.thrift")
+    "Generating Thrift for git.thrift")
 
 add_library(gitthrift STATIC
   gen-cpp/git_constants.cpp

--- a/plugins/metrics/service/CMakeLists.txt
+++ b/plugins/metrics/service/CMakeLists.txt
@@ -18,6 +18,7 @@ add_custom_command(
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp/metrics_types.h
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp/MetricsService.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-js
   COMMAND
     thrift --gen cpp --gen js 
       -o ${CMAKE_CURRENT_SOURCE_DIR}
@@ -26,7 +27,7 @@ add_custom_command(
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/metrics.thrift
   COMMENT
-    "Generate thrift for metrics.thrift")
+    "Generating Thrift for metrics.thrift")
 
 add_library(metricsthrift STATIC
   gen-cpp/metrics_constants.cpp

--- a/plugins/search/indexer/CMakeLists.txt
+++ b/plugins/search/indexer/CMakeLists.txt
@@ -14,11 +14,13 @@ add_custom_command(
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-java
   COMMAND
-    thrift --gen cpp --gen java -o ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/searchindexer.thrift
+    thrift --gen cpp --gen java
+      -o ${CMAKE_CURRENT_SOURCE_DIR}
+      ${CMAKE_CURRENT_SOURCE_DIR}/searchindexer.thrift
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/searchindexer.thrift
   COMMENT
-    "Generate thrift for searchindexer.thrift")
+    "Generating Thrift for searchindexer.thrift")
 
 add_library(searchindexerthrift STATIC
   gen-cpp/searchindexer_constants.cpp

--- a/plugins/search/service/CMakeLists.txt
+++ b/plugins/search/service/CMakeLists.txt
@@ -21,13 +21,14 @@ add_custom_command(
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-java
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-js
   COMMAND
-    thrift --gen cpp --gen js --gen java -o ${CMAKE_CURRENT_SOURCE_DIR}
-    -I ${PROJECT_SOURCE_DIR}/service
-    ${CMAKE_CURRENT_SOURCE_DIR}/search.thrift
+    thrift --gen cpp --gen js --gen java
+      -o ${CMAKE_CURRENT_SOURCE_DIR}
+      -I ${PROJECT_SOURCE_DIR}/service
+      ${CMAKE_CURRENT_SOURCE_DIR}/search.thrift
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/search.thrift
   COMMENT
-    "Generate thrift for search.thrift")
+    "Generating Thrift for search.thrift")
 
 # Create cpp static library from thrift files
 add_library(searchthrift STATIC

--- a/service/language/CMakeLists.txt
+++ b/service/language/CMakeLists.txt
@@ -13,12 +13,15 @@ add_custom_command(
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp/LanguageService.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp/LanguageService.h
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-js
   COMMAND
-    thrift --gen cpp --gen js -o ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/language.thrift
+    thrift --gen cpp --gen js
+      -o ${CMAKE_CURRENT_SOURCE_DIR}
+      ${CMAKE_CURRENT_SOURCE_DIR}/language.thrift
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/language.thrift
   COMMENT
-    "Generate thrift for language.thrift")
+    "Generating Thrift for language.thrift")
 
 add_library(languagethrift STATIC
   gen-cpp/language_constants.cpp

--- a/service/plugin/CMakeLists.txt
+++ b/service/plugin/CMakeLists.txt
@@ -16,12 +16,15 @@ add_custom_command(
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp/PluginService.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp/PluginService.h
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-js
   COMMAND
-    thrift --gen cpp --gen js -o ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/plugin.thrift
+    thrift --gen cpp --gen js
+      -o ${CMAKE_CURRENT_SOURCE_DIR}
+      ${CMAKE_CURRENT_SOURCE_DIR}/plugin.thrift
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/plugin.thrift
   COMMENT
-    "Generate thrift for workspace.thrift")
+    "Generating Thrift for workspace.thrift")
 
 add_library(pluginthrift STATIC
   gen-cpp/plugin_constants.cpp

--- a/service/project/CMakeLists.txt
+++ b/service/project/CMakeLists.txt
@@ -9,6 +9,8 @@ include_directories(SYSTEM
   ${THRIFT_LIBTHRIFT_INCLUDE_DIRS}
   ${ODB_INCLUDE_DIRS})
 
+# The folders here are added so that executing `make clean` removes all
+# generated files.
 add_custom_command(
   OUTPUT
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp/common_constants.cpp
@@ -16,13 +18,18 @@ add_custom_command(
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp/common_types.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp/common_types.h
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-java
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-js
   COMMAND
-    thrift --gen cpp --gen js --gen java -o ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/common.thrift
+    thrift --gen cpp --gen js --gen java
+      -o ${CMAKE_CURRENT_SOURCE_DIR}
+      ${CMAKE_CURRENT_SOURCE_DIR}/common.thrift
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/common.thrift
   COMMENT
-    "Generate thrift for common.thrift")
+    "Generating Thrift for common.thrift")
 
+# Do not add the same folders to both output commands as it produces a warning.
 add_custom_command(
   OUTPUT
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp/project_constants.cpp
@@ -31,13 +38,14 @@ add_custom_command(
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp/project_types.h
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp/ProjectService.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp/ProjectService.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp
   COMMAND
-    thrift --gen cpp --gen js --gen java -o ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/project.thrift
+    thrift --gen cpp --gen js --gen java
+      -o ${CMAKE_CURRENT_SOURCE_DIR}
+      ${CMAKE_CURRENT_SOURCE_DIR}/project.thrift
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/project.thrift
   COMMENT
-    "Generate thrift for workspace.thrift")
+    "Generating Thrift for project.thrift")
 
 add_library(commonthrift STATIC
   gen-cpp/common_constants.cpp
@@ -66,6 +74,8 @@ add_jar(corethriftjava
   ${CMAKE_CURRENT_SOURCE_DIR}/gen-java/cc/service/core/Range.java
   ${CMAKE_CURRENT_SOURCE_DIR}/gen-java/cc/service/core/Timeout.java
   OUTPUT_NAME corethrift)
+
+add_dependencies(corethriftjava commonthrift)
 
 add_library(projectservice SHARED
   src/projectservice.cpp

--- a/service/workspace/CMakeLists.txt
+++ b/service/workspace/CMakeLists.txt
@@ -16,12 +16,15 @@ add_custom_command(
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp/WorkspaceService.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp/WorkspaceService.h
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-js
   COMMAND
-    thrift --gen cpp --gen js -o ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/workspace.thrift
+    thrift --gen cpp --gen js
+      -o ${CMAKE_CURRENT_SOURCE_DIR}
+      ${CMAKE_CURRENT_SOURCE_DIR}/workspace.thrift
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/workspace.thrift
   COMMENT
-    "Generate thrift for workspace.thrift")
+    "Generating Thrift for workspace.thrift")
 
 add_library(workspacethrift STATIC
   gen-cpp/workspace_constants.cpp


### PR DESCRIPTION
According to [CMake's documentation](https://cmake.org/cmake/help/v3.0/command/add_custom_command.html), the `add_custom_command`:

> This defines a command to generate specified OUTPUT file(s). A target created in the same directory (CMakeLists.txt file) that specifies any output of the custom command as a source file is given a rule to generate the file using the command at build time.

There is no indication anywhere that `OUTPUT` can be set to a folder and that it will be meaningful.

In certain environments (seemingly dependent of system language options or collation?), especially when multithreaded build is done, building CodeCompass can fail:

```
make[2]: *** No rule to make target '/mnt/storage/jenkins/workspace/Build master CodeCompass/Source/service/project/gen-java/cc/service/core/Timeout.java', needed by 'service/project/CMakeFiles/corethriftjava.dir/java_compiled_corethriftjava'.  Stop.
CMakeFiles/Makefile2:2040: recipe for target 'service/project/CMakeFiles/corethriftjava.dir/all' failed
make[1]: *** [service/project/CMakeFiles/corethriftjava.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```

This is because CMake did not know of the dependency between the Thrift-generated Java file and the fact that this class is to be packaged by `add_jar`.