### PR TITLE
Eliminating compiler warnings

### DIFF
--- a/parser/include/parser/abstractparser.h
+++ b/parser/include/parser/abstractparser.h
@@ -40,7 +40,7 @@ public:
    * but do not execute any maintenance actions.
    * @return Return true if the preparse was success, false otherwise.
    */
-  virtual bool preparse(bool dry_ = false)
+  virtual bool preparse(bool /* dry_ */ = false)
   {
     return true;
   }

--- a/parser/include/parser/parsercontext.h
+++ b/parser/include/parser/parsercontext.h
@@ -32,10 +32,10 @@ enum class IncrementalStatus
 struct ParserContext 
 {  
   ParserContext(
-      std::shared_ptr<odb::database> db_,
-      SourceManager& srcMgr_,
-      std::string& compassRoot_,
-      po::variables_map& options);
+    std::shared_ptr<odb::database> db_,
+    SourceManager& srcMgr_,
+    std::string& compassRoot_,
+    po::variables_map& options_);
 
   std::shared_ptr<odb::database> db;
   SourceManager& srcMgr;

--- a/parser/include/parser/sourcemanager.h
+++ b/parser/include/parser/sourcemanager.h
@@ -29,7 +29,7 @@ public:
 
   struct AllFilesFilter
   {
-    bool operator()(model::FilePtr file_) const { return true; }
+    bool operator()(model::FilePtr) const { return true; }
   };
 
   template<typename Filter = SourceManager::AllFilesFilter>

--- a/parser/src/parsercontext.cpp
+++ b/parser/src/parsercontext.cpp
@@ -19,14 +19,14 @@ namespace parser
 {
 
 ParserContext::ParserContext(
-    std::shared_ptr<odb::database> db_,
-    SourceManager& srcMgr_,
-    std::string& compassRoot_,
-    po::variables_map& options_):
-      db(db_),
-      srcMgr(srcMgr_),
-      options(options_),
-      compassRoot(compassRoot_)
+  std::shared_ptr<odb::database> db_,
+  SourceManager& srcMgr_,
+  std::string& compassRoot_,
+  po::variables_map& options_) :
+    db(db_),
+    srcMgr(srcMgr_),
+    compassRoot(compassRoot_),
+    options(options_)
 {
   std::unordered_map<std::string, std::string> fileHashes;
 

--- a/plugins/cpp/service/src/filediagram.cpp
+++ b/plugins/cpp/service/src/filediagram.cpp
@@ -554,7 +554,7 @@ std::vector<util::Graph::Node> FileDiagram::getProvidedFiles(
 }
 
 std::vector<core::FileId> FileDiagram::getProvidedFileIds(
-  util::Graph& graph_,
+  util::Graph&,
   const util::Graph::Node& node_,
   bool reverse_)
 {
@@ -662,7 +662,7 @@ std::vector<util::Graph::Node> FileDiagram::getUsedFiles(
 }
 
 std::vector<core::FileId> FileDiagram::getUsedFileIds(
-  util::Graph& graph_,
+  util::Graph&,
   const util::Graph::Node& node_,
   bool reverse_)
 {

--- a/plugins/cpp/test/src/cppservicetest.cpp
+++ b/plugins/cpp/test/src/cppservicetest.cpp
@@ -14,12 +14,18 @@ int main(int argc, char** argv)
     return 1;
   }
 
+  int status;
+
   GTEST_LOG_(INFO) << "Testing C++ started...";
   GTEST_LOG_(INFO) << "Executing build command: " << argv[1];
-  system(argv[1]);
+  status = system(argv[1]);
+  if (status != 0)
+    return status;
 
   GTEST_LOG_(INFO) << "Executing parser command: " << argv[2];
-  system(argv[2]);
+  status = system(argv[2]);
+  if (status != 0)
+    return status;
 
   GTEST_LOG_(INFO) << "Using database for tests: " << dbConnectionString;
   ::testing::InitGoogleTest(&argc, argv);

--- a/plugins/dummy/parser/CMakeLists.txt
+++ b/plugins/dummy/parser/CMakeLists.txt
@@ -7,4 +7,6 @@ include_directories(
 add_library(dummyparser SHARED
   src/dummyparser.cpp)
 
+target_compile_options(dummyparser PUBLIC -Wno-unknown-pragmas)
+
 install(TARGETS dummyparser DESTINATION ${INSTALL_PARSER_DIR})

--- a/plugins/git/parser/CMakeLists.txt
+++ b/plugins/git/parser/CMakeLists.txt
@@ -6,6 +6,8 @@ include_directories(
 add_library(gitparser SHARED 
   src/gitparser.cpp)
 
+target_compile_options(gitparser PUBLIC -Wno-unknown-pragmas)
+
 target_link_libraries(gitparser
   util
   git2

--- a/plugins/git/parser/src/gitparser.cpp
+++ b/plugins/git/parser/src/gitparser.cpp
@@ -55,7 +55,8 @@ util::DirIterCallback GitParser::getParserCallback()
 
     //--- Clone the repo into a bare repo ---//
 
-    git_clone_options opts(GIT_CLONE_OPTIONS_INIT);
+    git_clone_options opts;
+    git_clone_init_options(&opts, GIT_CLONE_OPTIONS_VERSION);
     opts.bare = true;
 
     git_repository *out;

--- a/plugins/git/service/src/gitservice.cpp
+++ b/plugins/git/service/src/gitservice.cpp
@@ -793,7 +793,7 @@ BlamePtr GitServiceHandler::getBlameData(
 BlameOptsPtr GitServiceHandler::createBlameOpts(const git_oid& newCommitOid_)
 {
   git_blame_options* blameOpts = new git_blame_options;
-  *blameOpts = GIT_BLAME_OPTIONS_INIT;
+  git_blame_init_options(blameOpts, GIT_BLAME_OPTIONS_VERSION);
   blameOpts->newest_commit = newCommitOid_;
   return BlameOptsPtr { blameOpts };
 }

--- a/service/plugin/CMakeLists.txt
+++ b/service/plugin/CMakeLists.txt
@@ -31,7 +31,7 @@ add_library(pluginthrift STATIC
   gen-cpp/plugin_types.cpp
   gen-cpp/PluginService.cpp)
 
-target_compile_options(pluginthrift PUBLIC -fPIC)
+target_compile_options(pluginthrift PUBLIC -fPIC -Wno-unknown-pragmas)
 
 add_library(pluginservice SHARED
   src/pluginservice.cpp

--- a/service/workspace/CMakeLists.txt
+++ b/service/workspace/CMakeLists.txt
@@ -31,7 +31,7 @@ add_library(workspacethrift STATIC
   gen-cpp/workspace_types.cpp
   gen-cpp/WorkspaceService.cpp)
 
-target_compile_options(workspacethrift PUBLIC -fPIC)
+target_compile_options(workspacethrift PUBLIC -fPIC -Wno-unknown-pragmas)
 
 add_library(workspaceservice SHARED
   src/workspaceservice.cpp

--- a/util/src/dbutil.cpp
+++ b/util/src/dbutil.cpp
@@ -130,11 +130,15 @@ void sqliteRegexImpl(
 
 #ifdef DATABASE_PGSQL
 /**
- * This function checks the existance of a postgres database and
+ * This function checks the existance of a PostgreSQL database and
  * optionally creates the database if it doesn't exists.
- * @return True if the database exists after the function call; otherwise, false.
+ * @return True if the database exists after the function call; otherwise,
+ *   false.
  */
-bool checkPsqlDatbase(const std::string& connStr_, const std::string dbName_, bool create_)
+bool checkPsqlDatbase(
+  const std::string& connStr_,
+  const std::string& dbName_,
+  bool create_)
 {
   std::size_t colonPos = connStr_.find(':');
   std::string database = connStr_.substr(0, colonPos);
@@ -152,7 +156,7 @@ bool checkPsqlDatbase(const std::string& connStr_, const std::string dbName_, bo
     bool exists = connection->execute(
       "SELECT 1 FROM pg_database WHERE datname = '" + dbName_ + "'") > 0;
 
-    if(!exists && create_)
+    if (!exists && create_)
     {
       std::string createCmd = "CREATE DATABASE " + dbName_
         + " ENCODING = 'SQL_ASCII'"
@@ -173,7 +177,10 @@ bool checkPsqlDatbase(const std::string& connStr_, const std::string dbName_, bo
   catch (const odb::exception& ex)
   {
     LOG(warning) << ex.what();
+    throw;
   }
+
+  return false;
 }
 #endif
 
@@ -269,7 +276,9 @@ namespace util
  */
 static std::map<std::string, std::shared_ptr<odb::database>> databasePool;
 
-std::shared_ptr<odb::database> connectDatabase(const std::string& connStr_, bool create_)
+std::shared_ptr<odb::database> connectDatabase(
+  const std::string& connStr_,
+  bool create_)
 {
   auto iter = databasePool.find(connStr_);
   if (iter != databasePool.end())

--- a/webserver/src/mainrequesthandler.cpp
+++ b/webserver/src/mainrequesthandler.cpp
@@ -44,6 +44,7 @@ int MainRequestHandler::operator()(
       return begin_request_handler(conn_);
 
     case MG_AUTH:
+    {
       if (digestPasswdFile.empty())
         return MG_TRUE;
 
@@ -62,6 +63,10 @@ int MainRequestHandler::operator()(
         // TODO: An internal server error response would be nicer.
         throw std::runtime_error("Password file could not be opened.");
       }
+      break;
+    }
+
+    default:
       break;
   }
 


### PR DESCRIPTION
In this commit the compiler warnings are eliminated, except for the ones
in the C++ service. Those are unhandled cases in switch structures. Those
are planned to be implemented.