### PR TITLE
Using Clang 10 specifically

### DIFF
--- a/plugins/cpp/parser/CMakeLists.txt
+++ b/plugins/cpp/parser/CMakeLists.txt
@@ -1,18 +1,25 @@
-find_package(LLVM 7 REQUIRED CONFIG)
-
-# Check whether RTTI is on for LLVM
+# Find LLVM
+find_package(LLVM REQUIRED CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+
+# Check whether RTTI is on for LLVM
 message(STATUS "Using RTTI for LLVM: ${LLVM_ENABLE_RTTI}")
 if(NOT LLVM_ENABLE_RTTI)
     message(SEND_ERROR "RTTI is required for LLVM")
 endif()
 
-find_package(Clang REQUIRED CONFIG)
-message(STATUS "Using ClangConfig.cmake in: ${Clang_DIR}")
+# Check LLVM version
+if (${LLVM_PACKAGE_VERSION} VERSION_LESS "10")
+    message(SEND_ERROR "Loaded LLVM version must be at least 10.0, ${LLVM_PACKAGE_VERSION} found.")
+endif()
 
 # Add LLVM to the library path
 mark_as_run_env_path(LD_LIBRARY_PATH "${LLVM_BUILD_LIBRARY_DIR}")
+
+# Find Clang
+find_package(Clang REQUIRED CONFIG)
+message(STATUS "Using ClangConfig.cmake in: ${Clang_DIR}")
 
 include_directories(
   include


### PR DESCRIPTION
In case multiple LLVM/Clang versions are installed on a machine it is
not determined which one is used. In this commit LLVM 7 is enforced
because cpp plugin compiles with this version.