### PR TITLE
Eliminating parser dependencies

### DIFF
--- a/parser/include/parser/abstractparser.h
+++ b/parser/include/parser/abstractparser.h
@@ -26,14 +26,6 @@ public:
   virtual ~AbstractParser(){}
 
   /**
-   * Get dependencies of parsers. 
-   * Using these dependencies we will create a linear ordering of the parsers
-   * and then we will call the parse() function in the correct order.
-   * @return dependent parsers
-   */
-  virtual std::vector<std::string> getDependentParsers() const = 0;
-
-  /**
    * Look up and mark indirectly modified files for incremental parsing,
    * based on the semantic information of the parser.
    */

--- a/parser/include/parser/pluginhandler.h
+++ b/parser/include/parser/pluginhandler.h
@@ -49,11 +49,6 @@ public:
   bool createPlugins(ParserContext& ctx_);
 
   /**
-   * Create topological order of parsers by parser dependencies.
-   */
-  std::vector<std::string> getTopologicalOrder();
-
-  /**
    * Get parser by parser name.
    * @param parserName_ Parser name (e.g.: dummyparser, cppparser). A parser is
    * identified by its name. For example dummyparser is implemented in

--- a/parser/src/pluginhandler.cpp
+++ b/parser/src/pluginhandler.cpp
@@ -2,9 +2,6 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
-#include <boost/graph/graph_traits.hpp>
-#include <boost/graph/adjacency_list.hpp>
-#include <boost/graph/topological_sort.hpp>
 
 #include <util/logutil.h>
 
@@ -113,65 +110,6 @@ boost::program_options::options_description PluginHandler::getOptions() const
   }
 
   return desc;
-}
-
-std::vector<std::string> PluginHandler::getTopologicalOrder()
-{
-  std::vector<std::string> topologicalOrder;
-  typedef boost::adjacency_list<boost::vecS, boost::vecS, 
-          boost::bidirectionalS> Graph;
-  typedef boost::graph_traits<Graph>::vertex_descriptor Vertex;
-  typedef std::pair<int,int> Edge;
-
-  Graph g;
-  std::vector<Edge> edges;
-
-  std::vector<std::string> vertexNames;
-  std::map<std::string, boost::adjacency_list<>::vertex_descriptor>
-    parserNameToVertex;
-
-  //--- Init data ---//
-
-  for(const auto& parser : _parsers)
-  {        
-    vertexNames.push_back(parser.first); 
-    parserNameToVertex[parser.first] = boost::add_vertex(g);
-  }
-
-  //--- Add edges ---//
-
-  for(const auto& parser : _parsers)
-  {
-    for(const auto& dependency : parser.second->getDependentParsers())
-    {
-      if(!parserNameToVertex.count(dependency))
-      {
-        // TODO: This shouldn't be tolerated so easy.
-        LOG(warning) << dependency << " is not a real parser";
-        continue;
-      }
-
-      //--- Add edges to the graph ---//
-
-      bool inserted;
-      boost::graph_traits<Graph>::edge_descriptor e; 
-      boost::tie(e, inserted) = boost::add_edge(
-        parserNameToVertex.at(dependency), 
-        parserNameToVertex.at(parser.first), g);
-    }
-  } 
-
-  //--- Topological order of the graph ---//
-
-  std::deque<Vertex> make_order;
-  boost::topological_sort(g, std::front_inserter(make_order));
-
-  for (auto it = make_order.begin(); it != make_order.end(); ++it) 
-  {
-    topologicalOrder.push_back(vertexNames[*it]);
-  }
-
-  return topologicalOrder;
 }
 
 std::shared_ptr<AbstractParser>& PluginHandler::getParser(

--- a/plugins/cpp/parser/include/cppparser/cppparser.h
+++ b/plugins/cpp/parser/include/cppparser/cppparser.h
@@ -24,7 +24,6 @@ class CppParser : public AbstractParser
 public:
   CppParser(ParserContext& ctx_);
   virtual ~CppParser();  
-  virtual std::vector<std::string> getDependentParsers() const override;
   virtual void markModifiedFiles() override;
   /**
    * Maintains and cleans up the database in preparation of incremental parsing.

--- a/plugins/cpp/parser/src/cppparser.cpp
+++ b/plugins/cpp/parser/src/cppparser.cpp
@@ -338,11 +338,6 @@ CppParser::CppParser(ParserContext& ctx_) : AbstractParser(ctx_)
 {
 }
 
-std::vector<std::string> CppParser::getDependentParsers() const
-{
-  return std::vector<std::string>{};
-}
-
 std::vector<std::vector<std::string>> CppParser::createCleanupOrder()
 {
   typedef boost::adjacency_list<boost::vecS, boost::vecS,

--- a/plugins/dummy/parser/include/dummyparser/dummyparser.h
+++ b/plugins/dummy/parser/include/dummyparser/dummyparser.h
@@ -14,7 +14,6 @@ class DummyParser : public AbstractParser
 public:
   DummyParser(ParserContext& ctx_);
   virtual ~DummyParser();
-  virtual std::vector<std::string> getDependentParsers() const override;
   virtual bool parse() override;
 private:
   bool accept(const std::string& path_);

--- a/plugins/dummy/parser/src/dummyparser.cpp
+++ b/plugins/dummy/parser/src/dummyparser.cpp
@@ -15,11 +15,6 @@ DummyParser::DummyParser(ParserContext& ctx_): AbstractParser(ctx_)
 {
 }
 
-std::vector<std::string> DummyParser::getDependentParsers()  const
-{
-  return std::vector<std::string>{};
-}
-
 bool DummyParser::accept(const std::string& path_)
 {
   std::string ext = boost::filesystem::extension(path_);

--- a/plugins/git/parser/include/gitparser/gitparser.h
+++ b/plugins/git/parser/include/gitparser/gitparser.h
@@ -16,7 +16,6 @@ class GitParser : public AbstractParser
 public:
   GitParser(ParserContext& ctx_);
   virtual ~GitParser();
-  virtual std::vector<std::string> getDependentParsers() const override;
   virtual bool parse() override;
 private:
   util::DirIterCallback getParserCallback();

--- a/plugins/git/parser/src/gitparser.cpp
+++ b/plugins/git/parser/src/gitparser.cpp
@@ -20,11 +20,6 @@ GitParser::GitParser(ParserContext& ctx_) : AbstractParser(ctx_)
   git_libgit2_init();
 }
 
-std::vector<std::string> GitParser::getDependentParsers() const
-{
-  return std::vector<std::string>{};
-}
-
 util::DirIterCallback GitParser::getParserCallback()
 {
   std::string wsDir = _ctx.options["workspace"].as<std::string>();

--- a/plugins/metrics/parser/include/metricsparser/metricsparser.h
+++ b/plugins/metrics/parser/include/metricsparser/metricsparser.h
@@ -15,7 +15,6 @@ class MetricsParser : public AbstractParser
 {
 public:
   MetricsParser(ParserContext& ctx_);
-  virtual std::vector<std::string> getDependentParsers() const override;
   virtual bool cleanupDatabase() override;
   virtual bool parse() override;
 

--- a/plugins/metrics/parser/src/metricsparser.cpp
+++ b/plugins/metrics/parser/src/metricsparser.cpp
@@ -46,11 +46,6 @@ MetricsParser::MetricsParser(ParserContext& ctx_): AbstractParser(ctx_)
     });
 }
 
-std::vector<std::string> MetricsParser::getDependentParsers() const
-{
-  return std::vector<std::string>{};
-}
-
 bool MetricsParser::cleanupDatabase()
 {
   if (!_fileIdCache.empty())

--- a/plugins/search/parser/include/searchparser/searchparser.h
+++ b/plugins/search/parser/include/searchparser/searchparser.h
@@ -21,7 +21,6 @@ public:
   SearchParser(ParserContext& ctx_);
   virtual ~SearchParser();
 
-  virtual std::vector<std::string> getDependentParsers() const override;
   virtual bool parse() override;
 
 private:

--- a/plugins/search/parser/src/searchparser.cpp
+++ b/plugins/search/parser/src/searchparser.cpp
@@ -78,11 +78,6 @@ SearchParser::SearchParser(ParserContext& ctx_) : AbstractParser(ctx_),
   }
 }
 
-std::vector<std::string> SearchParser::getDependentParsers() const
-{
-  return std::vector<std::string>{};
-}
-
 bool SearchParser::parse()
 {
   if (fs::is_directory(_searchDatabase))


### PR DESCRIPTION
For historical reasons parser plugins were able to give the set of
parsers they depend on. The order of parsers were organized according
to these dependencies. However, this was never used in CodeCompass, so
in this commit this dependency relationship is eliminated.