### PR TITLE
Restrict LLVM's scope to the C++ parser module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,11 @@ include(Functions.cmake)
 # Do some sanity check on the testing setup and enable testing if applicable.
 include(Testing.cmake)
 
-find_package(Threads REQUIRED)
 find_package(Boost   REQUIRED COMPONENTS filesystem log program_options regex system thread)
-find_package(Odb     REQUIRED)
-find_package(Thrift  REQUIRED)
 find_package(Java    REQUIRED)
+find_package(Odb     REQUIRED)
+find_package(Threads REQUIRED)
+find_package(Thrift  REQUIRED)
 find_package(GTest)
 
 include(UseJava)
@@ -24,14 +24,14 @@ include(Exports.cmake)
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH};${RUNENV_LD_LIBRARY_PATH}")
 
 # Modules
-add_subdirectory(model)
-add_subdirectory(util)
-add_subdirectory(parser)
-add_subdirectory(webserver)
-add_subdirectory(service)
 add_subdirectory(logger)
+add_subdirectory(model)
+add_subdirectory(parser)
 add_subdirectory(scripts)
+add_subdirectory(service)
+add_subdirectory(util)
 add_subdirectory(webgui)
+add_subdirectory(webserver)
 # Plugins
 add_subdirectory(plugins)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,21 +11,11 @@ include(Functions.cmake)
 include(Testing.cmake)
 
 find_package(Threads REQUIRED)
-find_package(LLVM    REQUIRED CONFIG)
 find_package(Boost   REQUIRED COMPONENTS filesystem log program_options regex system thread)
 find_package(Odb     REQUIRED)
 find_package(Thrift  REQUIRED)
 find_package(Java    REQUIRED)
 find_package(GTest)
-
-# Check whether RTTI is on for LLVM
-message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
-message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
-message(STATUS "Using ClangConfig.cmake in: ${Clang_DIR}")
-message(STATUS "Using RTTI for LLVM: ${LLVM_ENABLE_RTTI}")
-if(NOT LLVM_ENABLE_RTTI)
-  message(SEND_ERROR "RTTI is required for LLVM")
-endif()
 
 include(UseJava)
 
@@ -33,22 +23,19 @@ include(UseJava)
 include(Exports.cmake)
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH};${RUNENV_LD_LIBRARY_PATH}")
 
+# Modules
 add_subdirectory(model)
 add_subdirectory(util)
 add_subdirectory(parser)
-add_subdirectory(plugins)
 add_subdirectory(webserver)
 add_subdirectory(service)
 add_subdirectory(logger)
 add_subdirectory(scripts)
 add_subdirectory(webgui)
+# Plugins
+add_subdirectory(plugins)
 
 # Install java libraries
 install(DIRECTORY
   lib/java/
   DESTINATION "${INSTALL_JAVA_LIB_DIR}")
-
-# Install Clang additional files
-install(DIRECTORY
-  ${LLVM_LIBRARY_DIRS}/clang
-  DESTINATION "${INSTALL_LIB_DIR}")

--- a/Exports.cmake
+++ b/Exports.cmake
@@ -37,9 +37,6 @@ endfunction(mark_as_run_env_path)
 set(RUNENV_LD_LIBRARY_PATH ""
   CACHE INTERNAL "Environment variable exported to install." FORCE)
 
-# LLVM
-mark_as_run_env_path(LD_LIBRARY_PATH "${LLVM_BUILD_LIBRARY_DIR}")
-
 # ODB
 filelist_to_dirlist_unique(_odbLibDirs "${ODB_LIBRARIES}")
 mark_as_run_env_path(LD_LIBRARY_PATH "${_odbLibDirs}")

--- a/Functions.cmake
+++ b/Functions.cmake
@@ -39,7 +39,7 @@ function(generate_odb_files _src)
   set(ODB_CXX_SOURCES ${SOURCES} PARENT_SCOPE)
 endfunction(generate_odb_files)
 
-# add new odb static library
+# Add a new static library target that links against ODB.
 function(add_odb_library _name)
   add_library(${_name} STATIC ${ARGN})
   target_compile_options(${_name} PUBLIC -Wno-unknown-pragmas -fPIC)

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -4,11 +4,14 @@ include_directories(SYSTEM
 
 # Add all subdirectories to the build
 file(GLOB plugins RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/*")
-message(STATUS "Adding new plugins:")
 
 # Set unique plugin directory variable for each plugin
+message(STATUS "Found the following CodeCompass plugins:")
 foreach(_plugin ${plugins})
-  set(${_plugin}_PLUGIN_DIR "${CMAKE_CURRENT_SOURCE_DIR}/${_plugin}")
+  if(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${_plugin}")
+    set(${_plugin}_PLUGIN_DIR "${CMAKE_CURRENT_SOURCE_DIR}/${_plugin}")
+    message(STATUS "  ${_plugin}")
+  endif()
 endforeach(_plugin)
 
 # Add plugins
@@ -16,7 +19,7 @@ foreach(_plugin ${plugins})
   if(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${_plugin}")
     set(PLUGIN_NAME ${_plugin})
     set(PLUGIN_DIR ${${_plugin}_PLUGIN_DIR})
-    message(STATUS "  ${_plugin}")
+    fancy_message("Loading plugin ${_plugin}" "blue" TRUE)
     add_subdirectory(${_plugin})
   endif()
 endforeach(_plugin)

--- a/plugins/cpp/parser/CMakeLists.txt
+++ b/plugins/cpp/parser/CMakeLists.txt
@@ -1,4 +1,17 @@
+find_package(LLVM REQUIRED CONFIG)
 find_package(Clang REQUIRED CONFIG)
+
+# Check whether RTTI is on for LLVM
+message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+message(STATUS "Using ClangConfig.cmake in: ${Clang_DIR}")
+message(STATUS "Using RTTI for LLVM: ${LLVM_ENABLE_RTTI}")
+if(NOT LLVM_ENABLE_RTTI)
+    message(SEND_ERROR "RTTI is required for LLVM")
+endif()
+
+# Add LLVM to the library path
+mark_as_run_env_path(LD_LIBRARY_PATH "${LLVM_BUILD_LIBRARY_DIR}")
 
 include_directories(
   include
@@ -38,9 +51,13 @@ target_link_libraries(cppparser
   clangAST
   clangLex
   clangBasic
-  clang
-  )
+  clang)
 
 target_compile_options(cppparser PUBLIC -Wno-unknown-pragmas)
 
 install(TARGETS cppparser DESTINATION ${INSTALL_PARSER_DIR})
+
+# Install Clang additional files
+install(DIRECTORY
+        ${LLVM_LIBRARY_DIRS}/clang
+        DESTINATION "${INSTALL_LIB_DIR}")

--- a/plugins/git/CMakeLists.txt
+++ b/plugins/git/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(Git REQUIRED)
+
 add_subdirectory(parser)
 add_subdirectory(service)
 

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -1,7 +1,6 @@
 include_directories(
   ${PROJECT_SOURCE_DIR}/util/include
   ${PROJECT_SOURCE_DIR}/model/include
-  ${LLVM_INCLUDE_DIRS}
   ${BOOST_INCLUDE_DIRS})
 
 include_directories(SYSTEM


### PR DESCRIPTION
LLVM is only used by the C++ parser module, which should be reflected by the build system, by not importing it in the global `CMakeLists.txt`.
Based on the original work of @whisperity.