### PR TITLE
Refactoring docker image for development

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,31 +1,49 @@
 FROM ubuntu:bionic
 
-RUN apt-get update && apt-get -y install \
+RUN set -x && apt-get update -qq \
+&& apt-get -y install \
   cmake make \
   llvm-7 clang-7 llvm-7-dev libclang-7-dev \
-  libboost-all-dev \
   odb libodb-sqlite-dev libodb-pgsql-dev \
   libsqlite3-dev \
-  default-jdk ant\
-  libssl-dev \
+  default-jdk \
+  libssl1.0-dev \
   libgraphviz-dev \
   libmagic-dev \
   libgit2-dev \
-  nodejs \
+  nodejs-dev node-gyp npm \
   ctags \
   wget \
   git \
-  && \
-  wget "http://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=thrift/0.12.0/thrift-0.12.0.tar.gz" -O /opt/thrift-0.12.0.tar.gz; \
-  tar -xf /opt/thrift-0.12.0.tar.gz -C /opt; \
-  cd /opt/thrift-0.12.0; \
-  ./configure --prefix=/opt/thrift --silent; \
-  cd /; \
-  make -C /opt/thrift-0.12.0 -j4 --silent install; \
-  rm -rf /opt/thrift-0.12.0 /opt/thrift-0.12.0.tar.gz
+  libgtest-dev \
+  # Install boost libraries.
+  libboost-filesystem-dev \
+  libboost-log-dev \
+  libboost-program-options-dev \
+  libboost-regex-dev \
+  # Build thrift.
+  && wget "http://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=thrift/0.12.0/thrift-0.12.0.tar.gz" -O /opt/thrift-0.12.0.tar.gz; \
+     tar -xf /opt/thrift-0.12.0.tar.gz -C /opt; \
+     cd /opt/thrift-0.12.0; \
+     ./configure --silent; \
+     cd /; \
+     make -C /opt/thrift-0.12.0 -j4 --silent install; \
+     rm -rf /opt/thrift-0.12.0 /opt/thrift-0.12.0.tar.gz \
+  # Build GTest.
+  && cd /usr/src/googletest/ && \
+     mkdir build && \
+     cd build && \
+     cmake .. && \
+     make install && \
+     cd / && \
+     rm -rf /usr/src/googletest/build \
+  # Erase downloaded archive files.
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/ \
+  && set +x
 
 COPY codecompass-build.sh /usr/local/bin
 
-ENV DATABASE=pgsql BUILD_TYPE=Release
+ENV DATABASE=sqlite BUILD_TYPE=Release
 
 ENTRYPOINT ["codecompass-build.sh"]

--- a/scripts/docker/codecompass-build.sh
+++ b/scripts/docker/codecompass-build.sh
@@ -3,13 +3,10 @@
 # This script will run inside the Docker container. This will build CodeCompass
 # using the following environment variables:
 #
-# DATABASE - pgsql (by default) or sqlite
+# DATABASE - sqlite (by default) or psql
 # BUILD_TYPE - Release (by default) or Debug
 
 # DON'T MODIFY THE REST OF THIS SCRIPT UNLESS YOU KNOW WHAT YOU'RE DOING!
-
-export PATH=/opt/thrift/bin:$PATH
-export CMAKE_PREFIX_PATH=/opt/thrift
 
 BUILD_DIR=/CodeCompass/build
 INSTALL_DIR=/CodeCompass/install
@@ -26,5 +23,4 @@ if [ ! -d $BUILD_DIR ]; then
     -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 fi
 
-cd $BUILD_DIR
-make $@
+make -C $BUILD_DIR $@


### PR DESCRIPTION
* Install missing npm.
* Install only necessary boost packages.
* Install gtest and build the source files.
* Erase downloaded archive files.
* Use sqlite as the default database for build.