### PR TITLE
Follow Clang signature changes

### DIFF
--- a/plugins/cpp/parser/src/ppincludecallback.cpp
+++ b/plugins/cpp/parser/src/ppincludecallback.cpp
@@ -65,7 +65,8 @@ void PPIncludeCallback::InclusionDirective(
   const clang::FileEntry*,
   clang::StringRef searchPath_,
   clang::StringRef,
-  const clang::Module*)
+  const clang::Module*,
+  clang::SrcMgr::CharacteristicKind)
 {
   if (searchPath_.empty())
     return;

--- a/plugins/cpp/parser/src/ppincludecallback.h
+++ b/plugins/cpp/parser/src/ppincludecallback.h
@@ -41,7 +41,8 @@ public:
     const clang::FileEntry *File,
     clang::StringRef SearchPath,
     clang::StringRef RelativePath,
-    const clang::Module *Imported) override;
+    const clang::Module *Imported,
+    clang::SrcMgr::CharacteristicKind FileType) override;
 
 private:
   /**


### PR DESCRIPTION
A function signature changed in Clang which must be followed in our
overload.