### PR TITLE
Use the automatic mirror selector for Thrift as opposed to SOTE

### DIFF
--- a/doc/deps.md
+++ b/doc/deps.md
@@ -66,7 +66,7 @@ Procedure Call (RPC) between the server and the client. Thrift is not part of
 the official Ubuntu 16.04 LTS repositories, but you can download it and build
 from source:
 
-- [Download Thrift](http://xenia.sote.hu/ftp/mirrors/www.apache.org/thrift/0.10.0/thrift-0.10.0.tar.gz)
+- [Download Thrift](http://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=thrift/0.10.0/thrift-0.10.0.tar.gz)
 - Uncompress and build it:
 
 ```bash


### PR DESCRIPTION
The Hungarian SOTE mirror might not be always available (there has been cases earlier...), and for international people it might not be the closest / fastest / best mirror. The Apache Foundation offers an API which automatically selects the best mirror based on the invoker's location. This mirror selection is handled through a HTTP redirect, which is respected by basically every browser, `wget` and `curl`.