### PR TITLE
Make keepalive script also trap SIGTERM

### DIFF
--- a/scripts/keepalive
+++ b/scripts/keepalive
@@ -8,7 +8,7 @@ ending()
   kill $pid
 }
 
-trap ending SIGINT
+trap ending SIGINT SIGTERM
 
 ulimit -c unlimited &> /dev/null
 


### PR DESCRIPTION
Certain background process wrappers, such as `daemon(1)` (and by default, the `kill` command) send `SIGTERM` (15) as opposed to `SIGINT` (2, generated by a `Ctrl-C` in the runner shell). Without trapping on this signal, only the keepalive script is terminated, which zombifies the underlying shell and also prevents (without manual intervention or looking at the process table...) killing the CodeCompass server.

> Related to #225 but does not necessarily fix the issue.