### PR TITLE
Massively speed up navigation by not sending source text for every AST node

### DIFF
--- a/plugins/cpp/service/include/service/cppservice.h
+++ b/plugins/cpp/service/include/service/cppservice.h
@@ -48,6 +48,10 @@ public:
     AstNodeInfo& return_,
     const core::FilePosition& fpos_) override;
 
+  void getSourceText(
+    std::string& return_,
+    const core::AstNodeId& astNodeId_) override;
+
   void getDocumentation(
     std::string& return_,
     const core::AstNodeId& astNodeId_) override;

--- a/plugins/cpp/service/src/cppservice.cpp
+++ b/plugins/cpp/service/src/cppservice.cpp
@@ -71,6 +71,9 @@ namespace
     {
     }
 
+    /**
+     * Returns the Thrift object for this C++ AST node.
+     */
     cc::service::language::AstNodeInfo operator()(
       const cc::model::CppAstNode& astNode_)
     {
@@ -88,16 +91,7 @@ namespace
       ret.range.range.endpos.column = astNode_.location.range.end.column;
 
       if (astNode_.location.file)
-      {
         ret.range.file = std::to_string(astNode_.location.file.object_id());
-
-        ret.__set_srcText(cc::util::textRange(
-          astNode_.location.file.load()->content.load()->content,
-          astNode_.location.range.start.line,
-          astNode_.location.range.start.column,
-          astNode_.location.range.end.line,
-          astNode_.location.range.end.column));
-      }
 
       TagMap::const_iterator it = _tags.find(astNode_.id);
       if (it != _tags.end())
@@ -137,6 +131,25 @@ void CppServiceHandler::getAstNodeInfo(
 {
   return_ = _transaction([this, &astNodeId_](){
     return CreateAstNodeInfo()(queryCppAstNode(astNodeId_));
+  });
+}
+
+void CppServiceHandler::getSourceText(
+  std::string& return_,
+  const core::AstNodeId& astNodeId_)
+{
+  return_ = _transaction([this, &astNodeId_](){
+    model::CppAstNode astNode = queryCppAstNode(astNodeId_);
+
+    if (astNode.location.file)
+      return cc::util::textRange(
+        astNode.location.file.load()->content.load()->content,
+        astNode.location.range.start.line,
+        astNode.location.range.start.column,
+        astNode.location.range.end.line,
+        astNode.location.range.end.column);
+
+    return std::string();
   });
 }
 

--- a/service/language/language.thrift
+++ b/service/language/language.thrift
@@ -10,9 +10,8 @@ struct AstNodeInfo
   3:string astNodeType /** String representation of AST type (e.g. Statement/Declaration/Usage). */
   4:string symbolType /** String representation of Symbol type (e.g. Function/Type/Variable). */
   5:string astNodeValue /** String representation of an AST node. */
-  6:string srcText /** Corresponding code fragment in the source code. */
-  7:common.FileRange range /** Source code range of an AST node. */
-  8:list<string> tags /** Meta information of the AST node (e.g. public, static, virtual etc.) */
+  6:common.FileRange range /** Source code range of an AST node. */
+  7:list<string> tags /** Meta information of the AST node (e.g. public, static, virtual etc.) */
 }
 
 struct SyntaxHighlight
@@ -51,6 +50,16 @@ service LanguageService
    */
   AstNodeInfo getAstNodeInfoByPosition(1:common.FilePosition fpos)
     throws (1:common.InvalidInput ex)
+
+  /**
+   * Returns the source code text that corresponds to the given AST node.
+   * @param astNodeId ID of an AST node.
+   * @return The source text as a verbatim string.
+   * @exception common.InvalidId Exception is thrown if no AST node belongs to
+   * the given ID.
+   */
+  string getSourceText(1:common.AstNodeId astNodeId)
+    throws (1:common.InvalidId ex)
 
   /**
    * Returns the documentation which belongs to the given AST node if any

--- a/webgui/scripts/codecompass/view/codeBites.js
+++ b/webgui/scripts/codecompass/view/codeBites.js
@@ -97,6 +97,8 @@ function (declare, array, dom, style, topic, on, ContentPane, ResizeHandle,
     if (astNodeInfo.astNodeType !== 'Definition')
       astNodeInfo = languageService.getReferences(astNodeInfo.id, 0)[0];
 
+    var srcText = languageService.getSourceText(astNodeInfo.id);
+
     var newElement = new CodeBitesElement({
       astNodeInfo     : astNodeInfo,
       firstLineNumber : astNodeInfo.range.range.startpos.line,
@@ -108,7 +110,7 @@ function (declare, array, dom, style, topic, on, ContentPane, ResizeHandle,
       selection       : panel.selection
     });
 
-    newElement.set('content', astNodeInfo.srcText);
+    newElement.set('content', srcText);
     newElement.set('header', fileInfo);
 
     //--- Place node ---//


### PR DESCRIPTION
> Fixes #231.

As I can see from the source code, there was only **one** location where the source code was actually used (in CodeBites), so it was really, really superfluous to send the source text every time.

Conceptually, the abstract language information system had to be modified. A new API call is introduced to query the full source text, if and when needed.

While I don't have any precise measurings for this on large projects, even on a small synthesised example (a few types and whatnot) the whole interface feels much, much faster. This is especially prominent for large codebases like LLVM/Clang where the removal of sending **(almost) entire headers** (for types) in the API really helps.