### PR TITLE
Do not depend on libsqlite3 being installed if PostgreSQL database is used

### DIFF
--- a/FindOdb.cmake
+++ b/FindOdb.cmake
@@ -98,7 +98,7 @@ endif()
 set(ODB_INCLUDE_DIRS ${ODB_LIBODB_INCLUDE_DIRS})
 set(ODB_LIBRARIES ${ODB_LIBODB_LIBRARIES})
 
-set(ODB_FIND_COMPONENTS "pgsql" "sqlite" "mysql")
+set(ODB_FIND_COMPONENTS "pgsql" "sqlite")
 foreach(component ${ODB_FIND_COMPONENTS})
 	find_odb_api(${component})
 endforeach()
@@ -107,4 +107,9 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(ODB
 	FOUND_VAR ODB_FOUND
 	REQUIRED_VARS ODB_EXECUTABLE ODB_LIBODB_FOUND
-HANDLE_COMPONENTS)
+	HANDLE_COMPONENTS)
+
+string(TOLOWER "${DATABASE}" _databaseLib)
+if ("${ODB_${_databaseLib}_LIBRARY}" MATCHES "-NOTFOUND")
+  message(FATAL_ERROR "ODB library for selected DATABASE ${DATABASE} not found.")
+endif()

--- a/doc/deps.md
+++ b/doc/deps.md
@@ -1,6 +1,6 @@
 # Operating system
-We build CodeCompass under Linux. It is recommended to use a 64-bit operating
-system.
+We build CodeCompass under Linux. Currently, we are supporting Ubuntu 16.04 LTS.
+It is recommended to use a 64-bit operating system.
 
 # Dependencies
 CodeCompass uses some third-party dependencies. These can be installed from the
@@ -52,14 +52,20 @@ Some third-party tools are present in the distribution's package manager in a
 way that they are eiter incompatible with each other or not available as a
 package, thus can't be used to create your CodeCompass installation.
 
+:warning: Building and installing from source code to the system is a dangerous
+operation - outside package managers, the wrong binaries can end up being used
+by other processes which could, in extreme cases, make the system very hard or
+impossible to recover. **Please do NOT add a `sudo` in front of any `make` or
+other commands below, unless *explicitly* specified!**
+
 ### Thrift
+=======
 CodeCompass needs [Thrift](https://thrift.apache.org/) which provides Remote
 Procedure Call (RPC) between the server and the client. Thrift is not part of
 the official Ubuntu 16.04 LTS repositories, but you can download it and build
 from source:
 
-- [Download](http://xenia.sote.hu/ftp/mirrors/www.apache.org/thrift/0.10.0/thrift-0.10.0.tar.gz)
-  Thrift
+- [Download Thrift](http://xenia.sote.hu/ftp/mirrors/www.apache.org/thrift/0.10.0/thrift-0.10.0.tar.gz)
 - Uncompress and build it:
 
 ```bash

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -22,7 +22,12 @@ target_compile_options(util PUBLIC -fPIC)
 
 find_boost_libraries(
   regex)
-#FIXME: Why does util link unconditionally against sqlite3?
+
 target_link_libraries(util
-  ${Boost_LINK_LIBRARIES}
-  sqlite3)
+  ${Boost_LINK_LIBRARIES})
+
+string(TOLOWER "${DATABASE}" _database)
+if (${_database} STREQUAL "sqlite")
+  target_link_libraries(util
+    sqlite3)
+endif()

--- a/util/include/util/odbtransaction.h
+++ b/util/include/util/odbtransaction.h
@@ -132,6 +132,7 @@ public:
       s.reset();
     }
 #ifdef DATABASE_SQLITE
+    (void)_switchCurrent; // Silence unused variable warning in SQLite mode.
     // IT'S COMMENTED OUT (SLOW, VERY SLOW)
     /*else if (_switchCurrent)
     {


### PR DESCRIPTION
> Closes #200.

The only dependency of `libsqlite3` in the `util` module is this function:

https://github.com/Ericsson/CodeCompass/blob/a45aaeb300e7739980a8c1814eff65cc477052f6/util/src/dbutil.cpp#L97-L102

Thus, the linking should only happen if SQLite is used as database backend.