### PR TITLE
Show parameters for member functions, cross out explicit deletes, don't show implicits "-1" line

### DIFF
--- a/plugins/cpp/model/include/model/common.h
+++ b/plugins/cpp/model/include/model/common.h
@@ -23,7 +23,8 @@ enum Tag
   Static  = 3,
   Implicit = 4,
   Global = 5,
-  Constant = 6
+  Constant = 6,
+  UserDeleted = 7
 };
 
 inline std::string visibilityToString(Visibility v_)
@@ -43,7 +44,8 @@ inline std::string tagToString(Tag t_)
     t_ == Static        ? "static" :
     t_ == Implicit      ? "implicit" :
     t_ == Global        ? "global" :
-    t_ == Constant      ? "constant" : "";
+    t_ == Constant      ? "constant" :
+    t_ == UserDeleted   ? "user-deleted" : "";
 }
 
 }

--- a/plugins/cpp/parser/src/clangastvisitor.h
+++ b/plugins/cpp/parser/src/clangastvisitor.h
@@ -624,6 +624,9 @@ public:
         cppFunction->tags.insert(model::Tag::Destructor);
     }
 
+    if (fn_->isDeletedAsWritten())
+      cppFunction->tags.insert(model::Tag::UserDeleted);
+
     if (_isImplicit)
       cppFunction->tags.insert(model::Tag::Implicit);
 

--- a/plugins/cpp/service/src/cppservice.cpp
+++ b/plugins/cpp/service/src/cppservice.cpp
@@ -295,7 +295,7 @@ void CppServiceHandler::getProperties(
         return_["Name"] = function.qualifiedName.substr(
           function.qualifiedName.find_last_of(':') + 1);
         return_["Qualified name"] = function.qualifiedName;
-        return_["Signature"] = function.name;
+        return_["Signature"] = node.astValue;
 
         break;
       }

--- a/plugins/cpp/webgui/js/cppInfoTree.js
+++ b/plugins/cpp/webgui/js/cppInfoTree.js
@@ -26,6 +26,9 @@ function (model, viewHandler, util) {
       label += '<span class="tag tag-virtual" title="Virtual">V</span>';
     if (tags.indexOf('global') > -1)
       label += '<span class="tag tag-global" title="Global">G</span>';
+    if (tags.indexOf('user-deleted') > -1)
+      label +=
+        '<span class="tag tag-user-deleted" title="User deleted">X</span>';
 
     return label;
   }
@@ -38,11 +41,13 @@ function (model, viewHandler, util) {
     var labelClass = '';
 
     if (astNodeInfo.tags.indexOf('implicit') > -1)
-      labelClass = 'label-implicit';
+      labelClass += 'label-implicit ';
+    if (astNodeInfo.tags.indexOf('user-deleted') > -1)
+      labelClass += 'label-user-deleted ';
 
     var labelValue = astNodeInfo.astNodeValue;
 
-    // Create dom node for return type of a function and place it at the end of
+    // Create DOM node for return type of a function and place it at the end of
     // signature.
     if (astNodeInfo.symbolType === 'Function') {
       var init = labelValue.slice(0, labelValue.indexOf('('));
@@ -51,7 +56,7 @@ function (model, viewHandler, util) {
       //--- Constructor, destructor doesn't have return type ---//
 
       if (returnTypeEnd !== -1) {
-        var funcSignature = init.slice(returnTypeEnd);
+        var funcSignature = labelValue.slice(returnTypeEnd);
 
         labelValue = funcSignature
           + ' : <span class="label-return-type">'
@@ -61,11 +66,14 @@ function (model, viewHandler, util) {
     }
 
     var label = createTagLabels(astNodeInfo.tags)
-      + '<span class="' + labelClass + '">'
-      + astNodeInfo.range.range.startpos.line   + ':'
-      + astNodeInfo.range.range.startpos.column + ': '
-      + labelValue
-      + '</span>';
+      + '<span class="' + labelClass + '">';
+
+    if (astNodeInfo.range.range.startpos.line != -1) {
+      label += astNodeInfo.range.range.startpos.line + ':'
+        + astNodeInfo.range.range.startpos.column + ': '
+    }
+
+    label += labelValue + '</span>';
 
     return label;
   }
@@ -335,7 +343,7 @@ function (model, viewHandler, util) {
                 return loadReferenceNodes(this, elementInfo, refTypes);
               }
             });
-        };
+        }
 
       } else if (elementInfo instanceof FileInfo) {
 
@@ -358,7 +366,7 @@ function (model, viewHandler, util) {
                 return loadFileReferenceNodes(this);
               }
             });
-        };
+        }
 
       }
 

--- a/webgui/style/codecompass.css
+++ b/webgui/style/codecompass.css
@@ -218,8 +218,18 @@ svg {
   color: #fff;
 }
 
+.tag-user-deleted {
+  background-color: #812d06;
+  color: #fff;
+}
+
 .label-implicit {
   color: grey;
+}
+
+.label-user-deleted {
+  color: grey;
+  text-decoration: line-through #812d06;
 }
 
 .label-return-type {


### PR DESCRIPTION
> Closes #302.

 - Fixed an issue with the InfoTree for a C++ function returned the name of the function as *signature*, as opposed to the real signature stored in the database.
 - The listing of methods for a type listed only the name and return value of methods, without their parameters. This made distinguishing overloads impossible: from a glance at the method list, one could not deduce what overloads exist for the type.
 - The "source range" for implicit methods is invalid (`-1` is saved and returned), and thus isn't a useful information to show on the API.
 - If the user explicitly `= delete`s an implicit generated function or an overload, show the delete in the info tree with a new special marker.

Current behaviour with the problems:
![image](https://user-images.githubusercontent.com/1969470/43088605-d82d0cfa-8ea2-11e8-9582-324edc439b2c.png)
![image](https://user-images.githubusercontent.com/1969470/43088587-cf83a29e-8ea2-11e8-87e8-eccc3829814b.png)
![image](https://user-images.githubusercontent.com/1969470/43088866-88fbb252-8ea3-11e8-90eb-f6aa5207fe2e.png)

New behaviour introduced by this patch:
![image](https://user-images.githubusercontent.com/1969470/43089036-f5a18a62-8ea3-11e8-8a26-a074c19851c8.png)
![image](https://user-images.githubusercontent.com/1969470/43089247-763407e0-8ea4-11e8-94a5-48e3e1cb3e7e.png)
![image](https://user-images.githubusercontent.com/1969470/43089231-6ab974f4-8ea4-11e8-834e-3dd746d1ebd7.png)
