### PR TITLE
LLVM/Clang known issues in the documentation.

### DIFF
--- a/doc/deps.md
+++ b/doc/deps.md
@@ -1,6 +1,6 @@
 # Operating system
-We build CodeCompass under Linux. Currently, we are supporting Ubuntu 16.04 LTS.
-It is recommended to use a 64-bit operating system.
+We build CodeCompass under Linux. Currently, we are supporting Ubuntu 16.04 LTS
+and Ubuntu 18.04 LTS. It is recommended to use a 64-bit operating system.
 
 # Dependencies
 CodeCompass uses some third-party dependencies. These can be installed from the
@@ -12,12 +12,10 @@ packages are necessary for building CodeCompass:
 - **`g++`**: For compiling CodeCompass. A version which supports C++14 features
   is required. (Alternatively, you can compile with Clang.)
 - **`libboost-all-dev`**: Boost can be used during the development.
-- **`llvm-7.0`**, **`clang-7.0`**: For compiling CodeCompass with Clang
+- **`llvm-7`**, **`clang-7`**: For compiling CodeCompass with Clang
   instead of G++.
-- **`llvm-7.0-dev`**, **`libclang-7.0-dev`**: C++ parser uses LLVM/Clang for
-  parsing the source code. Version 7.0 or newer is required. Clang 7 is not yet
-  released, so the project must be compiled manually from source.
-  ***See [Known issues](#known-issues)!***  
+- **`llvm-7-dev`**, **`libclang-7-dev`**: C++ parser uses LLVM/Clang for
+  parsing the source code.
 - **`odb`**, **`libodb-dev`**: For persistence ODB can be used which is an Object Relation
   Mapping (ORM) system.
 - **`libsqlite3-dev`**, **`libodb-sqlite-dev`**: SQLite library and the corresponding ODB
@@ -36,19 +34,42 @@ packages are necessary for building CodeCompass:
 - **`libgtest-dev`**: For testing CodeCompass.
   ***See [Known issues](#known-issues)!***
 
+## Quick guide
+
 The following command installs the packages except for those which have some
-known issues:
+known issues.
+
+#### Ubuntu 16.04 LTS
+
+The standard Ubuntu Xenial package repository contains only LLCM/Clang version 6,
+which is not sufficient for CodeCompass, as at least version 7.0 is required.
+Therefore LLVM and Clang should be installed from the official LLVM repositories:
+
 ```bash
-sudo apt-get install git cmake make g++ libboost-all-dev odb libodb-dev \
-  openjdk-8-jdk libssl-dev libgraphviz-dev libmagic-dev libgit2-dev npm ctags \
-  libgtest-dev
+sudo deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main
+sudo deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main
 
-# For Ubuntu 16.04 "Xenial Xerus" LTS:
-sudo apt-get install nodejs-legacy
+sudo apt-get install git cmake make g++ libboost-all-dev \
+  llvm-7 clang-7 llvm-7-dev libclang-7-dev odb libodb-dev \
+  openjdk-8-jdk libssl-dev libgraphviz-dev libmagic-dev libgit2-dev ctags \
+  libgtest-dev npm nodejs-legacy
+```
 
-# For Ubuntu 18.04 "Bionic Beaver" LTS:
-sudo apt-get install nodejs
+#### Ubuntu 18.04 LTS
 
+```bash
+sudo apt-get install git cmake make g++ libboost-all-dev \
+  llvm-7 clang-7 llvm-7-dev libclang-7-dev odb libodb-dev \
+  openjdk-8-jdk libssl-dev libgraphviz-dev libmagic-dev libgit2-dev ctags \
+  libgtest-dev npm nodejs
+```
+
+#### Database engine support
+
+Depending on the desired database engines to be supported, the following packages
+should be installed:
+
+```bash
 # For SQLite database systems:
 sudo apt-get install libodb-sqlite-dev libsqlite3-dev
 
@@ -58,7 +79,7 @@ sudo apt-get install libodb-pgsql-dev postgresql-server-dev-<version>
 
 ## Known issues
 Some third-party tools are present in the distribution's package manager in a
-way that they are eiter incompatible with each other or not available as a
+way that they are either incompatible with each other or not available as a
 package, thus can't be used to create your CodeCompass installation.
 
 :warning: Building and installing from source code to the system is a dangerous
@@ -70,8 +91,8 @@ other commands below, unless *explicitly* specified!**
 ### Thrift
 CodeCompass needs [Thrift](https://thrift.apache.org/) which provides Remote
 Procedure Call (RPC) between the server and the client. Thrift is not part of
-the official Ubuntu 16.04 LTS repositories, but you can download it and build
-from source:
+the official Ubuntu 16.04 LTS and 18.04 LTS repositories, but you can download it
+and build from source:
 
 ```bash
 # Thrift may require yacc and flex as dependency:
@@ -96,44 +117,6 @@ cd thrift-0.10.0
 # Python development headers are not, Thrift will unable to install.
 # Python, PHP and such other Thrift builds are NOT required by CodeCompass.
 
-make install
-```
-
-### LLVM/Clang
-In Ubuntu 16.04 LTS the LLVM/Clang has some packaging issues, i.e. some libs
-are searched in `/usr/lib` however the package has these in
-`/usr/lib/llvm-3.8/lib` (see
-[`http://stackoverflow.com/questions/38171543/error-when-using-cmake-with-llvm`](http://stackoverflow.com/questions/38171543/error-when-using-cmake-with-llvm)
-. This problem causes an error when emitting `cmake` command during CodeCompass
-build. A solution would be to download a prebuilt package from the LLVM/Clang
-webpage but another issue is that the prebuilt packages don't use runtime type
-informations (RTTI) which is needed for CodeCompass. Clang needs to be compiled
-with RTTI manually.
-
-```bash
-# If you want Clang's diagnostic output to have colours, install the following.
-sudo apt-get install libtinfo-dev
-
-wget http://releases.llvm.org/7.0.0/llvm-7.0.0.src.tar.xz
-tar -xvf llvm-7.0.0.src.tar.xz
-rm llvm-7.0.0.src.tar.xz
-mv llvm-* llvm
-cd llvm/tools
-wget http://releases.llvm.org/7.0.0/cfe-7.0.0.src.tar.xz
-tar -xvf cfe-7.0.0.src.tar.xz
-rm cfe-7.0.0.src.tar.xz
-mv cfe-* clang
-cd ../..
-
-mkdir build
-cd build
-cmake -G "Unix Makefiles" \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DLLVM_ENABLE_RTTI=ON \
-  -DCMAKE_INSTALL_PREFIX=<clang_install_dir> \
-  ../llvm
-# This make step takes a while. If you have more CPUs then you can compile on
-# several threads with -j<number_of_threads> flag.
 make install
 ```
 
@@ -182,7 +165,6 @@ be seen by CMake build system:
 ```bash
 export GTEST_ROOT=<gtest_install_dir>
 export CMAKE_PREFIX_PATH=<thrift_install_dir>:$CMAKE_PREFIX_PATH
-export CMAKE_PREFIX_PATH=<clang_install_dir>:$CMAKE_PREFIX_PATH
 export PATH=<thrift_install_dir>/bin:$PATH
 ```
 


### PR DESCRIPTION
As described in #328, the manual compilation of LLVM/Clang is not required. LLVM/Clang can be installed from Ubuntu package repository.
* For Ubuntu Bionic LLVM 7 and Clang 7 is part of the default package repository, compiled with RTTI.
* For Ubuntu Xenial, the [official package repository provided by LLVM](https://apt.llvm.org/) can easily be added and then LLVM/Clang version 7 can be installed with `apt-get` (also compiled with RTTI).