### PR TITLE
Fix CREATE USER command for PostgreSQL.

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -32,7 +32,7 @@ psql
 In the PostgreSQL command-line shell, type:
 
 ```sql
-CREATE USER compass SUPERUSER LOGIN WITH PASSWORD 'mypassword';
+CREATE USER compass WITH SUPERUSER LOGIN PASSWORD 'mypassword';
 ```
 
 You can exit this shell by typing `\q` and pressing the `ENTER` key. A user


### PR DESCRIPTION
Incorrect order of keywords.
See docs: https://www.postgresql.org/docs/9.5/static/sql-createuser.html