### PR TITLE
Fix non-compiling code

### DIFF
--- a/plugins/git/service/src/gitservice.cpp
+++ b/plugins/git/service/src/gitservice.cpp
@@ -75,7 +75,6 @@ GitServiceHandler::GitServiceHandler(
   const cc::webserver::ServerContext& context_)
     : _db(db_),
       _transaction(db_),
-      _config(context_.options),
       _datadir(datadir_),
       _projectHandler(db_, datadir_, context_)
 {

--- a/plugins/metrics/service/src/metricsservice.cpp
+++ b/plugins/metrics/service/src/metricsservice.cpp
@@ -19,7 +19,6 @@ MetricsServiceHandler::MetricsServiceHandler(
   const cc::webserver::ServerContext& context_)
     : _db(db_),
       _transaction(db_),
-      _config(context_.options),
       _projectService(db_, datadir_, context_)
 {
 }


### PR DESCRIPTION
Some earlier commit caused that the code doesn't compile. Non-existing
member initializations have to be removed.