### PR TITLE
Skipped plugins are not started, only loaded ones.

### DIFF
--- a/parser/include/parser/pluginhandler.h
+++ b/parser/include/parser/pluginhandler.h
@@ -37,6 +37,12 @@ public:
   void loadPlugins(std::vector<std::string>& skipParserList_);
 
   /**
+   * Return the list of loaded plugins based the file names in the dynamic
+   * libraries.
+   */
+  std::vector<std::string> getLoadedPluginNames() const;
+
+  /**
    * Return the list of available plugins based on the file names in the parser
    * lib directory.
    */

--- a/parser/include/parser/pluginhandler.h
+++ b/parser/include/parser/pluginhandler.h
@@ -37,8 +37,7 @@ public:
   void loadPlugins(std::vector<std::string>& skipParserList_);
 
   /**
-   * Return the list of loaded plugins based the file names in the dynamic
-   * libraries.
+   * Return the list of loaded (not skipped) plugin names.
    */
   std::vector<std::string> getLoadedPluginNames() const;
 

--- a/parser/src/parser.cpp
+++ b/parser/src/parser.cpp
@@ -350,7 +350,7 @@ int main(int argc, char* argv[])
   cc::parser::ParserContext ctx(db, srcMgr, compassRoot, vm);
   pHandler.createPlugins(ctx);
 
-  std::vector<std::string> pluginNames = pHandler.getPluginNames();
+  std::vector<std::string> pluginNames = pHandler.getLoadedPluginNames();
   for (const std::string& pluginName : pluginNames)
   {
     LOG(info) << "[" << pluginName << "] started to mark modified files!";

--- a/parser/src/pluginhandler.cpp
+++ b/parser/src/pluginhandler.cpp
@@ -63,6 +63,18 @@ void PluginHandler::loadPlugins(std::vector<std::string>& skipParserList_)
   }
 }
 
+std::vector<std::string> PluginHandler::getLoadedPluginNames() const
+{
+  std::vector<std::string> plugins;
+
+  for (auto pair : _dynamicLibraries)
+  {
+    plugins.push_back(pair.first);
+  }
+
+  return plugins;
+}
+
 std::vector<std::string> PluginHandler::getPluginNames() const
 {
   std::vector<std::string> plugins;

--- a/parser/src/pluginhandler.cpp
+++ b/parser/src/pluginhandler.cpp
@@ -67,9 +67,9 @@ std::vector<std::string> PluginHandler::getLoadedPluginNames() const
 {
   std::vector<std::string> plugins;
 
-  for (auto pair : _dynamicLibraries)
+  for (const auto& lib : _dynamicLibraries)
   {
-    plugins.push_back(pair.first);
+    plugins.push_back(lib.first);
   }
 
   return plugins;


### PR DESCRIPTION
Skipped plugins have been called in `parser.cpp` along with non-skipped ones when the `pluginHandler` started the parsers which caused a runtime error. Now only loaded parsers are being started. Solves #371 .