### PR TITLE
Incremental support for changes in compilation commands

### DIFF
--- a/parser/include/parser/parsercontext.h
+++ b/parser/include/parser/parsercontext.h
@@ -26,7 +26,8 @@ enum class IncrementalStatus
 {
   MODIFIED,
   ADDED,
-  DELETED
+  DELETED,
+  ACTION_CHANGED
 };
 
 struct ParserContext 

--- a/parser/src/parser.cpp
+++ b/parser/src/parser.cpp
@@ -169,6 +169,9 @@ void incrementalList(cc::parser::ParserContext& ctx_)
       case cc::parser::IncrementalStatus::DELETED:
         LOG(info) << "DELETED file: " << item.first;
         break;
+      case cc::parser::IncrementalStatus::ACTION_CHANGED:
+        LOG(info) << "BUILD ACTION CHANGED file: " << item.first;
+        break;
     }
   }
 }
@@ -188,6 +191,7 @@ void incrementalCleanup(cc::parser::ParserContext& ctx_)
       {
         case cc::parser::IncrementalStatus::MODIFIED:
         case cc::parser::IncrementalStatus::DELETED:
+        case cc::parser::IncrementalStatus::ACTION_CHANGED:
         {
           LOG(info) << "Database cleanup: " << item.first;
 

--- a/plugins/metrics/parser/src/metricsparser.cpp
+++ b/plugins/metrics/parser/src/metricsparser.cpp
@@ -60,7 +60,8 @@ bool MetricsParser::cleanupDatabase()
           auto it = _ctx.fileStatus.find(file.path);
           if (it != _ctx.fileStatus.end() &&
               (it->second == cc::parser::IncrementalStatus::DELETED ||
-               it->second == cc::parser::IncrementalStatus::MODIFIED))
+               it->second == cc::parser::IncrementalStatus::MODIFIED ||
+               it->second == cc::parser::IncrementalStatus::ACTION_CHANGED))
           {
             LOG(info) << "[metricsparser] Database cleanup: " << file.path;
 


### PR DESCRIPTION
CodeCompass is already capable of detecting *modified* and *deleted* files, cleaning them from the workspace database, thus providing an incremental parsing functionality.

This PR extends incremental parsing to detect **changes in the compilation commands**. This is achieved as follows:
1.  The compile commands from the given JSON file(s) are loaded.
2.  All `BuildAction` entities are loaded from the workspace database.
3.  For each `BuildAction` in the workspace database it is checked: if a `BuildAction` stores a command, which is not present in the compile commands database loaded from the JSON file(s), the source files for that build action are marked for cleanup. (This will ultimately clean up the given source file, the related AST info and the related build action itself.)