### PR TITLE
Follow Clang signature changes (update for LLVM/Clang 7.0)

### DIFF
--- a/doc/deps.md
+++ b/doc/deps.md
@@ -102,30 +102,23 @@ webpage but another issue is that the prebuilt packages don't use runtime type
 informations (RTTI) which is needed for CodeCompass. Clang needs to be compiled
 with RTTI manually.
 
-Additionally, LLVM 7.0 has not yet been made into a full release, it is only
-available as the current in-development version. However, certain CodeCompass
-features depend on these features.
-
 ```bash
-sudo apt-get install unzip
-
 # If you want Clang's diagnostic output to have colours, install the following.
 sudo apt-get install libtinfo-dev
 
-wget https://github.com/llvm-mirror/llvm/archive/d79c539c3b03f5e05ff3a528a8e4d9bfce121d69.zip -O llvm.zip
-unzip llvm.zip
-rm llvm.zip
+wget http://releases.llvm.org/7.0.0/llvm-7.0.0.src.tar.xz
+tar -xvf llvm-7.0.0.src.tar.xz
+rm llvm-7.0.0.src.tar.xz
 mv llvm-* llvm
 cd llvm/tools
-wget https://github.com/llvm-mirror/clang/archive/e2fbe37780ca1bad55fbdb18a8c448d7156a932d.zip -O clang.zip
-unzip clang.zip
-rm clang.zip
-mv clang-* clang
+wget http://releases.llvm.org/7.0.0/cfe-7.0.0.src.tar.xz
+tar -xvf cfe-7.0.0.src.tar.xz
+rm cfe-7.0.0.src.tar.xz
+mv cfe-* clang
 cd ../..
 
 mkdir build
 cd build
-export REQUIRES_RTTI=1
 cmake -G "Unix Makefiles" \
   -DCMAKE_BUILD_TYPE=Release \
   -DLLVM_ENABLE_RTTI=ON \

--- a/plugins/cpp/parser/src/ppincludecallback.cpp
+++ b/plugins/cpp/parser/src/ppincludecallback.cpp
@@ -65,7 +65,8 @@ void PPIncludeCallback::InclusionDirective(
   const clang::FileEntry*,
   clang::StringRef searchPath_,
   clang::StringRef,
-  const clang::Module*)
+  const clang::Module*,
+  clang::SrcMgr::CharacteristicKind)
 {
   if (searchPath_.empty())
     return;

--- a/plugins/cpp/parser/src/ppincludecallback.h
+++ b/plugins/cpp/parser/src/ppincludecallback.h
@@ -41,7 +41,8 @@ public:
     const clang::FileEntry *File,
     clang::StringRef SearchPath,
     clang::StringRef RelativePath,
-    const clang::Module *Imported) override;
+    const clang::Module *Imported,
+    clang::SrcMgr::CharacteristicKind FileType) override;
 
 private:
   /**


### PR DESCRIPTION
A function signature changed in Clang which must be followed in our
overload.

Moreover the documentation is updated to use Clang 7.