### PR TITLE
Dry-run incremental parsing & fixes

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -176,6 +176,10 @@ compilation database will always contain all files.
 Currently the C++ and metrics parsers support incremental parsing, while other parsers
 just execute a forced reparse.
 
+In order to review the changes detected by the incremental parser without performing any
+action that would alter the workspace database or directory, the `--dry-run` command line 
+option can be specified for `CodeCompass_parser`.
+
 ## 3. Start the web server
 You can start the CodeCompass webserver with `CodeCompass_webserver` binary in
 the CodeCompass installation directory.

--- a/parser/include/parser/abstractparser.h
+++ b/parser/include/parser/abstractparser.h
@@ -36,9 +36,11 @@ public:
   /**
    * Maintains and cleans up the database in preparation of
    * incremental parsing.
+   * @param dry_ When true, perform a dry-run and only detect the changed files,
+   * but do not execute any maintenance actions.
    * @return Return true if the preparse was success, false otherwise.
    */
-  virtual bool preparse()
+  virtual bool preparse(bool dry_ = false)
   {
     return true;
   }

--- a/parser/include/parser/abstractparser.h
+++ b/parser/include/parser/abstractparser.h
@@ -15,7 +15,7 @@ class AbstractParser
 {
 public:
   /**
-   * Constructor, initalize the parsers
+   * Constructor, initialize the parsers
    * @param ctx_ - Parser context options
    */
   AbstractParser(ParserContext& ctx_) : _ctx(ctx_){} 

--- a/parser/src/parser.cpp
+++ b/parser/src/parser.cpp
@@ -74,7 +74,11 @@ po::options_description commandLineArguments()
     ("skip,s", po::value<std::vector<std::string>>(),
       "This is a list of parsers which will be omitted during the parsing "
       "process. The possible values are the plugin names which can be listed "
-      "by --list flag.");
+      "by --list flag.")
+    ("dry-run",
+     "Performs a dry on the incremental parsing maintenance,"
+     "listing the detected changes, but without executing any"
+     "further actions modifying the state of the database.");
 
   return desc;
 }
@@ -227,7 +231,17 @@ int main(int argc, char* argv[])
   }
 
   if (!isNewDb)
-    LOG(info) << "Project already exists, incremental parsing in action.";
+  {
+    LOG(info) << "Project already exists, incremental parsing in action"
+              << (vm.count("dry-run") ? " (DRY RUN)" : "") << ".";
+  }
+
+  if (isNewDb && vm.count("dry-run"))
+  {
+    LOG(warning) << "Dry-run can be only used with incremental parsing, "
+                    "no project found, turning --dry-run off.";
+    vm.erase("dry-run");
+  }
 
   //--- Prepare workspace and project directory ---//
   
@@ -266,44 +280,66 @@ int main(int argc, char* argv[])
   for (auto it = topologicalOrder.rbegin(); it != topologicalOrder.rend(); ++it)
   {
     LOG(info) << "[" << *it << "] preparse started!";
-    if (!pHandler.getParser(*it)->preparse())
+    if (!pHandler.getParser(*it)->preparse(vm.count("dry-run")))
     {
       LOG(error) << "[" << *it << "] preparse failed!";
       return 2;
     }
   }
 
-  // TODO: Consider whether there is a better place for this code.
-  cc::util::OdbTransaction {ctx.db} ([&]
+  if(vm.count("dry-run"))
   {
+    LOG(info) << "[Incremental parsing] Detected change list:";
     for (const auto& item : ctx.fileStatus)
     {
-      switch (item.second)
+      switch(item.second)
       {
-        case cc::parser::IncrementalStatus::MODIFIED:
-        case cc::parser::IncrementalStatus::DELETED:
-        {
-          LOG(info) << "Database cleanup: " << item.first;
-
-          // Fetch file from SourceManager by path
-          cc::model::FilePtr delFile = srcMgr.getFile(item.first);
-
-          // Delete File and FileContent (only when no other File references it)
-          srcMgr.removeFile(*delFile);
-          break;
-        }
         case cc::parser::IncrementalStatus::ADDED:
-          // Empty deliberately
+          LOG(info) << "ADDED file: " << item.first;
+          break;
+        case cc::parser::IncrementalStatus::MODIFIED:
+          LOG(info) << "MODIFIED file: " << item.first;
+          break;
+        case cc::parser::IncrementalStatus::DELETED:
+          LOG(info) << "DELETED file: " << item.first;
           break;
       }
     }
-  });
-
-  // TODO: Handle errors returned by parse().
-  for (const std::string& parserName : topologicalOrder)
+  }
+  else
   {
-    LOG(info) << "[" << parserName << "] parse started!";
-    pHandler.getParser(parserName)->parse();
+    // TODO: Consider whether there is a better place for this code.
+    cc::util::OdbTransaction {ctx.db} ([&]
+    {
+      for (auto& item : ctx.fileStatus)
+      {
+        switch (item.second)
+        {
+          case cc::parser::IncrementalStatus::MODIFIED:
+          case cc::parser::IncrementalStatus::DELETED:
+          {
+            LOG(info) << "Database cleanup: " << item.first;
+
+            // Fetch file from SourceManager by path
+            cc::model::FilePtr delFile = srcMgr.getFile(item.first);
+
+            // Delete File and FileContent (only when no other File references it)
+            srcMgr.removeFile(*delFile);
+            break;
+          }
+          case cc::parser::IncrementalStatus::ADDED:
+            // Empty deliberately
+            break;
+        }
+      }
+    });
+
+    // TODO: Handle errors returned by parse().
+    for (const std::string& parserName : pHandler.getTopologicalOrder())
+    {
+      LOG(info) << "[" << parserName << "] parse started!";
+      pHandler.getParser(parserName)->parse();
+    }
   }
 
   //--- Add indexes to the database ---//

--- a/parser/src/parsercontext.cpp
+++ b/parser/src/parsercontext.cpp
@@ -54,8 +54,8 @@ ParserContext::ParserContext(
 
            std::ifstream fileStream(file->path);
            std::string fileContent(
-               (std::istreambuf_iterator<char>(fileStream)),
-               (std::istreambuf_iterator<char>()));
+             std::istreambuf_iterator<char>{fileStream},
+             std::istreambuf_iterator<char>{});
            fileStream.close();
 
            if (content->hash != util::sha1Hash(fileContent))
@@ -69,7 +69,7 @@ ParserContext::ParserContext(
        else
        {
          fileStatus.emplace(
-             file->path, cc::parser::IncrementalStatus::DELETED);
+           file->path, cc::parser::IncrementalStatus::DELETED);
          LOG(debug) << "File deleted: " << file->path;
        }
      }

--- a/plugins/cpp/parser/include/cppparser/cppparser.h
+++ b/plugins/cpp/parser/include/cppparser/cppparser.h
@@ -26,7 +26,7 @@ public:
   CppParser(ParserContext& ctx_);
   virtual ~CppParser();  
   virtual std::vector<std::string> getDependentParsers() const override;
-  virtual bool preparse() override;
+  virtual bool preparse(bool dry_) override;
   virtual bool parse() override;
 
 private:
@@ -82,8 +82,7 @@ private:
   int worker(const clang::tooling::CompileCommand& command_);
   
   void initBuildActions();
-  void markAsModified(model::FilePtr file_);
-  std::set<model::CppNodeId> collectNodeSet(model::CppNodeId node_) const;
+  void markByInclusion(model::FilePtr file_);
 
   std::unordered_set<std::uint64_t> _parsedCommandHashes;
 

--- a/plugins/cpp/parser/src/cppparser.cpp
+++ b/plugins/cpp/parser/src/cppparser.cpp
@@ -339,7 +339,7 @@ std::vector<std::string> CppParser::getDependentParsers() const
   return std::vector<std::string>{};
 }
 
-bool CppParser::preparse()
+bool CppParser::preparse(bool dry_)
 {
   std::vector<model::FilePtr> filePtrs(_ctx.fileStatus.size());
 
@@ -358,107 +358,114 @@ bool CppParser::preparse()
                    }
                  });
 
-  try
+  // Detect changed files through C++ header inclusions.
+  util::OdbTransaction {_ctx.db} ([&]
   {
-    util::OdbTransaction {_ctx.db} ([&]
+    for (const model::FilePtr file : filePtrs)
     {
-      for (const model::FilePtr& file : filePtrs)
+      if(file)
       {
-        if(file)
-        {
-          markAsModified(file);
-        }
+        markByInclusion(file);
       }
+    }
+  }); // end of transaction
 
-      for (auto& item : _ctx.fileStatus)
+  // Perform maintenance actions.
+  if(!dry_)
+  {
+    try
+    {
+      util::OdbTransaction{_ctx.db}([&]
       {
-        switch (item.second)
+        for (auto &item : _ctx.fileStatus)
         {
-          case IncrementalStatus::MODIFIED:
-          case IncrementalStatus::DELETED:
+          switch (item.second)
           {
-            LOG(info) << "[cppparser] Database cleanup: " << item.first;
-
-            // Fetch file from SourceManager by path
-            model::FilePtr delFile = _ctx.srcMgr.getFile(item.first);
-
-            // Query CppAstNode
-            auto defCppAstNodes = _ctx.db->query<model::CppAstNode>(
-              odb::query<model::CppAstNode>::location.file == delFile->id &&
-              odb::query<model::CppAstNode>::astType == model::CppAstNode::AstType::Definition);
-            for (const model::CppAstNode& astNode : defCppAstNodes)
+            case IncrementalStatus::MODIFIED:
+            case IncrementalStatus::DELETED:
             {
-              // Delete CppEntity
-              auto delCppEntities = _ctx.db->query<model::CppEntity>(
-                odb::query<model::CppEntity>::astNodeId == astNode.id);
-              for (const model::CppEntity& entity : delCppEntities)
-              {
-                _ctx.db->erase<model::CppEntity>(entity.id);
-              }
+              LOG(info) << "[cppparser] Database cleanup: " << item.first;
 
-              // Delete CppInheritance
-              auto delCppInheritance = _ctx.db->query<model::CppInheritance>(
-                odb::query<model::CppInheritance>::derived == astNode.mangledNameHash);
-              for (const model::CppInheritance& inheritance : delCppInheritance)
-              {
-                _ctx.db->erase<model::CppInheritance>(inheritance.id);
-              }
+              // Fetch file from SourceManager by path
+              model::FilePtr delFile = _ctx.srcMgr.getFile(item.first);
 
-              // Delete CppFriendship
-              auto delCppFriendship = _ctx.db->query<model::CppFriendship>(
-                odb::query<model::CppFriendship>::target == astNode.mangledNameHash);
-              for (const model::CppFriendship& friendship : delCppFriendship)
+              // Query CppAstNode
+              auto defCppAstNodes = _ctx.db->query<model::CppAstNode>(
+                odb::query<model::CppAstNode>::location.file == delFile->id &&
+                odb::query<model::CppAstNode>::astType ==
+                model::CppAstNode::AstType::Definition);
+              for (const model::CppAstNode &astNode : defCppAstNodes)
               {
-                _ctx.db->erase<model::CppFriendship>(friendship.id);
-              }
-
-              // Delete CppNode (connected to CppAstNode) with all its connected CppNodes
-              auto delNodes = _ctx.db->query<model::CppNode>(
-                odb::query<model::CppNode>::domainId == std::to_string(astNode.id) &&
-                odb::query<model::CppNode>::domain == model::CppNode::CPPASTNODE);
-              for (model::CppNode& node : delNodes)
-              {
-                for (model::CppNodeId nodeId : collectNodeSet(node.id))
+                // Delete CppEntity
+                auto delCppEntities = _ctx.db->query<model::CppEntity>(
+                  odb::query<model::CppEntity>::astNodeId == astNode.id);
+                for (const model::CppEntity &entity : delCppEntities)
                 {
-                  _ctx.db->erase<model::CppNode>(nodeId);
+                  _ctx.db->erase<model::CppEntity>(entity.id);
+                }
+
+                // Delete CppInheritance
+                auto delCppInheritance = _ctx.db->query<model::CppInheritance>(
+                  odb::query<model::CppInheritance>::derived == astNode.mangledNameHash);
+                for (const model::CppInheritance &inheritance : delCppInheritance)
+                {
+                  _ctx.db->erase<model::CppInheritance>(inheritance.id);
+                }
+
+                // Delete CppFriendship
+                auto delCppFriendship = _ctx.db->query<model::CppFriendship>(
+                  odb::query<model::CppFriendship>::target == astNode.mangledNameHash);
+                for (const model::CppFriendship &friendship : delCppFriendship)
+                {
+                  _ctx.db->erase<model::CppFriendship>(friendship.id);
+                }
+
+                // Delete CppNode (connected to CppAstNode) with all its connected CppNodes
+                auto delNodes = _ctx.db->query<model::CppNode>(
+                  odb::query<model::CppNode>::domainId == std::to_string(astNode.id) &&
+                  odb::query<model::CppNode>::domain == model::CppNode::CPPASTNODE);
+                for (model::CppNode &node : delNodes)
+                {
+                  _ctx.db->erase<model::CppNode>(node.id);
+                  // TODO: handle that RelationCollector will try to reinsert the other end of the relation
+                  // Raises "[WARNING] object already persistent"
                 }
               }
-            }
 
-            // Delete BuildAction
-            auto delSources = _ctx.db->query<model::BuildSource>(
-              odb::query<model::BuildSource>::file == delFile->id);
-            for (const model::BuildSource& source : delSources)
-            {
-              _ctx.db->erase<model::BuildAction>(source.action->id);
-            }
-
-            // Delete CppNode (connected to File) with all its connected CppNodes
-            auto delNodes = _ctx.db->query<model::CppNode>(
-              odb::query<model::CppNode>::domainId == std::to_string(delFile->id) &&
-              odb::query<model::CppNode>::domain == model::CppNode::FILE);
-            for (model::CppNode& node : delNodes)
-            {
-              for (model::CppNodeId nodeId : collectNodeSet(node.id))
+              // Delete BuildAction
+              auto delSources = _ctx.db->query<model::BuildSource>(
+                odb::query<model::BuildSource>::file == delFile->id);
+              for (const model::BuildSource &source : delSources)
               {
-                _ctx.db->erase<model::CppNode>(nodeId);
+                _ctx.db->erase<model::BuildAction>(source.action->id);
               }
+
+              // Delete CppNode (connected to File) with all its connected CppNodes
+              auto delNodes = _ctx.db->query<model::CppNode>(
+                odb::query<model::CppNode>::domainId == std::to_string(delFile->id) &&
+                odb::query<model::CppNode>::domain == model::CppNode::FILE);
+              for (model::CppNode &node : delNodes)
+              {
+                _ctx.db->erase<model::CppNode>(node.id);
+                // TODO: handle that RelationCollector will try to reinsert the other end of the relation
+                // Raises "[WARNING] object already persistent"
+              }
+
+              break;
             }
 
-            break;
+            case IncrementalStatus::ADDED:
+              // Empty deliberately
+              break;
           }
-
-          case IncrementalStatus::ADDED:
-            // Empty deliberately
-            break;
         }
-      }
-    }); // end of transaction
-  }
-  catch (odb::database_exception&)
-  {
-    LOG(fatal) << "Transaction failed in C++ parser!";
-    return false;
+      });
+    }
+    catch (odb::database_exception&)
+    {
+      LOG(fatal) << "Transaction failed in C++ parser!";
+      return false;
+    }
   }
 
   return true;
@@ -491,7 +498,7 @@ void CppParser::initBuildActions()
   });
 }
 
-void CppParser::markAsModified(const model::FilePtr file_)
+void CppParser::markByInclusion(model::FilePtr file_)
 {
   auto inclusions = _ctx.db->query<model::CppHeaderInclusion>(
     odb::query<model::CppHeaderInclusion>::included == file_->id);
@@ -504,50 +511,9 @@ void CppParser::markAsModified(const model::FilePtr file_)
       _ctx.fileStatus.emplace(loaded->path, IncrementalStatus::MODIFIED);
       LOG(debug) << "File modified: " << loaded->path;
 
-      markAsModified(loaded);
+      markByInclusion(loaded);
     }
   }
-}
-
-std::set<model::CppNodeId> CppParser::collectNodeSet(model::CppNodeId node_) const
-{
-  std::set<model::CppNodeId> nodes;
-  std::queue<model::CppNodeId> processQueue;
-
-  nodes.insert(node_);
-  processQueue.push(node_);
-
-  while(!processQueue.empty())
-  {
-    auto nodeId = processQueue.front();
-    processQueue.pop();
-
-    // Fetch nodes on edges where current node has a 'from' role
-    auto fromEdges = _ctx.db->query<model::CppEdge>(
-      odb::query<model::CppEdge>::from == nodeId);
-    for (const model::CppEdge &edge : fromEdges)
-    {
-      if (!nodes.count(edge.to->id))
-      {
-        nodes.insert(edge.to->id);
-        processQueue.push(edge.to->id);
-      }
-    }
-
-    // Fetch nodes on edges where current node has a 'to' role
-    auto toEdges = _ctx.db->query<model::CppEdge>(
-      odb::query<model::CppEdge>::to == nodeId);
-    for (const model::CppEdge &edge : toEdges)
-    {
-      if (!nodes.count(edge.from->id))
-      {
-        nodes.insert(edge.from->id);
-        processQueue.push(edge.from->id);
-      }
-    }
-  }
-
-  return nodes;
 }
 
 bool CppParser::parseByJson(

--- a/plugins/metrics/parser/include/metricsparser/metricsparser.h
+++ b/plugins/metrics/parser/include/metricsparser/metricsparser.h
@@ -17,7 +17,7 @@ public:
   MetricsParser(ParserContext& ctx_);
   virtual std::vector<std::string> getDependentParsers() const override;  
   virtual bool parse() override;
-  virtual bool preparse() override;
+  virtual bool preparse(bool dry_) override;
 
 private:
   util::DirIterCallback getParserCallback();

--- a/plugins/metrics/parser/src/metricsparser.cpp
+++ b/plugins/metrics/parser/src/metricsparser.cpp
@@ -51,37 +51,39 @@ std::vector<std::string> MetricsParser::getDependentParsers() const
   return std::vector<std::string>{};
 }
 
-bool MetricsParser::preparse()
+bool MetricsParser::preparse(bool dry_)
 {
-  if (!_fileIdCache.empty())
+  if (!dry_)
   {
-    try
+    if (!_fileIdCache.empty())
     {
-      util::OdbTransaction {_ctx.db} ([this] {
-        for (const model::File& file
-          : _ctx.db->query<model::File>(
-          odb::query<model::File>::id.in_range(_fileIdCache.begin(), _fileIdCache.end())))
-        {
-          auto it = _ctx.fileStatus.find(file.path);
-          if (it != _ctx.fileStatus.end() &&
-             (it->second == cc::parser::IncrementalStatus::DELETED ||
-              it->second == cc::parser::IncrementalStatus::MODIFIED))
+      try
+      {
+        util::OdbTransaction {_ctx.db} ([this] {
+          for (const model::File& file
+            : _ctx.db->query<model::File>(
+            odb::query<model::File>::id.in_range(_fileIdCache.begin(), _fileIdCache.end())))
           {
-            LOG(info) << "[metricsparser] Database cleanup: " << file.path;
+            auto it = _ctx.fileStatus.find(file.path);
+            if (it != _ctx.fileStatus.end() &&
+                (it->second == cc::parser::IncrementalStatus::DELETED ||
+                 it->second == cc::parser::IncrementalStatus::MODIFIED))
+            {
+              LOG(info) << "[metricsparser] Database cleanup: " << file.path;
 
-            _ctx.db->erase_query<model::Metrics>(odb::query<model::Metrics>::file == file.id);
-            _fileIdCache.erase(file.id);
+              _ctx.db->erase_query<model::Metrics>(odb::query<model::Metrics>::file == file.id);
+              _fileIdCache.erase(file.id);
+            }
           }
-        }
-      });
-    }
-    catch (odb::database_exception&)
-    {
-      LOG(fatal) << "Transaction failed in metrics parser!";
-      return false;
+        });
+      }
+      catch (odb::database_exception&)
+      {
+        LOG(fatal) << "Transaction failed in metrics parser!";
+        return false;
+      }
     }
   }
-
   return true;
 }
 


### PR DESCRIPTION
Added `--dry-run` flag, so incremental parsing can be executed to only list the detected changes (_ADDED_, _MODIFIED_ and _DELETED_ files), but do not evaluate any maintenance operations.

Also removed the `CppParser::collectNodeSet` method, which somehow got reintroduced when squashing the commits of #266.

This pull request should not be merged until #283 is solved, since appropriate testing could not be carried out because of it.