### PR TITLE
Case-sensitive LIKE in SQLite

### DIFF
--- a/util/src/dbutil.cpp
+++ b/util/src/dbutil.cpp
@@ -393,6 +393,11 @@ std::shared_ptr<odb::database> connectDatabase(
     return nullptr;
   }
 
+#ifdef DATABASE_SQLITE
+  if (database == "sqlite")
+    db->connection()->execute("PRAGMA case_sensitive_like = ON");
+#endif
+
   databasePool[connStr_] = db;
 
   return db;


### PR DESCRIPTION
In SQLite the LIKE closure is case-insensitive by default. This is
now set to case-sensitive.

Fixes #326