### PR TITLE
Error when running CodeCompass binary from extended PATH

### DIFF
--- a/util/src/filesystem.cpp
+++ b/util/src/filesystem.cpp
@@ -1,9 +1,8 @@
+#include <cstdlib>
+
 #include <boost/filesystem.hpp>
 
 #include <util/filesystem.h>
-#include <util/logutil.h>
-
-#include <stdlib.h>
 
 namespace fs = boost::filesystem;
 
@@ -28,24 +27,26 @@ std::string binaryPathToInstallDir(const char* path)
   }
   else
   {
-    std::string webserverPath;
+    std::string pPath;
     std::string fullPath = std::getenv("PATH");
     std::string delimiter = ":";
 
-    size_t pos = 0;
+    std::size_t pos = 0;
     while ((pos = fullPath.find(delimiter)) != std::string::npos)
     {
-      webserverPath = fullPath.substr(0, pos) + "/" + path;
+      pPath = fullPath.substr(0, pos) + "/" + path;
 
-      if (fs::exists(fs::path(webserverPath)))
+      if (fs::exists(fs::path(pPath)))
       {
-        return fs::canonical(fs::path(webserverPath))
+        return fs::canonical(fs::path(pPath))
           .parent_path().parent_path().string();
       }
 
       fullPath.erase(0, pos + delimiter.length());
     }
   }
+
+  throw std::runtime_error(std::string("Could not find ") + path + std::string("."));
 }
 
 } // namespace util

--- a/util/src/filesystem.cpp
+++ b/util/src/filesystem.cpp
@@ -1,6 +1,9 @@
 #include <boost/filesystem.hpp>
 
 #include <util/filesystem.h>
+#include <util/logutil.h>
+
+#include <stdlib.h>
 
 namespace fs = boost::filesystem;
 
@@ -15,8 +18,34 @@ std::string binaryPathToInstallDir(const char* path)
   // of any symbolic links and relative references.
   // The path is then parented twice (from binary to "bin" folder, and then
   // the root).
-  return fs::canonical(fs::system_complete(fs::path(path)))
-    .parent_path().parent_path().string();
+  // If the path does not exist, the given binary is searched for in the PATH
+  // environment variable.
+
+  if (fs::exists(fs::system_complete(fs::path(path))))
+  {
+    return fs::canonical(fs::system_complete(fs::path(path)))
+      .parent_path().parent_path().string();
+  }
+  else
+  {
+    std::string webserverPath;
+    std::string fullPath = std::getenv("PATH");
+    std::string delimiter = ":";
+
+    size_t pos = 0;
+    while ((pos = fullPath.find(delimiter)) != std::string::npos)
+    {
+      webserverPath = fullPath.substr(0, pos) + "/" + path;
+
+      if (fs::exists(fs::path(webserverPath)))
+      {
+        return fs::canonical(fs::path(webserverPath))
+          .parent_path().parent_path().string();
+      }
+
+      fullPath.erase(0, pos + delimiter.length());
+    }
+  }
 }
 
 } // namespace util

--- a/util/src/filesystem.cpp
+++ b/util/src/filesystem.cpp
@@ -19,6 +19,7 @@ std::string binaryPathToInstallDir(const char* path)
   // the root).
   // If the path does not exist, the given binary is searched for in the PATH
   // environment variable.
+  // TODO: replace else branch with fs::search_path if Boost 1.64 or above is used.
 
   if (fs::exists(fs::system_complete(fs::path(path))))
   {
@@ -27,18 +28,18 @@ std::string binaryPathToInstallDir(const char* path)
   }
   else
   {
-    std::string pPath;
+    fs::path pPath;
     std::string fullPath = std::getenv("PATH");
     std::string delimiter = ":";
 
     std::size_t pos = 0;
     while ((pos = fullPath.find(delimiter)) != std::string::npos)
     {
-      pPath = fullPath.substr(0, pos) + "/" + path;
+      pPath = fs::path(fullPath.substr(0, pos)) / fs::path(path);
 
       if (fs::exists(fs::path(pPath)))
       {
-        return fs::canonical(fs::path(pPath))
+        return fs::canonical(pPath)
           .parent_path().parent_path().string();
       }
 


### PR DESCRIPTION
Webserver path is searched for in PATH if not called from its install directory.
Fixes #353.