### PR TITLE
Eliminate unused field, argument, and some more warnings

### DIFF
--- a/plugins/cpp/parser/src/cppparser.cpp
+++ b/plugins/cpp/parser/src/cppparser.cpp
@@ -81,7 +81,7 @@ private:
 
       {
         RelationCollector relationCollector(
-          _ctx, _context, _mangledNameCache, _clangToAstNodeId);
+          _ctx, _context);
         relationCollector.TraverseDecl(context_.getTranslationUnitDecl());
       }
 

--- a/plugins/cpp/parser/src/relationcollector.cpp
+++ b/plugins/cpp/parser/src/relationcollector.cpp
@@ -18,12 +18,8 @@ std::unordered_set<model::CppEdgeAttributeId> RelationCollector::_edgeAttrCache;
 
 RelationCollector::RelationCollector(
   ParserContext& ctx_,
-  clang::ASTContext& astContext_,
-  MangledNameCache& mangledNameCache_,
-  std::unordered_map<const void*, model::CppAstNodeId>& clangToAstNodeId_)
+  clang::ASTContext& astContext_)
   : _ctx(ctx_),
-    _mangledNameCache(mangledNameCache_),
-    _clangToAstNodeId(clangToAstNodeId_),
     _fileLocUtil(astContext_.getSourceManager())
 {
 }

--- a/plugins/cpp/parser/src/relationcollector.h
+++ b/plugins/cpp/parser/src/relationcollector.h
@@ -15,7 +15,6 @@
 #include <util/logutil.h>
 
 #include "filelocutil.h"
-#include "manglednamecache.h"
 
 namespace cc
 {
@@ -27,9 +26,7 @@ class RelationCollector : public clang::RecursiveASTVisitor<RelationCollector>
 public:
   RelationCollector(
     ParserContext& ctx_,
-    clang::ASTContext& astContext_,
-    MangledNameCache& mangledNameCache_,
-    std::unordered_map<const void*, model::CppAstNodeId>& clangToAstNodeId_);
+    clang::ASTContext& astContext_);
 
   ~RelationCollector();
 
@@ -49,8 +46,6 @@ private:
     model::CppEdgeAttributePtr attr_ = nullptr);
 
   ParserContext& _ctx;
-  MangledNameCache& _mangledNameCache;
-  std::unordered_map<const void*, model::CppAstNodeId>& _clangToAstNodeId;
 
   static std::unordered_set<model::CppNodeId> _nodeCache;
   static std::unordered_set<model::CppEdgeId> _edgeCache;

--- a/plugins/cpp/service/include/service/cppservice.h
+++ b/plugins/cpp/service/include/service/cppservice.h
@@ -129,7 +129,7 @@ public:
 
   void getSyntaxHighlight(
     std::vector<SyntaxHighlight>& return_,
-    const core::FileId& fileId) override;
+    const core::FileId& fileId_) override;
 
 private:
   enum ReferenceType

--- a/plugins/cpp/service/src/cppservice.cpp
+++ b/plugins/cpp/service/src/cppservice.cpp
@@ -593,7 +593,7 @@ void CppServiceHandler::getReferences(
   std::vector<AstNodeInfo>& return_,
   const core::AstNodeId& astNodeId_,
   const std::int32_t referenceId_,
-  const std::vector<std::string>& tags_)
+  const std::vector<std::string>& /* tags_ */)
 {
   std::map<model::CppAstNodeId, std::vector<std::string>> tags;
   std::vector<model::CppAstNode> nodes;
@@ -991,28 +991,28 @@ void CppServiceHandler::getDiagramTypes(
 }
 
 void CppServiceHandler::getReferencesInFile(
-  std::vector<AstNodeInfo>& return_,
-  const core::AstNodeId& astNodeId_,
-  const std::int32_t referenceId_,
-  const core::FileId& fileId_,
-  const std::vector<std::string>& tags_)
+  std::vector<AstNodeInfo>& /* return_ */,
+  const core::AstNodeId& /* astNodeId_ */,
+  const std::int32_t /* referenceId_ */,
+  const core::FileId& /* fileId_ */,
+  const std::vector<std::string>& /* tags_ */)
 {
   // TODO
 }
 
 void CppServiceHandler::getReferencesPage(
-  std::vector<AstNodeInfo>& return_,
-  const core::AstNodeId& astNodeId_,
-  const std::int32_t referenceId_,
-  const std::int32_t pageSize_,
-  const std::int32_t pageNo_)
+  std::vector<AstNodeInfo>& /* return_ */,
+  const core::AstNodeId& /* astNodeId_ */,
+  const std::int32_t /* referenceId_ */,
+  const std::int32_t /* pageSize_ */,
+  const std::int32_t /* pageNo_ */)
 {
   // TODO
 }
 
 void CppServiceHandler::getFileReferenceTypes(
   std::map<std::string, std::int32_t>& return_,
-  const core::FileId& fileId_)
+  const core::FileId& /* fileId_ */)
 {
   return_["Types"]     = TYPES;
   return_["Functions"] = FUNCTIONS;
@@ -1106,8 +1106,8 @@ std::int32_t CppServiceHandler::getFileReferenceCount(
 }
 
 void CppServiceHandler::getSyntaxHighlight(
-  std::vector<SyntaxHighlight>& return_,
-  const core::FileId& fileId)
+  std::vector<SyntaxHighlight>& /* return_ */,
+  const core::FileId& /* fileId_ */)
 {
   // TODO
 }

--- a/plugins/git/service/include/service/gitservice.h
+++ b/plugins/git/service/include/service/gitservice.h
@@ -236,7 +236,6 @@ private:
 
   std::shared_ptr<odb::database> _db;
   util::OdbTransaction _transaction;
-  const boost::program_options::variables_map& _config;
   std::shared_ptr<std::string> _datadir;
 
   core::ProjectServiceHandler _projectHandler;

--- a/plugins/metrics/service/include/metricsservice/metricsservice.h
+++ b/plugins/metrics/service/include/metricsservice/metricsservice.h
@@ -53,8 +53,6 @@ private:
   std::shared_ptr<odb::database> _db;
   util::OdbTransaction _transaction;
 
-  const boost::program_options::variables_map& _config;
-
   core::ProjectServiceHandler _projectService;
 };
 

--- a/plugins/metrics/service/src/metricsservice.cpp
+++ b/plugins/metrics/service/src/metricsservice.cpp
@@ -87,7 +87,7 @@ std::string MetricsServiceHandler::getMetricsFromDir(
       [](const model::File& file) { return file.id; });
 
     if (descendantFids.empty())
-      return "";
+      return;
 
     //--- Get metrics for these files ---//
 


### PR DESCRIPTION
Minor things to make the compilation output less noisy. This should eliminate all warnings that happen and aren't in system headers (such as one rolling issue with `libgit`.)