### PR TITLE
Fixing message of incremental parsing.

### DIFF
--- a/parser/src/parser.cpp
+++ b/parser/src/parser.cpp
@@ -288,7 +288,7 @@ int main(int argc, char* argv[])
     return 1;
   }
 
-  if (!isNewDb)
+  if (!isNewDb && !vm.count("force"))
   {
     LOG(info)
       << "Project already exists, incremental parsing in action"


### PR DESCRIPTION
The message about doing incremental parse shouldn't be printed in case of forced parse.