### PR TITLE
Fix typo of thriftfile name in CMake output

### DIFF
--- a/service/plugin/CMakeLists.txt
+++ b/service/plugin/CMakeLists.txt
@@ -24,7 +24,7 @@ add_custom_command(
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/plugin.thrift
   COMMENT
-    "Generating Thrift for workspace.thrift")
+    "Generating Thrift for plugin.thrift")
 
 add_library(pluginthrift STATIC
   gen-cpp/plugin_constants.cpp


### PR DESCRIPTION
When fixing the output comments of CMake in #242, one file's name I glanced over. This patch fixes it once and for all.