### PR TITLE
Incremental parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # IDEs and editors
 
-nbproject
+nbproject/
+.idea/
 *.swp
 
 # Generated files and directories
@@ -17,3 +18,4 @@ nbproject
 # Other
 
 /build/
+/build_*/

--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,4 @@ nbproject/
 
 # Other
 
-/build/
-/build_*/
+/build*/

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -165,6 +165,17 @@ keepalive CodeCompass_parser \
   -j 4
 ```
 
+### Incremental parsing
+
+As an experimental feature CodeCompass supports incremental parsing, updating an
+existing database and project workspace by detecting the added, deleted and modified files.  
+Incremental parsing depends on that the build tooling generates a **complete** compilation database, 
+therefore the build commands for only the modified files are not sufficient.
+In case of CMake, using the result of the `CMAKE_EXPORT_COMPILE_COMMANDS=ON` argument, the 
+compilation database will always contain all files.
+Currently the C++ and metrics parsers support incremental parsing, while other parsers
+just execute a forced reparse.
+
 ## 3. Start the web server
 You can start the CodeCompass webserver with `CodeCompass_webserver` binary in
 the CodeCompass installation directory.

--- a/model/include/model/buildlog.h
+++ b/model/include/model/buildlog.h
@@ -44,6 +44,7 @@ struct BuildLog
   BuildLogMessage log;
 
   #pragma db not_null
+  #pragma db on_delete(cascade)
   std::shared_ptr<BuildAction> action;
 
   #pragma db null

--- a/model/include/model/buildsourcetarget.h
+++ b/model/include/model/buildsourcetarget.h
@@ -25,6 +25,7 @@ struct BuildSource
   FilePtr file;
 
   #pragma db not_null
+  #pragma db on_delete(cascade)
   std::shared_ptr<BuildAction> action;
 };
 
@@ -40,6 +41,7 @@ struct BuildTarget
   FilePtr file;
 
   #pragma db not_null
+#pragma db on_delete(cascade)
   std::shared_ptr<BuildAction> action;
 };
 

--- a/model/include/model/buildsourcetarget.h
+++ b/model/include/model/buildsourcetarget.h
@@ -41,7 +41,7 @@ struct BuildTarget
   FilePtr file;
 
   #pragma db not_null
-#pragma db on_delete(cascade)
+  #pragma db on_delete(cascade)
   std::shared_ptr<BuildAction> action;
 };
 

--- a/model/include/model/fileloc.h
+++ b/model/include/model/fileloc.h
@@ -15,6 +15,7 @@ struct FileLoc
   Range range;
 
   #pragma db null
+  #pragma db on_delete(cascade)
   odb::lazy_shared_ptr<File> file;
 };
 

--- a/parser/CMakeLists.txt
+++ b/parser/CMakeLists.txt
@@ -9,7 +9,8 @@ include_directories(SYSTEM
 add_executable(CodeCompass_parser
   src/pluginhandler.cpp
   src/sourcemanager.cpp
-  src/parser.cpp)
+  src/parser.cpp
+  src/parsercontext.cpp)
 
 set_target_properties(CodeCompass_parser
   PROPERTIES ENABLE_EXPORTS 1)

--- a/parser/include/parser/abstractparser.h
+++ b/parser/include/parser/abstractparser.h
@@ -36,6 +36,7 @@ public:
   /**
    * Maintains and cleans up the database in preparation of
    * incremental parsing.
+   * @return Return true if the preparse was success, false otherwise.
    */
   virtual bool preparse()
   {

--- a/parser/include/parser/abstractparser.h
+++ b/parser/include/parser/abstractparser.h
@@ -33,7 +33,14 @@ public:
    */
   virtual std::vector<std::string> getDependentParsers() const = 0;
 
-  virtual void preparse(){}
+  /**
+   * Maintains and cleans up the database in preparation of
+   * incremental parsing.
+   */
+  virtual bool preparse()
+  {
+    return true;
+  }
 
   /**
    * Method parses a path or a compilation database

--- a/parser/include/parser/abstractparser.h
+++ b/parser/include/parser/abstractparser.h
@@ -33,6 +33,8 @@ public:
    */
   virtual std::vector<std::string> getDependentParsers() const = 0;
 
+  virtual void preparse(){}
+
   /**
    * Method parses a path or a compilation database
    * @return Return true if the parse was success, false otherwise

--- a/parser/include/parser/parsercontext.h
+++ b/parser/include/parser/parsercontext.h
@@ -36,8 +36,7 @@ struct ParserContext
       std::shared_ptr<odb::database> db_,
       SourceManager& srcMgr_,
       std::string& compassRoot_,
-      po::variables_map& options_,
-      std::unordered_map<std::string, IncrementalStatus> fileStatus_);
+      po::variables_map& options);
 
   std::shared_ptr<odb::database> db;
   SourceManager& srcMgr;

--- a/parser/include/parser/parsercontext.h
+++ b/parser/include/parser/parsercontext.h
@@ -1,20 +1,13 @@
 #ifndef CC_PARSER_PARSERCONTEXT_H
 #define CC_PARSER_PARSERCONTEXT_H
 
+#include <fstream>
 #include <memory>
 #include <unordered_map>
-#include <fstream>
 
 #include <boost/program_options.hpp>
-#include <boost/filesystem.hpp>
 
 #include <odb/database.hxx>
-
-#include <model/file.h>
-#include <model/file-odb.hxx>
-
-#include <util/hash.h>
-#include <util/odbtransaction.h>
 
 namespace po = boost::program_options; 
 
@@ -25,8 +18,10 @@ namespace parser
 
 class SourceManager;
 
- /**
+/**
  * Defines file status categories for incremental parsing.
+ *
+ * State in database VERSUS state on disk at parse time.
  */
 enum class IncrementalStatus
 {

--- a/parser/include/parser/parsercontext.h
+++ b/parser/include/parser/parsercontext.h
@@ -2,8 +2,19 @@
 #define CC_PARSER_PARSERCONTEXT_H
 
 #include <memory>
+#include <unordered_map>
+#include <fstream>
+
 #include <boost/program_options.hpp>
+#include <boost/filesystem.hpp>
+
 #include <odb/database.hxx>
+
+#include <model/file.h>
+#include <model/file-odb.hxx>
+
+#include <util/hash.h>
+#include <util/odbtransaction.h>
 
 namespace po = boost::program_options; 
 
@@ -14,24 +25,30 @@ namespace parser
 
 class SourceManager;
 
+ /**
+ * Defines file status categories for incremental parsing.
+ */
+enum class IncrementalStatus
+{
+  MODIFIED,
+  ADDED,
+  DELETED
+};
+
 struct ParserContext 
 {  
   ParserContext(
-    std::shared_ptr<odb::database> db_,
-    SourceManager& srcMgr_,
-    std::string& compassRoot_,
-    po::variables_map& options_) :
-      db(db_),
-      srcMgr(srcMgr_),
-      compassRoot(compassRoot_),
-      options(options_)
-  {
-  }
+      std::shared_ptr<odb::database> db_,
+      SourceManager& srcMgr_,
+      std::string& compassRoot_,
+      po::variables_map& options_,
+      std::unordered_map<std::string, IncrementalStatus> fileStatus_);
 
   std::shared_ptr<odb::database> db;
   SourceManager& srcMgr;
   std::string& compassRoot;
   po::variables_map& options;
+  std::unordered_map<std::string, IncrementalStatus> fileStatus;
 };
 
 } // parser

--- a/parser/include/parser/parsercontext.h
+++ b/parser/include/parser/parsercontext.h
@@ -1,7 +1,6 @@
 #ifndef CC_PARSER_PARSERCONTEXT_H
 #define CC_PARSER_PARSERCONTEXT_H
 
-#include <fstream>
 #include <memory>
 #include <unordered_map>
 

--- a/parser/include/parser/sourcemanager.h
+++ b/parser/include/parser/sourcemanager.h
@@ -28,6 +28,12 @@ public:
   ~SourceManager();
 
   /**
+   * This function copies and returns a pointer to all model::File objects
+   * currently stored.
+   */
+  std::vector<model::FilePtr> getAllFiles();
+
+  /**
    * This function returns a pointer to the corresponding model::File object
    * based on the given path_. The object is read from a cache. If the file is
    * not in the cache yet then a model::File entry is created, persisted in the

--- a/parser/include/parser/sourcemanager.h
+++ b/parser/include/parser/sourcemanager.h
@@ -52,6 +52,13 @@ public:
   // TODO: Maybe this function shouldn't exist.
   void persistFiles();
 
+  /**
+   * This function removes the given file (and its content if necessary)
+   * from the SourceManager and also deletes it from the database.
+   * @param file_ A model::File object which is already persistent.
+   */
+  void removeFile(const model::File& file_);
+
 private:
   /**
    * This function creates a model::FileContent object and fills its attributes

--- a/parser/include/parser/sourcemanager.h
+++ b/parser/include/parser/sourcemanager.h
@@ -27,11 +27,22 @@ public:
   SourceManager(const SourceManager&) = delete;
   ~SourceManager();
 
-  /**
-   * This function copies and returns a pointer to all model::File objects
-   * currently stored.
-   */
-  std::vector<model::FilePtr> getAllFiles();
+  struct AllFilesFilter
+  {
+    bool operator()(model::FilePtr file_) const { return true; }
+  };
+
+  template<typename Filter = SourceManager::AllFilesFilter>
+  std::vector<model::FilePtr> getFiles(const Filter& beta_ = Filter())
+  {
+    std::vector<model::FilePtr> files;
+
+    for (const auto& p: _files)
+      if (beta_(p.second))
+        files.push_back(p.second);
+
+    return files;
+  }
 
   /**
    * This function returns a pointer to the corresponding model::File object

--- a/parser/src/parser.cpp
+++ b/parser/src/parser.cpp
@@ -211,8 +211,8 @@ int main(int argc, char* argv[])
     LOG(error) << "Error in command line arguments: " << e.what();
     return 1;
   }
-
-  //--- Check database and project directory existsence ---//
+  
+  //--- Check database and project directory existence ---//
   
   bool isNewDb = cc::util::connectDatabase(
     vm["database"].as<std::string>(), false) ? false : true;
@@ -224,6 +224,9 @@ int main(int argc, char* argv[])
       << "Database and working directory existence are inconsistent. Use -f for reparsing!";
     return 1;
   }
+
+  if(!isNewDb)
+    LOG(info) << "Project already exists, incremental parsing in action.";
 
   //--- Prepare workspace and project directory ---//
   
@@ -260,15 +263,17 @@ int main(int argc, char* argv[])
   std::vector<std::string> reversedTopologicalOrder = pHandler.getTopologicalOrder();
   std::reverse(reversedTopologicalOrder.begin(), reversedTopologicalOrder.end());
 
+  // TODO: Handle errors returned by preparse().
   for(const std::string& parserName : reversedTopologicalOrder)
   {
+    LOG(info) << "[" << parserName << "] preparse started!";
     pHandler.getParser(parserName)->preparse();
   }
 
   // TODO: Handle errors returned by parse().
   for (const std::string& parserName : pHandler.getTopologicalOrder())
   {
-    LOG(info) << "[" << parserName << "] started!";
+    LOG(info) << "[" << parserName << "] parse started!";
     pHandler.getParser(parserName)->parse();
   }
 

--- a/parser/src/parser.cpp
+++ b/parser/src/parser.cpp
@@ -82,7 +82,7 @@ po::options_description commandLineArguments()
 /**
  * This function checks the existence of the workspace and project directory
  * based on the given command line arguments.
- * @return The path of the project directory.
+ * @return Whether the project directory exists or not.
  */
 bool checkProjectDir(const po::variables_map& vm_)
 {
@@ -90,7 +90,7 @@ bool checkProjectDir(const po::variables_map& vm_)
     = vm_["workspace"].as<std::string>() + '/'
       + vm_["name"].as<std::string>();
 
-  return fs::exists(projDir) && fs::is_directory(projDir);
+  return fs::is_directory(projDir);
 }
 
 /**
@@ -276,7 +276,7 @@ int main(int argc, char* argv[])
   // TODO: Consider whether there is a better place for this code.
   cc::util::OdbTransaction {ctx.db} ([&]
   {
-    for (auto& item : ctx.fileStatus)
+    for (const auto& item : ctx.fileStatus)
     {
       switch (item.second)
       {
@@ -300,7 +300,7 @@ int main(int argc, char* argv[])
   });
 
   // TODO: Handle errors returned by parse().
-  for (const std::string& parserName : pHandler.getTopologicalOrder())
+  for (const std::string& parserName : topologicalOrder)
   {
     LOG(info) << "[" << parserName << "] parse started!";
     pHandler.getParser(parserName)->parse();

--- a/parser/src/parsercontext.cpp
+++ b/parser/src/parsercontext.cpp
@@ -1,3 +1,5 @@
+#include <fstream>
+
 #include <boost/filesystem.hpp>
 
 #include <model/file.h>
@@ -30,14 +32,13 @@ ParserContext::ParserContext(
 
   (util::OdbTransaction(this->db))([&]
    {
-     // Fetch all files from SourceManager
-     std::vector<model::FilePtr> files = this->srcMgr.getAllFiles();
-     files.erase(std::remove_if(files.begin(), files.end(),
-                                [](const auto &item)
-                                {
-                                  return item->type == model::File::DIRECTORY_TYPE ||
-                                         item->type == model::File::BINARY_TYPE;
-                                }), files.end());
+     // Fetch directory and binary type files from SourceManager
+     auto func = [](const auto& item)
+     {
+       return item->type != model::File::DIRECTORY_TYPE &&
+              item->type != model::File::BINARY_TYPE;
+     };
+     std::vector<model::FilePtr> files = this->srcMgr.getFiles(func);
 
      for (model::FilePtr file : files)
      {

--- a/parser/src/parsercontext.cpp
+++ b/parser/src/parsercontext.cpp
@@ -12,7 +12,7 @@
 namespace po = boost::program_options;
 
 namespace cc
-{,
+{
 namespace parser
 {
 
@@ -43,12 +43,13 @@ ParserContext::ParserContext(
      {
        if (boost::filesystem::exists(file->path))
        {
-         if (!this->fileStatus.count(file->path))
+         if (!fileStatus.count(file->path))
          {
-           auto content = file->content.load();
-           fileHashes[file->path] = content != nullptr ? content->hash : "";
-           if (content == nullptr)
+           model::FileContentPtr content = file->content.load();
+           if (!content)
              continue;
+
+           fileHashes[file->path] = content->hash;
 
            std::ifstream fileStream(file->path);
            std::string fileContent(
@@ -58,16 +59,16 @@ ParserContext::ParserContext(
 
            if (content->hash != util::sha1Hash(fileContent))
            {
-             this->fileStatus.insert(
-               std::make_pair(file->path, cc::parser::IncrementalStatus::MODIFIED));
+             this->fileStatus.emplace(
+               file->path, cc::parser::IncrementalStatus::MODIFIED);
              LOG(debug) << "File modified: " << file->path;
            }
          }
        }
        else
        {
-         this->fileStatus.insert(
-             std::make_pair(file->path, cc::parser::IncrementalStatus::DELETED));
+         fileStatus.emplace(
+             file->path, cc::parser::IncrementalStatus::DELETED);
          LOG(debug) << "File deleted: " << file->path;
        }
      }

--- a/parser/src/parsercontext.cpp
+++ b/parser/src/parsercontext.cpp
@@ -1,0 +1,73 @@
+#include <parser/parsercontext.h>
+#include <parser/sourcemanager.h>
+
+namespace po = boost::program_options;
+
+namespace cc
+{,
+namespace parser
+{
+
+ParserContext::ParserContext(
+    std::shared_ptr<odb::database> db_,
+    SourceManager& srcMgr_,
+    std::string& compassRoot_,
+    po::variables_map& options_,
+    std::unordered_map<std::string, IncrementalStatus> fileStatus_):
+    db(db_),
+    srcMgr(srcMgr_),
+    compassRoot(compassRoot_),
+    options(options_),
+    fileStatus(fileStatus_)
+{
+  std::unordered_map<std::string, std::string> fileHashes;
+
+  (util::OdbTransaction(this->db))([&]
+   {
+     // Fetch all files from SourceManager
+     std::vector<model::FilePtr> files = this->srcMgr.getAllFiles();
+     files.erase(std::remove_if(files.begin(), files.end(),
+                                [](const auto &item)
+                                {
+                                  return item->type == model::File::DIRECTORY_TYPE ||
+                                         item->type == model::File::BINARY_TYPE;
+                                }), files.end());
+
+     for (model::FilePtr file : files)
+     {
+       if (boost::filesystem::exists(file->path))
+       {
+         if (!this->fileStatus.count(file->path))
+         {
+           auto content = file->content.load();
+           fileHashes[file->path] = content != nullptr ? content->hash : "";
+           if (content == nullptr)
+             continue;
+
+           std::ifstream fileStream(file->path);
+           std::string fileContent(
+               (std::istreambuf_iterator<char>(fileStream)),
+               (std::istreambuf_iterator<char>()));
+           fileStream.close();
+
+           if (content->hash != util::sha1Hash(fileContent))
+           {
+             this->fileStatus.insert(
+               std::make_pair(file->path, cc::parser::IncrementalStatus::MODIFIED));
+             LOG(debug) << "File modified: " << file->path;
+           }
+         }
+       }
+       else
+       {
+         this->fileStatus.insert(
+             std::make_pair(file->path, cc::parser::IncrementalStatus::DELETED));
+         LOG(debug) << "File deleted: " << file->path;
+       }
+     }
+   });
+}
+
+}
+}
+

--- a/parser/src/parsercontext.cpp
+++ b/parser/src/parsercontext.cpp
@@ -65,6 +65,8 @@ ParserContext::ParserContext(
          LOG(debug) << "File deleted: " << file->path;
        }
      }
+
+     // TODO: detect ADDED files
    });
 }
 

--- a/parser/src/parsercontext.cpp
+++ b/parser/src/parsercontext.cpp
@@ -1,3 +1,11 @@
+#include <boost/filesystem.hpp>
+
+#include <model/file.h>
+#include <model/file-odb.hxx>
+
+#include <util/hash.h>
+#include <util/odbtransaction.h>
+
 #include <parser/parsercontext.h>
 #include <parser/sourcemanager.h>
 
@@ -12,13 +20,11 @@ ParserContext::ParserContext(
     std::shared_ptr<odb::database> db_,
     SourceManager& srcMgr_,
     std::string& compassRoot_,
-    po::variables_map& options_,
-    std::unordered_map<std::string, IncrementalStatus> fileStatus_):
-    db(db_),
-    srcMgr(srcMgr_),
-    compassRoot(compassRoot_),
-    options(options_),
-    fileStatus(fileStatus_)
+    po::variables_map& options_):
+      db(db_),
+      srcMgr(srcMgr_),
+      options(options_),
+      compassRoot(compassRoot_)
 {
   std::unordered_map<std::string, std::string> fileHashes;
 

--- a/parser/src/sourcemanager.cpp
+++ b/parser/src/sourcemanager.cpp
@@ -251,12 +251,11 @@ void SourceManager::removeFile(const model::File& file_)
   });
 
   // Maintain cache
-  _createFileMutex.lock();
+  std::lock_guard<std::mutex> guard(_createFileMutex);
   _files.erase(file_.path);
   _persistedFiles.erase(file_.id);
-  if(removeContent)
+  if (removeContent)
     _persistedContents.erase(file_.content.object_id());
-  _createFileMutex.unlock();
 }
 
 void SourceManager::persistFiles()

--- a/parser/src/sourcemanager.cpp
+++ b/parser/src/sourcemanager.cpp
@@ -149,6 +149,19 @@ model::FilePtr SourceManager::getCreateFileEntry(
   return file;
 }
 
+std::vector<model::FilePtr> SourceManager::getAllFiles()
+{
+  std::lock_guard<std::mutex> guard(_createFileMutex);
+
+  std::vector<model::FilePtr> values;
+  values.reserve(_files.size());
+
+  std::transform(_files.begin(), _files.end(), std::back_inserter(values),
+                 [](const auto &pair) { return pair.second; });
+
+  return values;
+}
+
 model::FilePtr SourceManager::getFile(const std::string& path_)
 {
   //--- Create canonical form of the path ---//

--- a/parser/src/sourcemanager.cpp
+++ b/parser/src/sourcemanager.cpp
@@ -149,19 +149,6 @@ model::FilePtr SourceManager::getCreateFileEntry(
   return file;
 }
 
-std::vector<model::FilePtr> SourceManager::getAllFiles()
-{
-  std::lock_guard<std::mutex> guard(_createFileMutex);
-
-  std::vector<model::FilePtr> values;
-  values.reserve(_files.size());
-
-  std::transform(_files.begin(), _files.end(), std::back_inserter(values),
-                 [](const auto &pair) { return pair.second; });
-
-  return values;
-}
-
 model::FilePtr SourceManager::getFile(const std::string& path_)
 {
   //--- Create canonical form of the path ---//

--- a/parser/src/sourcemanager.cpp
+++ b/parser/src/sourcemanager.cpp
@@ -227,12 +227,15 @@ void SourceManager::removeFile(const model::File& file_)
 
   // Delete File and FileContent (only when no other File references it)
   _transaction([&]() {
-    auto relFiles = _db->query<model::File>(
-        odb::query<model::File>::content == file_.content.object_id());
-    if (relFiles.size() == 1)
+    if(file_.content)
     {
-      removeContent = true;
-      _db->erase<model::FileContent>(file_.content.object_id());
+      auto relFiles = _db->query<model::File>(
+        odb::query<model::File>::content == file_.content.object_id());
+      if (relFiles.size() == 1)
+      {
+        removeContent = true;
+        _db->erase<model::FileContent>(file_.content.object_id());
+      }
     }
     _db->erase<model::File>(file_.id);
   });

--- a/plugins/cpp/model/include/model/cppedge.h
+++ b/plugins/cpp/model/include/model/cppedge.h
@@ -35,9 +35,11 @@ struct CppEdge
   CppEdgeId id;
 
   #pragma db not_null
+  #pragma db on_delete(cascade)
   std::shared_ptr<CppNode> from;
 
   #pragma db not_null
+  #pragma db on_delete(cascade)
   std::shared_ptr<CppNode> to;
 
   #pragma db not_null
@@ -93,6 +95,7 @@ struct CppEdgeAttribute
   CppEdgeAttributeId id;
 
   #pragma db not_null
+  #pragma db on_delete(cascade)
   std::shared_ptr<CppEdge> edge;
 
   #pragma db not_null

--- a/plugins/cpp/model/include/model/cppfunction.h
+++ b/plugins/cpp/model/include/model/cppfunction.h
@@ -14,7 +14,9 @@ namespace model
 #pragma db object
 struct CppFunction : CppTypedEntity
 {
+  #pragma db on_delete(cascade)
   std::vector<odb::lazy_shared_ptr<CppVariable>> parameters;
+  #pragma db on_delete(cascade)
   std::vector<odb::lazy_shared_ptr<CppVariable>> locals;
 
   std::string toString() const

--- a/plugins/cpp/model/include/model/cppheaderinclusion.h
+++ b/plugins/cpp/model/include/model/cppheaderinclusion.h
@@ -21,9 +21,11 @@ struct CppHeaderInclusion
   int id;
 
   #pragma db not_null
+  #pragma db on_delete(cascade)
   odb::lazy_shared_ptr<File> includer;
 
   #pragma db not_null
+  #pragma db on_delete(cascade)
   odb::lazy_shared_ptr<File> included;
 
   std::string toString() const

--- a/plugins/cpp/model/include/model/cppnode.h
+++ b/plugins/cpp/model/include/model/cppnode.h
@@ -70,6 +70,7 @@ public:
   CppNodeAttributeId id;
 
   #pragma db not_null
+  #pragma db on_delete(cascade)
   std::shared_ptr<CppNode> node;
 
   #pragma db not_null

--- a/plugins/cpp/model/include/model/cpptype.h
+++ b/plugins/cpp/model/include/model/cpptype.h
@@ -26,6 +26,7 @@ struct CppMemberType
   std::uint64_t typeHash;
 
   #pragma db unique
+  #pragma db on_delete(cascade)
   odb::lazy_shared_ptr<CppAstNode> memberAstNode;
   std::uint64_t memberTypeHash;
 

--- a/plugins/cpp/parser/include/cppparser/cppparser.h
+++ b/plugins/cpp/parser/include/cppparser/cppparser.h
@@ -90,7 +90,7 @@ private:
 
   void incrementalParse();
   void initBuildActions();
-  void markAsModified(const model::File& file_);
+  void markAsModified(model::FilePtr file_);
   std::set<model::CppNodeId> collectNodeSet(model::CppNodeId node_) const;
 
   std::unordered_set<std::uint64_t> _parsedCommandHashes;

--- a/plugins/cpp/parser/include/cppparser/cppparser.h
+++ b/plugins/cpp/parser/include/cppparser/cppparser.h
@@ -76,6 +76,17 @@ private:
     ParseJob(const ParseJob&) = default;
   };
 
+  /**
+   * Defines file status categories for incremental parsing.
+   */
+  enum class IncrementalStatus
+  {
+    UNCHANGED,
+    MODIFIED,
+    ADDED,
+    DELETED,
+  };
+
   std::unordered_set<std::uint64_t> _parsedCommandHashes;
 };
   

--- a/plugins/cpp/parser/include/cppparser/cppparser.h
+++ b/plugins/cpp/parser/include/cppparser/cppparser.h
@@ -2,6 +2,7 @@
 #define CC_PARSER_CXXPARSER_H
 
 #include <map>
+#include <set>
 #include <unordered_set>
 #include <vector>
 
@@ -9,6 +10,7 @@
 #include <clang/Tooling/Tooling.h>
 
 #include <model/buildaction.h>
+#include <model/cppnode.h>
 
 #include <parser/abstractparser.h>
 #include <parser/parsercontext.h>
@@ -85,8 +87,11 @@ private:
   bool isNonSourceFlag(const std::string& arg_) const;
   bool parseByJson(const std::string& jsonFile_, std::size_t threadNum_);
   int worker(const clang::tooling::CompileCommand& command_);
+
+  void incrementalParse();
+  void initBuildActions();
   void markAsModified(const model::File& file_);
-  void insertBuildActions();
+  std::set<model::CppNodeId> collectNodeSet(model::CppNodeId node_) const;
 
   std::unordered_set<std::uint64_t> _parsedCommandHashes;
   std::unordered_map<std::string, IncrementalStatus> _fileStatus;

--- a/plugins/cpp/parser/include/cppparser/cppparser.h
+++ b/plugins/cpp/parser/include/cppparser/cppparser.h
@@ -28,6 +28,17 @@ public:
 
 private:
   /**
+   * Defines file status categories for incremental parsing.
+   */
+  enum class IncrementalStatus
+  {
+    UNCHANGED,
+    MODIFIED,
+    ADDED,
+    DELETED,
+  };
+
+  /**
    * This function gets the input-output pairs from the compile command.
    *
    * If the compile command comtains C/C++ source file(s) and the output is set
@@ -37,6 +48,9 @@ private:
    * -o provided then the output file name will be a.out.  If the compile
    * command contains no source files then the function returns an empty map.
    */
+
+  std::unordered_map<std::string, IncrementalStatus> fileStatus;
+
   std::map<std::string, std::string> extractInputOutputs(
     const clang::tooling::CompileCommand& command_) const;
 
@@ -53,6 +67,8 @@ private:
   bool isNonSourceFlag(const std::string& arg_) const;
   bool parseByJson(const std::string& jsonFile_, std::size_t threadNum_);
   int worker(const clang::tooling::CompileCommand& command_);
+
+  void markAsModified(model::File file);
 
   /**
    * A single build command's cc::util::JobQueueThreadPool job.
@@ -74,17 +90,6 @@ private:
     {}
 
     ParseJob(const ParseJob&) = default;
-  };
-
-  /**
-   * Defines file status categories for incremental parsing.
-   */
-  enum class IncrementalStatus
-  {
-    UNCHANGED,
-    MODIFIED,
-    ADDED,
-    DELETED,
   };
 
   std::unordered_set<std::uint64_t> _parsedCommandHashes;

--- a/plugins/cpp/parser/include/cppparser/cppparser.h
+++ b/plugins/cpp/parser/include/cppparser/cppparser.h
@@ -26,7 +26,8 @@ public:
   CppParser(ParserContext& ctx_);
   virtual ~CppParser();  
   virtual std::vector<std::string> getDependentParsers() const override;
-  virtual bool parse() override; 
+  virtual void preparse() override;
+  virtual bool parse() override;
 
 private:
   /**
@@ -51,15 +52,7 @@ private:
     ParseJob(const ParseJob&) = default;
   };
 
-  /**
-   * Defines file status categories for incremental parsing.
-   */
-  enum class IncrementalStatus
-  {
-    MODIFIED,
-    ADDED,
-    DELETED,
-  };
+
 
   /**
    * This function gets the input-output pairs from the compile command.
@@ -87,14 +80,13 @@ private:
   bool isNonSourceFlag(const std::string& arg_) const;
   bool parseByJson(const std::string& jsonFile_, std::size_t threadNum_);
   int worker(const clang::tooling::CompileCommand& command_);
-
-  void incrementalParse();
+  
   void initBuildActions();
   void markAsModified(model::FilePtr file_);
   std::set<model::CppNodeId> collectNodeSet(model::CppNodeId node_) const;
 
   std::unordered_set<std::uint64_t> _parsedCommandHashes;
-  std::unordered_map<std::string, IncrementalStatus> _fileStatus;
+
 };
   
 } // parser

--- a/plugins/cpp/parser/include/cppparser/cppparser.h
+++ b/plugins/cpp/parser/include/cppparser/cppparser.h
@@ -28,11 +28,32 @@ public:
 
 private:
   /**
+   * A single build command's cc::util::JobQueueThreadPool job.
+   */
+  struct ParseJob
+  {
+    /**
+     * The build command itself. This is given to CppParser::worker.
+     */
+    std::reference_wrapper<const clang::tooling::CompileCommand> command;
+
+    /**
+     * The # of the build command in the compilation command database.
+     */
+    std::size_t index;
+
+    ParseJob(const clang::tooling::CompileCommand& command, std::size_t index)
+        : command(command), index(index)
+    {}
+
+    ParseJob(const ParseJob&) = default;
+  };
+
+  /**
    * Defines file status categories for incremental parsing.
    */
   enum class IncrementalStatus
   {
-    UNCHANGED,
     MODIFIED,
     ADDED,
     DELETED,
@@ -48,9 +69,6 @@ private:
    * -o provided then the output file name will be a.out.  If the compile
    * command contains no source files then the function returns an empty map.
    */
-
-  std::unordered_map<std::string, IncrementalStatus> fileStatus;
-
   std::map<std::string, std::string> extractInputOutputs(
     const clang::tooling::CompileCommand& command_) const;
 
@@ -67,32 +85,11 @@ private:
   bool isNonSourceFlag(const std::string& arg_) const;
   bool parseByJson(const std::string& jsonFile_, std::size_t threadNum_);
   int worker(const clang::tooling::CompileCommand& command_);
-
-  void markAsModified(model::File file);
-
-  /**
-   * A single build command's cc::util::JobQueueThreadPool job.
-   */
-  struct ParseJob
-  {
-    /**
-     * The build command itself. This is given to CppParser::worker.
-     */
-    std::reference_wrapper<const clang::tooling::CompileCommand> command;
-
-    /**
-     * The # of the build command in the compilation command database.
-     */
-    std::size_t index;
-
-    ParseJob(const clang::tooling::CompileCommand& command, std::size_t index)
-      : command(command), index(index)
-    {}
-
-    ParseJob(const ParseJob&) = default;
-  };
+  void markAsModified(const model::File& file_);
+  void insertBuildActions();
 
   std::unordered_set<std::uint64_t> _parsedCommandHashes;
+  std::unordered_map<std::string, IncrementalStatus> _fileStatus;
 };
   
 } // parser

--- a/plugins/cpp/parser/include/cppparser/cppparser.h
+++ b/plugins/cpp/parser/include/cppparser/cppparser.h
@@ -26,7 +26,7 @@ public:
   CppParser(ParserContext& ctx_);
   virtual ~CppParser();  
   virtual std::vector<std::string> getDependentParsers() const override;
-  virtual void preparse() override;
+  virtual bool preparse() override;
   virtual bool parse() override;
 
 private:

--- a/plugins/cpp/parser/src/cppparser.cpp
+++ b/plugins/cpp/parser/src/cppparser.cpp
@@ -348,7 +348,7 @@ void CppParser::preparse()
                  filePtrs.begin(),
                  [this](const auto& item)
                  {
-                   if (item.second == cc::parser::IncrementalStatus::MODIFIED)
+                   if (item.second == IncrementalStatus::MODIFIED)
                    {
                      return _ctx.srcMgr.getFile(item.first);
                    }
@@ -438,7 +438,7 @@ void CppParser::incrementalParse()
         case IncrementalStatus::MODIFIED:
         case IncrementalStatus::DELETED:
         {
-          LOG(info) << "Database cleanup: " << item.first;
+          LOG(info) << "[cppparser] Database cleanup: " << item.first;
 
           // Fetch file from SourceManager by path
           model::FilePtr delFile = _ctx.srcMgr.getFile(item.first);
@@ -451,7 +451,7 @@ void CppParser::incrementalParse()
           {
             // Delete CppEntity
             auto delCppEntities = _ctx.db->query<model::CppEntity>(
-              odb::query<model::CppEntity>::mangledNameHash == astNode.mangledNameHash);
+              odb::query<model::CppEntity>::astNodeId == astNode.id);
             for (const model::CppEntity &entity : delCppEntities)
             {
               _ctx.db->erase<model::CppEntity>(entity.id);
@@ -505,9 +505,6 @@ void CppParser::incrementalParse()
               _ctx.db->erase<model::CppNode>(nodeId);
             }
           }
-
-          // Delete File and FileContent (only when no other File references it)
-          _ctx.srcMgr.removeFile(*delFile);
 
           break;
         }

--- a/plugins/cpp/parser/src/cppparser.cpp
+++ b/plugins/cpp/parser/src/cppparser.cpp
@@ -716,9 +716,7 @@ extern "C"
     description.add_options()
       ("skip-doccomment",
        "If this flag is given the parser will skip parsing the documentation "
-       "comments.")
-      ("incremental",
-       "Enable incremental parsing.");
+       "comments.");
     return description;
   }
 

--- a/plugins/cpp/test/src/cpppropertiesservicetest.cpp
+++ b/plugins/cpp/test/src/cpppropertiesservicetest.cpp
@@ -16,7 +16,7 @@ class CppPropertiesServiceTest : public ::testing::Test
 {
 public:
   CppPropertiesServiceTest() :
-    _db(cc::util::createDatabase(dbConnectionString)),
+    _db(cc::util::connectDatabase(dbConnectionString)),
     _transaction(_db),
     _cppservice(new CppServiceHandler(
       _db,

--- a/plugins/cpp/test/src/cppreferenceservicetest.cpp
+++ b/plugins/cpp/test/src/cppreferenceservicetest.cpp
@@ -17,7 +17,7 @@ class CppReferenceServiceTest : public ::testing::Test
 {
 public:
   CppReferenceServiceTest() :
-    _db(cc::util::createDatabase(dbConnectionString)),
+    _db(cc::util::connectDatabase(dbConnectionString)),
     _transaction(_db),
     _cppservice( new CppServiceHandler(
       _db,

--- a/plugins/git/parser/CMakeLists.txt
+++ b/plugins/git/parser/CMakeLists.txt
@@ -1,7 +1,8 @@
 include_directories(
   include
   ${PROJECT_SOURCE_DIR}/util/include
-  ${PROJECT_SOURCE_DIR}/parser/include)
+  ${PROJECT_SOURCE_DIR}/parser/include
+  ${PROJECT_SOURCE_DIR}/model/include)
 
 add_library(gitparser SHARED 
   src/gitparser.cpp)

--- a/plugins/git/parser/CMakeLists.txt
+++ b/plugins/git/parser/CMakeLists.txt
@@ -1,8 +1,7 @@
 include_directories(
   include
   ${PROJECT_SOURCE_DIR}/util/include
-  ${PROJECT_SOURCE_DIR}/parser/include
-  ${PROJECT_SOURCE_DIR}/model/include)
+  ${PROJECT_SOURCE_DIR}/parser/include)
 
 add_library(gitparser SHARED 
   src/gitparser.cpp)

--- a/plugins/metrics/parser/include/metricsparser/metricsparser.h
+++ b/plugins/metrics/parser/include/metricsparser/metricsparser.h
@@ -17,7 +17,7 @@ public:
   MetricsParser(ParserContext& ctx_);
   virtual std::vector<std::string> getDependentParsers() const override;  
   virtual bool parse() override;
-  virtual void preparse() override;
+  virtual bool preparse() override;
 
 private:
   util::DirIterCallback getParserCallback();

--- a/plugins/metrics/parser/include/metricsparser/metricsparser.h
+++ b/plugins/metrics/parser/include/metricsparser/metricsparser.h
@@ -17,6 +17,7 @@ public:
   MetricsParser(ParserContext& ctx_);
   virtual std::vector<std::string> getDependentParsers() const override;  
   virtual bool parse() override;
+  virtual void preparse() override;
 
 private:
   util::DirIterCallback getParserCallback();

--- a/plugins/metrics/parser/src/metricsparser.cpp
+++ b/plugins/metrics/parser/src/metricsparser.cpp
@@ -60,9 +60,13 @@ void MetricsParser::preparse()
         : _ctx.db->query<model::File>(
         odb::query<model::File>::id.in_range(_fileIdCache.begin(), _fileIdCache.end())))
       {
-        if(_ctx.fileStatus[file.path] == cc::parser::IncrementalStatus::DELETED ||
-           _ctx.fileStatus[file.path] == cc::parser::IncrementalStatus::MODIFIED)
+        auto it = _ctx.fileStatus.find(file.path);
+        if(it != _ctx.fileStatus.end() &&
+          (it->second == cc::parser::IncrementalStatus::DELETED ||
+           it->second == cc::parser::IncrementalStatus::MODIFIED))
         {
+          LOG(info) << "[metricsparser] Database cleanup: " << file.path;
+
           _ctx.db->erase_query<model::Metrics>(odb::query<model::Metrics>::file == file.id);
           _fileIdCache.erase(file.id);
         }

--- a/plugins/metrics/parser/src/metricsparser.cpp
+++ b/plugins/metrics/parser/src/metricsparser.cpp
@@ -23,7 +23,7 @@ namespace parser
 
 MetricsParser::MetricsParser(ParserContext& ctx_): AbstractParser(ctx_)
 {
-  (util::OdbTransaction(_ctx.db))([&, this] {
+  util::OdbTransaction {_ctx.db} ([&, this] {
     for (const model::MetricsFileIdView& mf
       : _ctx.db->query<model::MetricsFileIdView>())
     {
@@ -53,17 +53,17 @@ std::vector<std::string> MetricsParser::getDependentParsers() const
 
 bool MetricsParser::preparse()
 {
-  if(!_fileIdCache.empty())
+  if (!_fileIdCache.empty())
   {
     try
     {
-      (util::OdbTransaction(_ctx.db))([this] {
-        for(const model::File& file
+      util::OdbTransaction {_ctx.db} ([this] {
+        for (const model::File& file
           : _ctx.db->query<model::File>(
           odb::query<model::File>::id.in_range(_fileIdCache.begin(), _fileIdCache.end())))
         {
           auto it = _ctx.fileStatus.find(file.path);
-          if(it != _ctx.fileStatus.end() &&
+          if (it != _ctx.fileStatus.end() &&
              (it->second == cc::parser::IncrementalStatus::DELETED ||
               it->second == cc::parser::IncrementalStatus::MODIFIED))
           {
@@ -75,7 +75,7 @@ bool MetricsParser::preparse()
         }
       });
     }
-    catch(odb::database_exception&)
+    catch (odb::database_exception&)
     {
       LOG(fatal) << "Transaction failed in metrics parser!";
       return false;

--- a/plugins/search/parser/src/searchparser.cpp
+++ b/plugins/search/parser/src/searchparser.cpp
@@ -87,18 +87,9 @@ bool SearchParser::parse()
 {
   if (fs::is_directory(_searchDatabase))
   {
-    if (_ctx.options.count("force"))
-    {
-      fs::remove_all(_searchDatabase);
-      fs::create_directory(_searchDatabase);
-    }
-    else
-    {
-      LOG(info)
-        << "Skipping search parser, because search database already exists. "
-           "Use -f flag for forcing reparse.";
-      return true;
-    }
+    fs::remove_all(_searchDatabase);
+    fs::create_directory(_searchDatabase);
+    LOG(info) << "Search database already exists, dropping.";
   }
 
   for (const std::string& path :

--- a/util/include/util/dbutil.h
+++ b/util/include/util/dbutil.h
@@ -5,7 +5,6 @@
 #include <string>
 
 #include <odb/database.hxx>
-#include <odb/sqlite/exceptions.hxx>
 
 #ifdef DATABASE_PGSQL
 #  define SQL_ILIKE "ILIKE"

--- a/util/include/util/dbutil.h
+++ b/util/include/util/dbutil.h
@@ -5,6 +5,7 @@
 #include <string>
 
 #include <odb/database.hxx>
+#include <odb/sqlite/exceptions.hxx>
 
 #ifdef DATABASE_PGSQL
 #  define SQL_ILIKE "ILIKE"
@@ -23,8 +24,14 @@ namespace cc
 {
 namespace util
 {
-
-std::shared_ptr<odb::database> createDatabase(const std::string& connStr_);
+/**
+ * This function connects to and if required, optionally creates a database.
+ * @param connStr_ The database connection string.
+ * @param create_ True to create database if does not exist; otherwise, false.
+ */
+std::shared_ptr<odb::database> connectDatabase(
+  const std::string& connStr_,
+  bool create_ = true);
 
 /**
  * This function adds indexes to the database. These indexes are added from the

--- a/util/src/dbutil.cpp
+++ b/util/src/dbutil.cpp
@@ -130,9 +130,11 @@ void sqliteRegexImpl(
 
 #ifdef DATABASE_PGSQL
 /**
- * This function creates a postgres database if the database doesn't exists.
+ * This function checks the existance of a postgres database and
+ * optionally creates the database if it doesn't exists.
+ * @return True if the database exists after the function call; otherwise, false.
  */
-void createPsqlDatbase(const std::string& connStr_, const std::string dbName_)
+bool checkPsqlDatbase(const std::string& connStr_, const std::string dbName_, bool create_)
 {
   std::size_t colonPos = connStr_.find(':');
   std::string database = connStr_.substr(0, colonPos);
@@ -147,8 +149,10 @@ void createPsqlDatbase(const std::string& connStr_, const std::string dbName_)
   odb::connection_ptr connection = db.connection();
   try
   {
-    if (!connection->execute(
-      "SELECT 1 FROM pg_database WHERE datname = '" + dbName_ + "'"))
+    bool exists = connection->execute(
+      "SELECT 1 FROM pg_database WHERE datname = '" + dbName_ + "'") > 0;
+
+    if(!exists && create_)
     {
       std::string createCmd = "CREATE DATABASE " + dbName_
         + " ENCODING = 'SQL_ASCII'"
@@ -159,6 +163,11 @@ void createPsqlDatbase(const std::string& connStr_, const std::string dbName_)
 
       LOG(info) << "Creating database: " << dbName_;
     }
+
+    exists = connection->execute(
+      "SELECT 1 FROM pg_database WHERE datname = '" + dbName_ + "'") > 0;
+
+    return exists;
   }
   catch (const odb::exception& ex)
   {
@@ -259,7 +268,7 @@ namespace util
  */
 static std::map<std::string, std::shared_ptr<odb::database>> databasePool;
 
-std::shared_ptr<odb::database> createDatabase(const std::string& connStr_)
+std::shared_ptr<odb::database> connectDatabase(const std::string& connStr_, bool create_)
 {
   auto iter = databasePool.find(connStr_);
   if (iter != databasePool.end())
@@ -281,39 +290,41 @@ std::shared_ptr<odb::database> createDatabase(const std::string& connStr_)
 
   std::vector<std::string> odbOpts = createOdbOptions(options);
   char** cStyleOptions = createCStyleOptions(odbOpts);
+  int optionsSize = odbOpts.size();
 
   std::shared_ptr<odb::database> db;
-
-#ifdef DATABASE_MYSQL
-  if (database == "mysql")
-    db.reset(new odb::mysql::database(odbOpts.size(), cStyleOptions),
-      [](odb::database*){});
-#endif
 
 #ifdef DATABASE_SQLITE
   if (database == "sqlite")
   {
-    int optionsSize = odbOpts.size();
-    auto sqliteDB = new odb::sqlite::database(
-      optionsSize,
-      cStyleOptions,
-      false,
-      SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE,
-      true,
-      "",
-      std::make_unique<odb::sqlite::single_connection_factory>());
-    db.reset(sqliteDB, [](odb::database*){});
+    try
+    {
+      auto sqliteDB = new odb::sqlite::database(
+        optionsSize,
+        cStyleOptions,
+        false,
+        SQLITE_OPEN_READWRITE | (create_ ? SQLITE_OPEN_CREATE : 0),
+        true,
+        "",
+        std::make_unique<odb::sqlite::single_connection_factory>());
+      db.reset(sqliteDB, [](odb::database*){});
 
-    auto sqlitePtr = sqliteDB->connection()->handle();
-    sqlite3_create_function_v2(
-      sqlitePtr,
-      "regexp", 2, // regexp function with one argument
-      SQLITE_UTF8,
-      nullptr,
-      &sqliteRegexImpl,
-      nullptr,
-      nullptr,
-      nullptr);
+      auto sqlitePtr = sqliteDB->connection()->handle();
+      sqlite3_create_function_v2(
+        sqlitePtr,
+        "regexp", 2, // regexp function with one argument
+        SQLITE_UTF8,
+        nullptr,
+        &sqliteRegexImpl,
+        nullptr,
+        nullptr,
+        nullptr);
+    }
+    catch(odb::database_exception& e)
+    {
+      // Could not connect to DB
+      db.reset();
+    }
   }
 #endif
 
@@ -324,11 +335,16 @@ std::shared_ptr<odb::database> createDatabase(const std::string& connStr_)
       updateConnectionString(connStr_, "database", "postgres");
     std::string dbName = connStrComponent(connStr_, "database");
 
-    createPsqlDatbase(defaultPsqlConnStr, dbName);
-
-    int size = odbOpts.size();
-    db.reset(new odb::pgsql::database(size, cStyleOptions),
-      [](odb::database*){});
+    if(checkPsqlDatbase(defaultPsqlConnStr, dbName, create_))
+    {
+      db.reset(new odb::pgsql::database(optionsSize, cStyleOptions),
+               [](odb::database *) {});
+    }
+    else
+    {
+      // DB does not exists
+      db.reset();
+    }
   }
 #endif
 

--- a/util/src/dbutil.cpp
+++ b/util/src/dbutil.cpp
@@ -320,7 +320,7 @@ std::shared_ptr<odb::database> connectDatabase(const std::string& connStr_, bool
         nullptr,
         nullptr);
     }
-    catch(odb::database_exception& e)
+    catch (odb::database_exception& e)
     {
       // Could not connect to DB
       db.reset();

--- a/util/src/dbutil.cpp
+++ b/util/src/dbutil.cpp
@@ -335,10 +335,10 @@ std::shared_ptr<odb::database> connectDatabase(const std::string& connStr_, bool
       updateConnectionString(connStr_, "database", "postgres");
     std::string dbName = connStrComponent(connStr_, "database");
 
-    if(checkPsqlDatbase(defaultPsqlConnStr, dbName, create_))
+    if (checkPsqlDatbase(defaultPsqlConnStr, dbName, create_))
     {
       db.reset(new odb::pgsql::database(optionsSize, cStyleOptions),
-               [](odb::database *) {});
+               [](odb::database*) {});
     }
     else
     {

--- a/webserver/include/webserver/pluginhelper.h
+++ b/webserver/include/webserver/pluginhelper.h
@@ -54,7 +54,7 @@ inline void registerPluginSimple(
       "database",
       dbName);
 
-    std::shared_ptr<odb::database> db = util::createDatabase(connStr);
+    std::shared_ptr<odb::database> db = util::connectDatabase(connStr);
 
     if (!db)
     {


### PR DESCRIPTION
Initial support for incremental parsing. Incremental parsing mode is carried out automatically in case both the specified database and the project workspace directory exist.
The main objectives were the following.

### Refactor the parser architecture
The `parse()` method of `AbstractParser` was separated into 2 phases: `preparse()` and `parse()`.
First, the `preparse()`  method for all parsers are evaluated (in reverse topological order), which are responsible for the database and project workspace maintenance for incremental parsing. Then, parsing on a cleaned up environment is carried out by the `parse()` methods for each parser in a same way as a "normal", initial parse.

Deleted and modified files are detected by the `ParserContext` and this is information is made available towards each parser.

### Implement incremental support for the parsers
- **CppParser**: all information regarding the deleted and modified files are cleaned up from the database, these files are treated as new files and parsed accordingly. Files along the header inclusion chains are also marked modified if a header file was edited.
- **MetricsParser:** all information regarding the deleted and modified files are cleaned up from the database, these files are treated as new files and parsed accordingly.
- **SearchParser:** the `search` directory in the project workspace is deleted and a new, complete parsing is carried out.
- **GitParser:** the repository directory under the `version` directory in the project workspace is deleted and a new, complete parsing is carried out.
