### PR TITLE
[server] Remove database option from webserver

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -212,14 +212,12 @@ reason.
 # Start the server listening on port 6251.
 keepalive CodeCompass_webserver \
   -w ~/cc/workdir \
-  -p 6251 \
-  -d "pgsql:host=localhost;port=5432;user=compass;password=mypassword"
+  -p 6251
 
 # Or if SQLite database is used:
 keepalive CodeCompass_webserver \
   -w ~/cc/workdir \
-  -p 6251 \
-  -d "sqlite:database=~/cc/mydatabase.sqlite"
+  -p 6251
 ```
 
 The server will be available in a browser on

--- a/docker/README.md
+++ b/docker/README.md
@@ -93,6 +93,5 @@ mkdir -p /CodeCompass/workspace
 
 # Run the web server.
 /CodeCompass/install/bin/CodeCompass_webserver \
-  -d "sqlite:" \
   -w /CodeCompass/workspace
 ```

--- a/parser/src/parser.cpp
+++ b/parser/src/parser.cpp
@@ -60,7 +60,8 @@ po::options_description commandLineArguments()
       "database can be given by a connection string. Keep in mind that the "
       "database type depends on the CodeCompass executable. CodeCompass can be "
       "build to support PostgreSQL or SQLite. Connection string has the "
-      "following format: pgsql:database=name;user=user_name.")
+      "following format: 'pgsql:database=name;port=5432;user=user_name' or "
+      "'sqlite:database=~/cc/mydatabase.sqlite'.")
     ("label", po::value<std::vector<std::string>>(),
       "The submodules of a large project can be labeled so it can be easier "
       "later to locate them. With this flag you can provide a label list in "
@@ -422,9 +423,7 @@ int main(int argc, char* argv[])
   std::string database
     = cc::util::connStrComponent(vm["database"].as<std::string>(), "database");
 
-  pt.put(
-    "database",
-    database.empty() ? vm["name"].as<std::string>() : database);
+  pt.put("database", vm["database"].as<std::string>());
 
   if (vm.count("description"))
     pt.put("description", vm["description"].as<std::string>());

--- a/webserver/src/webserver.cpp
+++ b/webserver/src/webserver.cpp
@@ -24,10 +24,6 @@ po::options_description commandLineArguments()
       "Prints this help message.")
     ("workspace,w", po::value<std::string>()->required(),
       "Path to a workspace directory which contains the parsed projects.")
-    ("database,d", po::value<std::string>()->required(),
-      // TODO: Provide a full connection string example.
-      "A connection string to the relational database with the following "
-      "format: pgsql:database=name;user=user_name.")
     ("port,p", po::value<int>()->default_value(8080),
       "Port number of the webserver to listen on.")
     ("loglevel",


### PR DESCRIPTION
Remove database connection string option from CodeCompass webserver because the `project_info.json` file contains a valid database connection string which is given during parse for each project.