### PR TITLE
Fix type conversion build issues with G++

### DIFF
--- a/doc/deps.md
+++ b/doc/deps.md
@@ -12,9 +12,9 @@ packages are necessary for building CodeCompass:
 - **`g++`**: For compiling CodeCompass. A version which supports C++14 features
   is required. (Alternatively, you can compile with Clang.)
 - **`libboost-all-dev`**: Boost can be used during the development.
-- **llvm-7.0**, **clang-7.0**: For compiling CodeCompass with Clang instead of
-  G++.
-- **llvm-7.0-dev**, **libclang-7.0-dev**: C++ parser uses LLVM/Clang for
+- **`llvm-7.0`**, **`clang-7.0`**: For compiling CodeCompass with Clang
+  instead of G++.
+- **`llvm-7.0-dev`**, **`libclang-7.0-dev`**: C++ parser uses LLVM/Clang for
   parsing the source code. Version 7.0 or newer is required. Clang 7 is not yet
   released, so the project must be compiled manually from source.
   ***See [Known issues](#known-issues)!***
@@ -60,7 +60,6 @@ impossible to recover. **Please do NOT add a `sudo` in front of any `make` or
 other commands below, unless *explicitly* specified!**
 
 ### Thrift
-=======
 CodeCompass needs [Thrift](https://thrift.apache.org/) which provides Remote
 Procedure Call (RPC) between the server and the client. Thrift is not part of
 the official Ubuntu 16.04 LTS repositories, but you can download it and build
@@ -96,7 +95,7 @@ make install
 In Ubuntu 16.04 LTS the LLVM/Clang has some packaging issues, i.e. some libs
 are searched in `/usr/lib` however the package has these in
 `/usr/lib/llvm-3.8/lib` (see
-[http://stackoverflow.com/questions/38171543/error-when-using-cmake-with-llvm](http://stackoverflow.com/questions/38171543/error-when-using-cmake-with-llvm)
+[`http://stackoverflow.com/questions/38171543/error-when-using-cmake-with-llvm`](http://stackoverflow.com/questions/38171543/error-when-using-cmake-with-llvm)
 . This problem causes an error when emitting `cmake` command during CodeCompass
 build. A solution would be to download a prebuilt package from the LLVM/Clang
 webpage but another issue is that the prebuilt packages don't use runtime type
@@ -138,7 +137,7 @@ make install
 ```
 
 ### ODB
-As of `gcc` version 5 the ABI has changed which practically means that some
+As of `gcc` version 5, the ABI has changed which practically means that some
 symbols in `std` namespace (like `std::string` and `std::list`) contain
 `__cxx11` in their mangled names. This results linkage errors if the compiled
 project has libraries compiled with an earlier version of `gcc`.
@@ -197,7 +196,9 @@ cd ..
 #### Ubuntu 18.04 LTS
 On Ubuntu 18.04, the default version of GNU/GCC is version 7, which considers
 the current release version of ODB invalid. Due to this error, **ODB's
-compilation must manually fall back to using GCC 5**.
+compilation must manually fall back to using GCC/G++ 5**. (This only applies
+to ODB. The rest of the manually built dependencies, and CodeCompass itself can
+and should be compiled with GCC/G++ 7!)
 
 ```bash
 sudo apt-get install g++-5 gcc-5-plugin-dev libcutl-dev libexpat1-dev
@@ -239,11 +240,11 @@ export PATH=<odb_install_dir>/bin:$PATH
 Use the following instructions to build CodeCompass with CMake.
 
 ```bash
-# Obtain CodeCompass source code
+# Obtain CodeCompass source code.
 git clone https://github.com/Ericsson/CodeCompass.git
 cd CodeCompass
 
-# Create build directory
+# Create build directory.
 mkdir build
 cd build
 
@@ -253,10 +254,10 @@ cmake .. \
   -DDATABASE=<database_type> \
   -DCMAKE_BUILD_TYPE=<build_type>
 
-# Build project
+# Build project.
 make -j<number_of_threads>
 
-# Copy files to install directory
+# Copy files to install directory.
 make install
 ```
 
@@ -267,7 +268,7 @@ during compilation.
 
 | Variable | Meaning |
 | -------- | ------- |
-| `CMAKE_INSTALL_PREFIX` | Install directory. For more information see: https://cmake.org/cmake/help/v3.0/variable/CMAKE_INSTALL_PREFIX.html |
-| `CMAKE_BUILD_TYPE` | Specifies the build type on single-configuration generators. Possible values are empty, **Debug**, **Release**. For more information see: https://cmake.org/cmake/help/v3.0/variable/CMAKE_BUILD_TYPE.html |
-| `CMAKE_CXX_COMPILER` | If the official repository of your Linux distribution doesn't contain a C++ compiler which supports C++14 then you can install one manually and set to use it. For more information see: https://cmake.org/Wiki/CMake_Useful_Variables |
-| `DATABASE` | Database type. Possible values are **sqlite**, **pgsql**. The default value is `sqlite`. |
+| [`CMAKE_INSTALL_PREFIX`](http://cmake.org/cmake/help/v3.0/variable/CMAKE_INSTALL_PREFIX.html) | Install directory. |
+| [`CMAKE_BUILD_TYPE`](http://cmake.org/cmake/help/v3.0/variable/CMAKE_BUILD_TYPE.html)| Specifies the build type on single-configuration generators. Possible values are empty, **`Debug`**, **`Release`**. |
+| `CMAKE_CXX_COMPILER` | If the official repository of your Linux distribution doesn't contain a C++ compiler which supports C++14 then you can install one manually and set to use it. For more information see: [Useful CMake Variables](http://cmake.org/Wiki/CMake_Useful_Variables). |
+| `DATABASE` | Database type. Possible values are **`sqlite`**, **`pgsql`**. The default value is `sqlite`. |

--- a/plugins/cpp_reparse/service/src/asthtml.cpp
+++ b/plugins/cpp_reparse/service/src/asthtml.cpp
@@ -123,6 +123,7 @@ public:
         break;
       case raw_ostream::WHITE:
         _name = "white";
+        break;
       case raw_ostream::SAVEDCOLOR:
       default:
         _name = "";

--- a/plugins/cpp_reparse/service/src/databasefilesystem.cpp
+++ b/plugins/cpp_reparse/service/src/databasefilesystem.cpp
@@ -220,7 +220,7 @@ DatabaseFileSystem::openFileForRead(const Twine& path_)
       fileToStatus(*_db, *file),
       std::move(file->content.load()->content));
   });
-  return dbFile;
+  return std::move(dbFile);
 }
 
 directory_iterator


### PR DESCRIPTION
In C++, it is not necessary to write `std::move` in a `return` statement referring to an **l**value (for RVO, it is also not a good practice to do so!) if the return value can be move-constructed from said expression. For example, the following code is valid, the return is move-constructed.

```c++
std::unique_ptr<Foo> foo()
{
  std::unique_ptr<Foo> myFoo;
  // ...
  return myFoo;
}
```
 
However, in the case of nested types, G++ does not properly handle this case. In case `T<U<V>>` can be move-constructed from an `U<V>` (such is the case in the actual file with `llvm::ErrorOr<U<V>>`), G++ still throws an error. (Clang 5.0 and newer compilers bind this reference properly without an error.)

```
error: could not convert ‘dbFile’ from ‘std::unique_ptr<clang::vfs::File>’
  to ‘llvm::ErrorOr<std::unique_ptr<clang::vfs::File> >’
   return dbFile;
```