### PR TITLE
Reparse: Create a Syntax InfoTree that allows browsing the AST on-demand by the user

### DIFF
--- a/plugins/cpp/webgui/js/cppInfoTree.js
+++ b/plugins/cpp/webgui/js/cppInfoTree.js
@@ -292,6 +292,7 @@ function (model, viewHandler, util) {
   }
 
   var cppInfoTree = {
+    id : 'cpp-infotree',
     render : function (elementInfo) {
       var ret = [];
 

--- a/plugins/cpp_reparse/service/CMakeLists.txt
+++ b/plugins/cpp_reparse/service/CMakeLists.txt
@@ -58,6 +58,7 @@ add_library(cppreparseservice SHARED
   src/astcache.cpp
   src/asthtml.cpp
   src/databasefilesystem.cpp
+  src/infotree.cpp
   src/reparser.cpp)
 
 target_compile_options(cppreparseservice PUBLIC -Wno-unknown-pragmas)

--- a/plugins/cpp_reparse/service/cppreparse.thrift
+++ b/plugins/cpp_reparse/service/cppreparse.thrift
@@ -50,4 +50,22 @@ service CppReparseService
    * Returns the AST for the given AST Node('s subtree) as an HTML string.
    */
   string getAsHTMLForNode(1: common.AstNodeId nodeId);
+
+  /**
+   * Gets a Clang AST node basic values for the top-level (translation unit)
+   * declaration of the given file.
+   */
+  ASTNodeBasic getBasic(1: common.FileId fileId);
+
+  /**
+   * Gets a Clang AST node basic values for the database-stored AST node given.
+   */
+  ASTNodeBasic getBasicForNode(1: common.AstNodeId nodeId);
+
+  /**
+   * Retrieves the details of the given AST node identified by visitId, in
+   * the traversal of the (file of the) tree of rootNode.
+   */
+  ASTNodeDetail getDetail(1: common.FileId fileId,
+                          2: i64 visitId);
 }

--- a/plugins/cpp_reparse/service/include/service/cppreparseservice.h
+++ b/plugins/cpp_reparse/service/include/service/cppreparseservice.h
@@ -50,6 +50,19 @@ public:
     std::string& return_,
     const core::AstNodeId& nodeId_) override;
 
+  virtual void getBasic(
+    ASTNodeBasic& return_,
+    const core::FileId& fileId_) override;
+
+  virtual void getBasicForNode(
+    ASTNodeBasic& return_,
+    const core::AstNodeId& nodeId_) override;
+
+  virtual void getDetail(
+    ASTNodeDetail& return_,
+    const core::FileId& fileId_,
+    const int64_t visitId_) override;
+
 private:
   std::shared_ptr<odb::database> _db;
   util::OdbTransaction _transaction;

--- a/plugins/cpp_reparse/service/src/astcache.h
+++ b/plugins/cpp_reparse/service/src/astcache.h
@@ -23,6 +23,16 @@ namespace service
 namespace reparse
 {
 
+// Because Clang's type hierarchy doesn't have a common parent (even with RTTI
+// enabled), this very small value is used to indicate what type the memory
+// address needs to be cast to.
+enum class ClangASTNodeType : unsigned char
+{
+  Unknown,
+  Decl,
+  Stmt
+};
+
 /**
  * Implements a caching mechanism over Clang ASTs to ease the runtime overhead
  * of having to parse source files over and over again, as it is a *very*
@@ -34,6 +44,7 @@ namespace reparse
 class ASTCache
 {
 public:
+  typedef std::map<size_t, std::pair<void*, ClangASTNodeType>> NodeVisitMap;
 
   /**
    * @param maxCacheSize_ The maximum size of the cache above which automatic
@@ -61,6 +72,25 @@ public:
     const core::FileId& id_,
     std::unique_ptr<clang::ASTUnit> AST_);
 
+  /**
+   * Retrieve the memory address and Clang AST node type stored for the given
+   * file's node identified by visit order.
+   *
+   * The returned pair's memory address is nullptr if the file or the node is
+   * not known by the cache.
+   */
+  NodeVisitMap::mapped_type getIdToAddressMapping(const core::FileId& id_,
+                                                  size_t nodeVisitId_);
+
+  /**
+   * Stores a single node visit order ID -> Clang AST Node memory address
+   * mapping for the given file's cached AST.
+   */
+   void storeIdToAddressMapping(const core::FileId& id_,
+                                const size_t nodeVisitId_,
+                                void* nodeAddress_,
+                                const ClangASTNodeType type_);
+
 private:
 
   class ASTCacheEntry
@@ -85,6 +115,11 @@ private:
      */
     size_t referenceCount() const;
 
+    void insertNodeMapping(const size_t nodeId_,
+                           void* address_,
+                           const ClangASTNodeType type_);
+    NodeVisitMap& getNodeMap();
+
   private:
     std::shared_ptr<clang::ASTUnit> _AST;
 
@@ -98,6 +133,14 @@ private:
      * retrieved, this timestamp stores the time when it was stored.
      */
     std::chrono::steady_clock::time_point _lastHit;
+
+    /**
+     * This inner cache maps node visit order numbers to the memory address
+     * where the node is located.
+     */
+    // These mappings are only valid as long as the AST is cached, because a
+    // new AST is always parsed with possibly different addresses of nodes.
+    NodeVisitMap _nodeIdToAddress;
   };
 
   /**

--- a/plugins/cpp_reparse/service/src/cppreparseservice.cpp
+++ b/plugins/cpp_reparse/service/src/cppreparseservice.cpp
@@ -16,6 +16,7 @@
 
 #include "astcache.h"
 #include "asthtml.h"
+#include "infotree.h"
 
 namespace
 {
@@ -142,6 +143,131 @@ void CppReparseServiceHandler::getAsHTMLForNode(
   htmlFactory.newASTConsumerForNode(context, astNode)
     ->HandleTranslationUnit(context);
   return_ = htmlFactory.str();
+}
+
+void CppReparseServiceHandler::getBasic(
+  ASTNodeBasic& return_,
+  const core::FileId& fileId_)
+{
+  if (!isEnabled())
+  {
+    LOG(warning) << "Reparse capabilities has been disabled at server start.";
+    return;
+  }
+
+  auto result = _reparser->getASTForTranslationUnitFile(fileId_);
+  if (std::string* err = boost::get<std::string>(&result))
+  {
+    LOG(warning) << "The AST could not be obtained. " + *err;
+    return;
+  }
+  std::shared_ptr<ASTUnit> AST = boost::get<std::shared_ptr<ASTUnit>>(result);
+
+  ASTInfoTree extractor(_astCache.get(), fileId_, AST->getASTContext());
+
+  // The first node that is visited is the TranslationUnit's root node.
+  boost::optional<ASTInfoTree::Node> res = extractor.getNodeDataForId(1);
+  if (!res)
+  {
+    LOG(warning) << "The node couldn't have been located.";
+    return;
+  }
+
+  return_.visitId = static_cast<int64_t>(res->_visitId);
+  return_.type = extractor.getNodeType(*res);
+  return_.hasChildren = res->_hasChildren;
+}
+
+void CppReparseServiceHandler::getBasicForNode(
+  ASTNodeBasic& return_,
+  const cc::service::core::AstNodeId& nodeId_)
+{
+  if (!isEnabled())
+  {
+    LOG(warning) << "Reparse capabilities has been disabled at server start.";
+    return;
+  }
+
+  model::CppAstNodePtr astNode;
+  _transaction([&, this](){
+    astNode = _db->query_one<model::CppAstNode>(
+      AstQuery::id == std::stoull(nodeId_));
+    astNode->location.file.load();
+  });
+
+  if (!astNode)
+  {
+    LOG(warning) << "No location file found for AST node #" << nodeId_;
+    return;
+  }
+
+  core::FileId fileId_ = std::to_string(astNode->location.file.object_id());
+  auto result = _reparser->getASTForTranslationUnitFile(fileId_);
+  if (std::string* err = boost::get<std::string>(&result))
+  {
+    LOG(warning) <<  "The AST could not be obtained. " + *err;
+    return;
+  }
+  std::shared_ptr<ASTUnit> AST = boost::get<std::shared_ptr<ASTUnit>>(result);
+
+  ASTInfoTree extractor(_astCache.get(), fileId_, AST->getASTContext());
+  boost::optional<ASTInfoTree::Node> res =
+    extractor.getNodeDataForAstNode(astNode);
+  if (!res)
+  {
+    LOG(warning) << "The node couldn't have been located.";
+    return;
+  }
+
+  return_.visitId = static_cast<int64_t>(res->_visitId);
+  return_.type = extractor.getNodeType(*res);
+  return_.hasChildren = res->_hasChildren;
+}
+
+void CppReparseServiceHandler::getDetail(
+  ASTNodeDetail& return_,
+  const core::FileId& fileId_,
+  const int64_t visitId_)
+{
+  if (!isEnabled())
+  {
+    LOG(warning) << "Reparse capabilities has been disabled at server start.";
+    return;
+  }
+
+  auto result = _reparser->getASTForTranslationUnitFile(fileId_);
+  if (std::string* err = boost::get<std::string>(&result))
+  {
+    LOG(warning) << "The AST could not be obtained. " + *err;
+    return;
+  }
+  std::shared_ptr<ASTUnit> AST = boost::get<std::shared_ptr<ASTUnit>>(result);
+
+  ASTInfoTree extractor(_astCache.get(), fileId_, AST->getASTContext());
+
+  auto node = extractor.getNodeDataForId(static_cast<size_t>(visitId_));
+  if (!node)
+  {
+    LOG(warning) << "Node " << visitId_ << " not found.";
+    return;
+  }
+
+  // Traverse the children nodes of the input node to fetch what (if any) types
+  // of children it has.
+  auto children = extractor.getChildrenForNode(*node);
+  for (auto child : children)
+  {
+    ASTNodeBasic basicRecord;
+    basicRecord.visitId = static_cast<int64_t>(child._visitId);
+    basicRecord.type = extractor.getNodeType(child);
+    basicRecord.hasChildren = child._hasChildren;
+
+    return_.children.push_back(basicRecord);
+  }
+
+  // TODO: Populate the details better based on the type of the node.
+  // (This is a basic dummy implementation for now.)
+  return_.otherStuff = extractor.dummyGetDetails(*node);
 }
 
 } // namespace language

--- a/plugins/cpp_reparse/service/src/infotree.cpp
+++ b/plugins/cpp_reparse/service/src/infotree.cpp
@@ -1,0 +1,481 @@
+#include <algorithm>
+#include <functional>
+#include <stack>
+
+#include <clang/AST/ASTConsumer.h>
+#include <clang/AST/RecursiveASTVisitor.h>
+
+#include <model/cppastnode-odb.hxx>
+
+#include <util/logutil.h>
+#include <util/util.h>
+
+#include <cppparser/filelocutil.h>
+
+#include "astnodelocator.h"
+#include "infotree.h"
+
+using namespace cc::service::reparse;
+
+namespace
+{
+
+using namespace cc;
+using namespace cc::service::language;
+using namespace clang;
+
+typedef std::map<size_t, ASTInfoTree::Node> NodeVisitMap;
+
+/**
+ * This RecursiveASTVisitor walks the AST and labels the nodes in the order
+ * they are visited with an ID, searching for a particular node based on a
+ * logic implemented by child classes.
+ */
+class NodeSearch
+  : public ASTConsumer,
+    public RecursiveASTVisitor<NodeSearch>
+{
+  typedef RecursiveASTVisitor<NodeSearch> Base;
+
+public:
+  /**
+   * This is an abstract class which should not be instantiated by itself.
+   */
+  NodeSearch() = delete;
+  virtual ~NodeSearch() = default;
+
+  bool shouldVisitImplicitCode() const { return true; }
+  bool shouldVisitTemplateInstantiations() const { return true; }
+
+  /**
+   * Initiate the traversal of the AST. This method must be the one called by
+   * the client code with the same context_ as the one that was passed to the
+   * constructor.
+   */
+  void HandleTranslationUnit(ASTContext& context_) override
+  {
+    assert(&_context == &context_ && "AST visitor must be called with the same "
+      "ASTContext as it was set up with.");
+
+    TranslationUnitDecl* d = context_.getTranslationUnitDecl();
+    _visitCount = 0;
+    TraverseDecl(d);
+  }
+
+  /* The traverse methods first walk the AST until the searched node is found.
+   * The located node's ID is saved, and then the traversal continues on the
+   * subtree of this node, labelling every node with its index still. This is
+   * used to then gather which IDs belong to the direct children of the node.
+   */
+
+  bool TraverseDecl(Decl* d_)
+  {
+    return TraverseClangASTNode(d_, [&]{ return Base::TraverseDecl(d_); },
+                                std::mem_fn(&NodeSearch::tryLocateDecl),
+                                ClangASTNodeType::Decl);
+  }
+
+  bool TraverseStmt(Stmt* s_)
+  {
+    return TraverseClangASTNode(s_, [&]{ return Base::TraverseStmt(s_); },
+                                std::mem_fn(&NodeSearch::tryLocateStmt),
+                                ClangASTNodeType::Stmt);
+  }
+
+  /**
+   * Returns whether or not a node has been found.
+   */
+  bool hasFoundNode() const
+  {
+    return static_cast<bool>(_foundNode);
+  }
+
+  /**
+   * Obtain the information about the found node.
+   */
+  ASTInfoTree::Node getFoundNode()
+  {
+    assert(hasFoundNode() && "Not applicable if no node was found.");
+    return *_foundNode;
+  }
+
+  /**
+   * Get the list of children of the found node.
+   */
+  std::vector<ASTInfoTree::Node> getChildren()
+  {
+    assert(hasFoundNode() && "Not applicable if no node was found.");
+
+    std::vector<ASTInfoTree::Node> ret;
+    std::transform(_children.begin(), _children.end(), std::back_inserter(ret),
+                   [](auto entry) {
+                     return entry.second;
+                   });
+
+    return ret;
+  };
+
+protected:
+  NodeSearch(const ASTContext& context_)
+    : _visitCount(0),
+      _context(context_)
+  {}
+
+  // Returns whether the passed AST node information matches for the filter.
+  virtual bool tryLocateDecl(Decl* d_, size_t index_) = 0;
+  virtual bool tryLocateStmt(Stmt* s_, size_t index_) = 0;
+
+  /**
+   * The current count where the recursive traversal is at.
+   */
+  size_t _visitCount;
+
+private:
+  template<typename ClangASTNode,
+           typename BaseTraverseFn,
+           typename LocatorFn>
+  bool TraverseClangASTNode(ClangASTNode* n_,
+                            BaseTraverseFn traverseInBase_,
+                            LocatorFn locatorFn_,
+                            ClangASTNodeType typeEnum_)
+  {
+    if (n_ == nullptr)
+      // Do not traverse nodes whom aren't really nodes. Turning on visiting of
+      // implicit produce some calls where the pointer is null.
+      return true;
+
+    size_t currentVisitedNodeId = ++_visitCount;
+    LOG(debug) << "Traverse node #" << currentVisitedNodeId << " @ " << n_;
+
+    if (!_foundNode)
+    {
+      // If the node has not yet been found, try to find it.
+      if (locatorFn_(this, n_, currentVisitedNodeId))
+      {
+        _foundNode = std::make_unique<ASTInfoTree::Node>();
+        _foundNode->_visitId = currentVisitedNodeId;
+        _foundNode->_clangMemoryAddress = n_;
+        _foundNode->_nodeType = typeEnum_;
+      }
+      else // TODO: This is debug print, can be removed.
+      {
+        // If still no success, continue the traversal in the children of the
+        // current node.
+        LOG(debug) << "Target still not found. Searching in children.";
+      }
+    }
+    else
+    {
+      if (_traverseStack.top() == _foundNode->_clangMemoryAddress)
+      {
+        _children[currentVisitedNodeId]._visitId = currentVisitedNodeId;
+        _children[currentVisitedNodeId]._clangMemoryAddress = n_;
+        _children[currentVisitedNodeId]._nodeType = typeEnum_;
+      }
+    }
+
+    // We walk the tree recursively via the Traverse* methods until the
+    // method that would return from the root of the subtree of the executed
+    // traversal is on the top of the stack.
+    _traverseStack.push(n_);
+    bool b = traverseInBase_();
+    _traverseStack.pop();
+
+    return (_foundNode && _foundNode->_visitId == currentVisitedNodeId)
+           ? false
+           : b;
+  }
+
+  const ASTContext& _context;
+
+  /**
+   * A stack that records the parents of the currently traversed node up until
+   * the root (at the bottom) of the AST subtree on which the traversal is done.
+   */
+  std::stack<const void*> _traverseStack;
+
+  /**
+   * Points to the details of the found AST node once the traversal has
+   * actually found it.
+   */
+  std::unique_ptr<ASTInfoTree::Node> _foundNode;
+
+  /**
+   * Contains the direct children's traversal number and information entries
+   * for the children of the found node.
+   */
+  NodeVisitMap _children;
+};
+
+/**
+ * This class searches for a Clang AST Node based on information available in
+ * the database.
+ */
+class ByDatabaseNodeSearch
+  : public NodeSearch
+{
+
+public:
+  /**
+   * Initialise a node visit order labeler class which traverses the AST
+   * filtering for the database-backed AST node entry given to the constructor.
+   *
+   * In this case, the user should call HandleTranslationUnit() with the
+   * context_ parameter to search for the node in the parsed AST in-memory.
+   */
+  ByDatabaseNodeSearch(const ASTContext& context_,
+                       model::CppAstNodePtr node_)
+    : NodeSearch(context_),
+      _locator(context_, std::move(node_))
+  {}
+
+  ~ByDatabaseNodeSearch() override = default;
+
+protected:
+  bool tryLocateDecl(Decl* d_, size_t /*index_*/) override
+  {
+    return _locator.matchNodeAgainstLocation(d_);
+  }
+
+  bool tryLocateStmt(Stmt* s_, size_t /*index_*/) override
+  {
+    return _locator.matchNodeAgainstLocation(s_);
+  }
+
+private:
+  /**
+   * The AST node locator which is used to find the Clang AST Node matching
+   * the database AST row if the database-row searching constructor was called.
+   */
+  ASTNodeLocator _locator;
+
+};
+
+/**
+ * This class allows for traversing the AST searching for a node that has the
+ * given visit number based in visit order.
+ */
+class ByIdNodeSearch
+  : public NodeSearch
+{
+
+public:
+  /**
+   * Initialise a node visit order labeler for the subtree whose root has the
+   * visitation ID `nodeId_`.
+   *
+   * In this case, the traversal should begin with Traverse*() on the node
+   * which has the given ID. The traversal will only do one step to the
+   * children of the given node.
+   */
+  ByIdNodeSearch(const ASTContext& context_,
+                 size_t nodeId_)
+    : NodeSearch(context_),
+      _searchNodeId(nodeId_)
+  {
+    // Minus one is used here, because when the user calls a Traverse*()
+    // method after constructing the visitor, it will automatically increase
+    // the _visitCount by 1.
+    _visitCount = nodeId_ - 1;
+  }
+
+  ~ByIdNodeSearch() override = default;
+
+protected:
+  bool tryLocateDecl(Decl* /*d_*/, size_t index_) override
+  {
+    return index_ == _searchNodeId;
+  }
+
+  bool tryLocateStmt(Stmt* /*s_*/, size_t index_) override
+  {
+    return index_ == _searchNodeId;
+  }
+
+private:
+  /**
+   * If the class was instantiated with a node-ID to pick up the traversal
+   * from, it is stored here, along with the root of the generated InfoTree.
+   */
+  const size_t _searchNodeId;
+};
+
+
+template <typename Traverser>
+boost::optional<ASTInfoTree::Node>
+getNodeInfoFromTraverser(ASTCache* cache_,
+                         const cc::service::core::FileId& fileId_,
+                         Traverser& traverser_)
+{
+  if (traverser_.hasFoundNode())
+  {
+    ASTInfoTree::Node node = traverser_.getFoundNode();
+    std::vector<ASTInfoTree::Node> children = traverser_.getChildren();
+
+    if (!children.empty())
+    {
+      node._hasChildren = true;
+
+      // Cache the visit IDs of the children of this node in the current file
+      // so traversal of the children can easily continue.
+      std::for_each(children.begin(), children.end(),
+                    [cache_, &fileId_](auto child) {
+        cache_->storeIdToAddressMapping(fileId_, child._visitId,
+                                        child._clangMemoryAddress,
+                                        child._nodeType);
+      });
+    }
+
+    // Add the visit ID of the root node (which was calculated from the top
+    // of the tree) to the cache record of the AST.
+    cache_->storeIdToAddressMapping(fileId_, node._visitId,
+                                    node._clangMemoryAddress,
+                                    node._nodeType);
+
+    return node;
+  }
+
+  return boost::optional<ASTInfoTree::Node>();
+}
+
+} // namespace (anonymous)
+
+namespace cc
+{
+namespace service
+{
+namespace language
+{
+
+boost::optional<ASTInfoTree::Node>
+ASTInfoTree::getNodeDataForAstNode(model::CppAstNodePtr astNode_)
+{
+  ByDatabaseNodeSearch traverser(_context, std::move(astNode_));
+  traverser.HandleTranslationUnit(_context);
+  return getNodeInfoFromTraverser(_astCache, _fileId, traverser);
+}
+
+boost::optional<ASTInfoTree::Node>
+ASTInfoTree::getNodeDataForId(size_t nodeId_)
+{
+  ByIdNodeSearch traverser(_context, nodeId_);
+
+  // Try the cache first.
+  auto clangNode = _astCache->getIdToAddressMapping(_fileId, nodeId_);
+  if (!clangNode.first || clangNode.second == ClangASTNodeType::Unknown)
+  {
+    // Cache miss, try the actual AST.
+    traverser.HandleTranslationUnit(_context);
+  }
+  else
+  {
+    if (clangNode.second == ClangASTNodeType::Decl)
+    {
+      Decl* decl = static_cast<Decl*>(clangNode.first);
+      traverser.TraverseDecl(decl);
+    }
+    else if (clangNode.second == ClangASTNodeType::Stmt)
+    {
+      Stmt* stmt = static_cast<Stmt*>(clangNode.first);
+      traverser.TraverseStmt(stmt);
+    }
+  }
+
+  return getNodeInfoFromTraverser(_astCache, _fileId, traverser);
+}
+
+std::vector<ASTInfoTree::Node>
+ASTInfoTree::getChildrenForNode(Node node_)
+{
+  ByIdNodeSearch traverser(_context, node_._visitId);
+  if (node_._nodeType == ClangASTNodeType::Decl)
+  {
+    Decl* decl = static_cast<Decl*>(node_._clangMemoryAddress);
+    traverser.TraverseDecl(decl);
+  }
+  else if (node_._nodeType == ClangASTNodeType::Stmt)
+  {
+    Stmt* stmt = static_cast<Stmt*>(node_._clangMemoryAddress);
+    traverser.TraverseStmt(stmt);
+  }
+
+  std::vector<Node> children = traverser.getChildren();
+
+  // Cache the children here too.
+  std::for_each(children.begin(), children.end(), [this](auto child) {
+    _astCache->storeIdToAddressMapping(_fileId, child._visitId,
+                                       child._clangMemoryAddress,
+                                       child._nodeType);
+  });
+
+  // The "_hasChild" member of the Nodes inside the getChildren() are not filled
+  // properly, as only one round is done by the lookup class, so individual
+  // lookups are optimised). But for the children information to be proper, an
+  // extra lookup has to be made so we properly know if the input node has
+  // "grandchildren".
+  std::transform(children.begin(), children.end(), children.begin(),
+                 [this](Node& node) {
+                   return *getNodeDataForId(node._visitId);
+                 });
+
+  return children;
+}
+
+std::string ASTInfoTree::getNodeType(Node node_)
+{
+  if (node_._clangMemoryAddress && node_._nodeType != ClangASTNodeType::Unknown)
+  {
+    if (node_._nodeType == ClangASTNodeType::Decl)
+    {
+      Decl* decl = static_cast<Decl*>(node_._clangMemoryAddress);
+      return std::string(decl->getDeclKindName()) + "Decl";
+    }
+    else if (node_._nodeType == ClangASTNodeType::Stmt)
+    {
+      Stmt* stmt = static_cast<Stmt*>(node_._clangMemoryAddress);
+      return stmt->getStmtClassName();
+    }
+  }
+
+  return "<Invalid Node ID.>";
+}
+
+std::string ASTInfoTree::dummyGetDetails(Node node_)
+{
+  std::string str;
+  llvm::raw_string_ostream out(str);
+
+  if (node_._clangMemoryAddress && node_._nodeType != ClangASTNodeType::Unknown)
+  {
+    if (node_._nodeType == ClangASTNodeType::Decl)
+    {
+      Decl * decl = static_cast<Decl*>(node_._clangMemoryAddress);
+      decl->dump(out, /* Deserialize = */ false);
+    }
+    else if (node_._nodeType == ClangASTNodeType::Stmt)
+    {
+      Stmt * stmt = static_cast<Stmt*>(node_._clangMemoryAddress);
+      stmt->dump(out, _context.getSourceManager());
+    }
+  }
+
+  out.flush();
+
+  // Split the string so that only the first line is kept.
+  str = str.substr(0, str.find('\n'));
+
+  // Also split the first word (the type of the node) because that is sent in
+  // a well-typed fashion already over the API.
+  if (str.find(" ") != std::string::npos)
+    str = str.substr(str.find(" ") + 1, std::string::npos);
+
+  // And cut the memory address of the node too, as it has no value to the user.
+  if (str.find(" ") != std::string::npos)
+    str = str.substr(str.find(" ") + 1, std::string::npos);
+
+  return util::escapeHtml(str);
+}
+
+} //namespace language
+} //namespace service
+} //namespace cc

--- a/plugins/cpp_reparse/service/src/infotree.h
+++ b/plugins/cpp_reparse/service/src/infotree.h
@@ -1,0 +1,114 @@
+#ifndef CC_SERVICE_CPPREPARSESERVICE_INFOTREE_H
+#define CC_SERVICE_CPPREPARSESERVICE_INFOTREE_H
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include <boost/optional.hpp>
+
+#include <model/cppastnode.h>
+
+// Required for the Thrift objects, such as core::FileId.
+#include "cppreparse_types.h"
+
+#include "astcache.h"
+
+namespace cc
+{
+namespace service
+{
+namespace language
+{
+
+/**
+ * This class can be used to produce InfoTree-like nodes from an AST that can be
+ * rendered for the user.
+ */
+class ASTInfoTree
+{
+public:
+  struct Node
+  {
+    /**
+     * The index of the node based on the Clang AST Visitor visition order.
+     */
+    size_t _visitId;
+
+    /**
+     * The memory address of the node itself.
+     */
+    void* _clangMemoryAddress;
+
+    /**
+     * The extracted (not necessarily the most accurate) type of the node.
+     */
+    reparse::ClangASTNodeType _nodeType;
+
+    /**
+     * Whether the node has further children in the tree. This value is always
+     * properly populated at data extraction, and does not use lazy traversal.
+     */
+    bool _hasChildren;
+  };
+
+  /**
+   * Instantiate a node detail extraction for the given file and the AST Context
+   * that is generated from reparsing the file.
+   */
+  // TODO: Yet again, what would you do with headers? (Later...)
+  ASTInfoTree(reparse::ASTCache* cache_,
+              const core::FileId& fileId_,
+              clang::ASTContext& context_)
+    : _fileId(fileId_),
+      _astCache(cache_),
+      _context(context_)
+  {
+    assert(cache_ && "AST InfoTree creation depends on a cache to speed up "
+                     "and type lookups.");
+  }
+
+  /**
+   * Retrieve the basic data for the given database-backed ASTNode by searching
+   * the AST stored in the current class.
+   */
+  boost::optional<Node> getNodeDataForAstNode(
+    model::CppAstNodePtr astNode_);
+
+  /**
+   * Retrieve the basic data for the given visit-ordered node ID by traversing
+   * and numbering the AST nodes from the top.
+   */
+  boost::optional<Node> getNodeDataForId(size_t nodeId_);
+
+  /**
+   * Retrieve the basic representation information for the children of the
+   * given node.
+   */
+  std::vector<Node> getChildrenForNode(Node node_);
+
+  /**
+   * Retrieve the full type of the Clang AST Node (such as CXXNewExpr,
+   * RecordDecl) for the Node record given.
+   */
+  std::string getNodeType(Node node_);
+
+  // TODO: Methods for further requesting some information from the AST.
+
+  /**
+   * Get some detailed information about the Node given.
+   * Currently this returns the full line of the "-ast-dump" of the node itself.
+   */
+  std::string dummyGetDetails(Node node_);
+
+private:
+  const core::FileId& _fileId;
+  reparse::ASTCache* _astCache;
+  clang::ASTContext& _context;
+};
+
+} //namespace language
+} //namespace service
+} //namespace cc
+
+#endif // CC_SERVICE_CPPREPARSESERVICE_INFOTREE_H

--- a/plugins/cpp_reparse/webgui/js/cppReparseInfoTree.js
+++ b/plugins/cpp_reparse/webgui/js/cppReparseInfoTree.js
@@ -1,0 +1,98 @@
+require([
+  'codecompass/model',
+  'codecompass/viewHandler',
+  'codecompass/util'],
+function (model, viewHandler, util) {
+
+  function getChildrenTreeElements(parent, fileId) {
+    if (!parent.hasChildren)
+      return [];
+
+    var astDetail = model.cppreparseservice.getDetail(
+      fileId, parent.id);
+
+    var ret = [];
+
+    // Create the node for the child node's detail.
+    ret.push({
+      name        : astDetail.otherStuff,
+      cssClass    : 'icon icon-info',
+      hasChildren : false
+    });
+
+    astDetail.children.forEach(function (child) {
+      ret.push({
+        id          : child.visitId,
+        name        : child.type,
+        parent      : parent.visitId,
+        hasChildren : true,
+        getChildren : function () {
+          return getChildrenTreeElements(this, fileId);
+        }
+      });
+    });
+
+    return ret;
+  }
+
+  var cppReparseInfoTree = {
+    id : 'cppreparse-ast',
+    render : function (elementInfo) {
+      var ret = [];
+
+      var fileId;
+      var astBasic;
+
+      if (elementInfo instanceof AstNodeInfo) {
+        // The root element will be expanded to the first level of children.
+        fileId = elementInfo.range.file;
+        astBasic = model.cppreparseservice.getBasicForNode(
+          elementInfo.id);
+      } else if (elementInfo instanceof FileInfo) {
+        fileId = elementInfo.id;
+        astBasic = model.cppreparseservice.getBasic(fileId);
+      } else {
+        console.error("Invalid element", elementInfo);
+        return;
+      }
+
+      var astDetail = model.cppreparseservice.getDetail(
+        fileId, astBasic.visitId);
+
+      // Create the root node for the AST.
+      ret.push({
+        id : 'root',
+        name : astBasic.type,
+        hasChildren : astBasic.hasChildren
+      });
+
+      // Create the node for the root node's detail.
+      ret.push({
+        name        : astDetail.otherStuff,
+        parent      : 'root',
+        cssClass    : 'icon icon-info',
+        hasChildren : false
+      });
+
+      // Add the basic node for the children, if any.
+      astDetail.children.forEach(function (child) {
+        ret.push({
+          id          : child.visitId,
+          name        : child.type,
+          parent      : 'root',
+          hasChildren : true,
+          getChildren : function () {
+            return getChildrenTreeElements(this, fileId);
+          }
+        });
+      });
+
+      return ret;
+    }
+  };
+
+  viewHandler.registerModule(cppReparseInfoTree, {
+    type : viewHandler.moduleType.InfoTree,
+    fileType : 'cpp-reparse'
+  });
+});

--- a/plugins/cpp_reparse/webgui/js/cppReparseMenu.js
+++ b/plugins/cpp_reparse/webgui/js/cppReparseMenu.js
@@ -24,6 +24,16 @@ function (topic, Menu, MenuItem, PopupMenuItem, model, viewHandler) {
       var submenu = new Menu();
 
       submenu.addChild(new MenuItem({
+        label : 'Show syntax InfoTree',
+        onClick : function () {
+          topic.publish('codecompass/infotree', {
+            fileType : 'cpp-reparse',
+            elementInfo : nodeInfo
+          });
+        }
+      }));
+
+      submenu.addChild(new MenuItem({
         label : 'Show AST HTML',
         onClick : function () {
           topic.publish('codecompass/cppreparsenode', {
@@ -53,6 +63,16 @@ function (topic, Menu, MenuItem, PopupMenuItem, model, viewHandler) {
         return;
 
       var submenu = new Menu();
+
+      submenu.addChild(new MenuItem({
+        label : 'Show syntax InfoTree',
+        onClick : function () {
+          topic.publish('codecompass/infotree', {
+              fileType : 'cpp-reparse',
+              elementInfo : fileInfo
+          });
+        }
+      }));
 
       submenu.addChild(new MenuItem({
         label : 'Show AST HTML',

--- a/webgui/scripts/codecompass/view/infoTree.js
+++ b/webgui/scripts/codecompass/view/infoTree.js
@@ -56,8 +56,10 @@ function (ObjectStoreModel, TitlePane, declare, Memory, Observable, mouse,
      * This function loads the first level of the info tree based on the given
      * info object.
      * @param {AstNodeInfo | FileInfo} elementInfo Thrift object.
+     * @param {string} fileType The type of the file which has the element the
+     * InfoTree is loaded for. (Optional.)
      */
-    loadInfoTree : function (elementInfo) {
+    loadInfoTree : function (elementInfo, fileType) {
       var that = this;
 
       //--- Remove previous tree data ---//
@@ -70,7 +72,8 @@ function (ObjectStoreModel, TitlePane, declare, Memory, Observable, mouse,
 
       viewHandler.getModules({ 
         type     : viewHandler.moduleType.InfoTree,
-        fileType : urlHandler.getFileInfo().type
+        fileType : fileType !== undefined
+                   ? fileType : urlHandler.getFileInfo().type
       }).forEach(function (item) {
         item.render(elementInfo).forEach(function (infoNode) {
           that._store.put(infoNode);

--- a/webgui/scripts/codecompass/viewHandler.js
+++ b/webgui/scripts/codecompass/viewHandler.js
@@ -72,6 +72,10 @@ function (lang, Deferred, model) {
              modules[module].options.type === filter.type) &&
             // Module is for the given file type.
             (filter.fileType === undefined ||
+                modules[module].options.fileType === undefined ||
+                modules[module].options.fileType === filter.fileType) &&
+            // Module is for the given file type's service.
+            (filter.fileType === undefined ||
              modules[module].options.service === undefined ||
              modules[module].options.service ===
                model.getLanguageService(filter.fileType)) &&


### PR DESCRIPTION
> Depends on #249. Patch needs to be rebased once it is merged.

This patch introduces a new *Info Tree* implementation which allows the user to browse the AST in the accordion. This can be used on whole translation units (by right-clicking in the file browser), or to a particular AST Node by clicking in the source code view (similar to how HTML generation is added in #248 and #249).

For each AST node, the tree is traversed quickly and only for the necessary parts, making the iteration on the tree a good user experience. As the user goes inwards on the tree, fewer nodes are visited each time (this is because the nodes are visited in a preorder labelling manner to make sure individual inner nodes can be located over the API, even if the AST is eliminated from the cache).

The InfoTree that is sent to the user persist through cache flushes, i.e. if the user is viewing a subtree and the AST for this translation unit is released from cache, at the next query, it is re-parsed (and cached), and the traversal of the tree identifies the node the user was viewing.

For each node, a "dummy" output is generated as an "info" :information_source:. This is a naive dump of the "first" line for the particular node in the AST HTML output, but without colouring.

This is to be extended *later* with tailored information for the particular node based on its type.

An example over a small `main()` function:

![reparse 3](https://user-images.githubusercontent.com/1969470/39762059-ff110c22-52d9-11e8-97bf-5aed1228562e.png)
