### PR TITLE
Incremental parsing fix

### DIFF
--- a/plugins/cpp/parser/src/cppparser.cpp
+++ b/plugins/cpp/parser/src/cppparser.cpp
@@ -432,7 +432,7 @@ bool CppParser::preparse(bool dry_)
             // Delete CppEdge (connected to File)
             auto delEdges = _ctx.db->query<model::CppEdge>(
               odb::query<model::CppEdge>::from == delFile->id ||
-              odb::query<model::CppEdge>::to == delFile->id);
+              odb::query<model::CppEdge>::to == delFile->id); // TODO: maybe deletion for the from side is sufficient?
             for (const model::CppEdge& edge : delEdges)
             {
               _ctx.db->erase<model::CppEdge>(edge.id);

--- a/plugins/cpp/parser/src/cppparser.cpp
+++ b/plugins/cpp/parser/src/cppparser.cpp
@@ -393,8 +393,7 @@ bool CppParser::preparse(bool dry_)
 
             // Query CppAstNode
             auto defCppAstNodes = _ctx.db->query<model::CppAstNode>(
-              odb::query<model::CppAstNode>::location.file == delFile->id &&
-              odb::query<model::CppAstNode>::astType == model::CppAstNode::AstType::Definition);
+              odb::query<model::CppAstNode>::location.file == delFile->id);
             for (const model::CppAstNode& astNode : defCppAstNodes)
             {
               // Delete CppEntity

--- a/plugins/cpp/parser/src/relationcollector.h
+++ b/plugins/cpp/parser/src/relationcollector.h
@@ -48,8 +48,8 @@ private:
   static std::unordered_set<model::CppEdgeId> _edgeCache;
   static std::unordered_set<model::CppEdgeAttributeId> _edgeAttrCache;
 
-  std::vector<model::CppEdgePtr> _edges;
-  std::vector<model::CppEdgeAttributePtr> _edgeAttributes;
+  std::vector<model::CppEdgePtr> _newEdges;
+  std::vector<model::CppEdgeAttributePtr> _newEdgeAttributes;
 
   FileLocUtil _fileLocUtil;
 };

--- a/util/include/util/odbtransaction.h
+++ b/util/include/util/odbtransaction.h
@@ -179,11 +179,17 @@ void persistAll(Cont& cont_, std::shared_ptr<odb::database> db_)
     }
     catch (const odb::database_exception& ex)
     {
-      LOG(debug)
-        << item->toString();
-      LOG(error)
-        << ex.what() << std::endl;
+      LOG(debug) << item->toString();
 
+#ifdef DATABASE_PGSQL
+      if (std::string(ex.what()).find("25P02") != std::string::npos)
+      {
+        LOG(error) << "The transaction was aborted due to previous error, omitting further changes!";
+        break;
+      }
+#endif
+
+      LOG(error) << ex.what() << std::endl;
       throw;
     }
   }

--- a/util/include/util/odbtransaction.h
+++ b/util/include/util/odbtransaction.h
@@ -175,12 +175,16 @@ void persistAll(Cont& cont_, std::shared_ptr<odb::database> db_)
         << item->toString();
       LOG(warning)
         << ex.what() << std::endl
-        << "AST nodes in this translation unit will be ignored!";
+        << "Further changes in this transaction will might be ignored!";
     }
     catch (const odb::database_exception& ex)
     {
-      // TODO: Error code should be checked and rethrow if it is not unique
-      // constraint error. Error code may be database specific.
+      LOG(debug)
+        << item->toString();
+      LOG(error)
+        << ex.what() << std::endl;
+
+      throw;
     }
   }
 }


### PR DESCRIPTION
Fixing incremental parsing:
- deleting all `CppEntity` records for modified files, not only those with a *Definition* AST type.
- caching preexisting `CppEdge` records in `RelationCollector`, so they will not get reinserted, raising a database exception.

Improved the handling of database errors in `OdbTransaction`.

Fixes #294 