### PR TITLE
Do not use keepalive in tests

### DIFF
--- a/plugins/cpp/test/CMakeLists.txt
+++ b/plugins/cpp/test/CMakeLists.txt
@@ -68,8 +68,7 @@ else()
        cd ${CMAKE_CURRENT_BINARY_DIR}/build && \
        cmake ${CMAKE_CURRENT_SOURCE_DIR}/sources/service \
          -DCMAKE_EXPORT_COMPILE_COMMANDS=on"
-    "${CMAKE_INSTALL_PREFIX}/bin/keepalive \
-       ${CMAKE_INSTALL_PREFIX}/bin/CodeCompass_parser \
+    "${CMAKE_INSTALL_PREFIX}/bin/CodeCompass_parser \
        --database \"${TEST_DB}\" \
        --name cppservicetest \
        --input ${CMAKE_CURRENT_BINARY_DIR}/build/compile_commands.json \
@@ -84,8 +83,7 @@ else()
        cd ${CMAKE_CURRENT_BINARY_DIR}/build && \
        cmake ${CMAKE_CURRENT_SOURCE_DIR}/sources/parser \
          -DCMAKE_EXPORT_COMPILE_COMMANDS=on"
-    "${CMAKE_INSTALL_PREFIX}/bin/keepalive \
-       ${CMAKE_INSTALL_PREFIX}/bin/CodeCompass_parser \
+    "${CMAKE_INSTALL_PREFIX}/bin/CodeCompass_parser \
        --database \"${TEST_DB}\" \
        --name cppparsertest \
        --input ${CMAKE_CURRENT_BINARY_DIR}/build/compile_commands.json \


### PR DESCRIPTION
Tests should be performed without any error terminating the program and should fail when e.g. an unhandled exception is raised or on a segmentation fault.
Therefore the `keepalive` script should not be used, because it restarts the program and the tests will probably never fail, nor succeed.