### PR TITLE
Error message instead of turning dry-run off

### DIFF
--- a/parser/src/parser.cpp
+++ b/parser/src/parser.cpp
@@ -297,9 +297,9 @@ int main(int argc, char* argv[])
 
   if (isNewDb && vm.count("dry-run"))
   {
-    LOG(warning) << "Dry-run can be only used with incremental parsing, "
-      "no project found, turning --dry-run off.";
-    vm.erase("dry-run");
+    LOG(error) << "Dry-run can be only used with incremental parsing, "
+      "no project found. Try turning --dry-run off.";
+    return 1;
   }
 
   //--- Prepare workspace and project directory ---//


### PR DESCRIPTION
See #293:
> When a new project is being parsed by `--dry-run` then the database shouldn't be created in case of a new project. With `--dry-run` no observable modification should happen in the file system.