### PR TITLE
Fix context menu appearance in Firefox

### DIFF
--- a/webgui/scripts/codecompass/view/component/Text.js
+++ b/webgui/scripts/codecompass/view/component/Text.js
@@ -267,9 +267,7 @@ function (declare, domClass, dom, style, query, topic, ContentPane, Dialog,
       this.inherited(arguments);
 
       // TODO: if add new resizehandler it will not be the last node of domNode
-      var codeMirror = query('.CodeMirror', this.domNode)[0];
-      this._contextMenu.bindDomNode(
-        query('.CodeMirror-scroll', codeMirror)[0]);
+      this._contextMenu.bindDomNode(query('.CodeMirror', this.domNode)[0]);
     },
 
     resize : function () {


### PR DESCRIPTION
When clicking right mouse button on a parsed file, the ContextMenu didn't
appear in some cases in Firefox.
Fixes #313