### PR TITLE
Google Testing installation

### DIFF
--- a/doc/deps.md
+++ b/doc/deps.md
@@ -205,16 +205,18 @@ cd ..
 
 ### GTest/Googletest
 The `libgtest-dev` package contains only the source files of GTest, but the
-binaries are missing. You have to compile GTest manually and copy the libs to
-the right place:
+binaries are missing. You have to compile GTest manually:
 
 ```bash
-mkdir <gtest_install_dir>
-cp -R /usr/src/gtest/* <gtest_install_dir>
-cmake .
-make
-mkdir <gtest_install_dir>/lib
-mv libgtest.a libgtest_main.a <gtest_install_dir>/lib/
+mkdir gtest
+cp -R /usr/src/gtest/* ./gtest
+cd gtest
+mkdir build
+cd build
+
+cmake .. \
+  -DCMAKE_INSTALL_PREFIX=<gtest_install_dir>
+make install
 ```
 
 # Build CodeCompass

--- a/doc/deps.md
+++ b/doc/deps.md
@@ -205,11 +205,13 @@ cd ..
 
 ### GTest/Googletest
 The `libgtest-dev` package contains only the source files of GTest, but the
-binaries are missing. You have to compile GTest manually:
+binaries are missing. You have to compile GTest manually.
 
 ```bash
 mkdir gtest
-cp -R /usr/src/gtest/* ./gtest
+cp -R /usr/src/gtest/* ./gtest      # for Ubuntu 16.04 LTS
+cp -R /usr/src/googletest/* ./gtest # for Ubuntu 18.04 LTS
+
 cd gtest
 mkdir build
 cd build


### PR DESCRIPTION
This pull request fixes 2 issues in the dependency installation for CodeCompass:

1. Until now *gtest* was installed through manually copying the compiled binaries, instead of using `make install` as it should be, since it uses the CMake build system.
2. The documentation was outdated for Ubuntu 18.04 LTS.