### PR TITLE
Set the linker to gold, because it is significantly faster.

### DIFF
--- a/Config.cmake
+++ b/Config.cmake
@@ -68,10 +68,14 @@ set(ODBFLAGS
   --include-with-brackets
   --default-pointer "std::shared_ptr")
 
+# Set CXX flags
 set(CMAKE_CXX_FLAGS "-W -Wall -Wextra -pedantic\
   -std=c++14 \
   -DDATABASE_${DATABASE_U} \
   -DBOOST_LOG_DYN_LINK")
+
+# Set gold linker
+set(CMAKE_LINKER "/usr/bin/gold")
 
 # Cmake module directory (FindOdb, FindThrift etc.)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/Config.cmake
+++ b/Config.cmake
@@ -74,8 +74,14 @@ set(CMAKE_CXX_FLAGS "-W -Wall -Wextra -pedantic\
   -DDATABASE_${DATABASE_U} \
   -DBOOST_LOG_DYN_LINK")
 
-# Set gold linker
-set(CMAKE_LINKER "/usr/bin/gold")
+# Gold is the primary linker 
+if(NOT DEFINED CODECOMPASS_LINKER)
+    set(CODECOMPASS_LINKER "/usr/bin/gold")
+endif()
+
+set(CMAKE_LINKER "${CODECOMPASS_LINKER}")
+
+
 
 # Cmake module directory (FindOdb, FindThrift etc.)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/Config.cmake
+++ b/Config.cmake
@@ -76,7 +76,7 @@ set(CMAKE_CXX_FLAGS "-W -Wall -Wextra -pedantic\
 
 # Gold is the primary linker 
 if(NOT DEFINED CODECOMPASS_LINKER)
-    set(CODECOMPASS_LINKER "/usr/bin/gold")
+    set(CODECOMPASS_LINKER "gold")
 endif()
 
 set(CMAKE_LINKER "${CODECOMPASS_LINKER}")

--- a/doc/deps.md
+++ b/doc/deps.md
@@ -189,6 +189,9 @@ cmake .. \
   -DDATABASE=<database_type> \
   -DCMAKE_BUILD_TYPE=<build_type>
 
+#To specify linker for building CodeCompass use
+# -DCODECOMPASS_LINKER=<path_to_linker>
+
 # Build project.
 make -j<number_of_threads>
 
@@ -208,6 +211,7 @@ during compilation.
 | `CMAKE_CXX_COMPILER` | If the official repository of your Linux distribution doesn't contain a C++ compiler which supports C++14 then you can install one manually and set to use it. For more information see: https://cmake.org/Wiki/CMake_Useful_Variables |
 | `DATABASE` | Database type. Possible values are **sqlite**, **pgsql**. The default value is `sqlite`. |
 | `TEST_DB` | The connection string for the database that will be used when executing tests with `make test`. |
+| `CODECOMPASS_LINKER` | The variable used to specify the linker. |
 
 # Docker
 [![Docker](images/docker.jpg)](https://www.docker.com/)


### PR DESCRIPTION
Also the CodeCompass project does not require any of the gnu linker's
extra tools, and gold is located in the binutils package, that needs to be installed
to build CodeCompass, meaning it's safe to change to gold.