### PR TITLE
Separated the different parts of the build into multiple docker RUN-s.

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,45 +1,51 @@
+# CodeCompass development dependecies
 FROM ubuntu:bionic
 
 RUN set -x && apt-get update -qq \
-&& apt-get -y install \
-  cmake make \
-  llvm-7 clang-7 llvm-7-dev libclang-7-dev \
-  odb libodb-sqlite-dev libodb-pgsql-dev \
-  libsqlite3-dev \
-  default-jdk \
-  libssl1.0-dev \
-  libgraphviz-dev \
-  libmagic-dev \
-  libgit2-dev \
-  nodejs-dev node-gyp npm \
-  ctags \
-  wget \
-  libgtest-dev \
-  # Install boost libraries.
-  libboost-filesystem-dev \
-  libboost-log-dev \
-  libboost-program-options-dev \
-  libboost-regex-dev \
-  # Build thrift.
-  && wget "http://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=thrift/0.12.0/thrift-0.12.0.tar.gz" -O /opt/thrift-0.12.0.tar.gz; \
-     tar -xf /opt/thrift-0.12.0.tar.gz -C /opt; \
-     cd /opt/thrift-0.12.0; \
-     ./configure --silent; \
-     cd /; \
-     make -C /opt/thrift-0.12.0 -j4 --silent install; \
-     rm -rf /opt/thrift-0.12.0 /opt/thrift-0.12.0.tar.gz \
-  # Build GTest.
-  && cd /usr/src/googletest/ && \
+    && apt-get -y install \
+    cmake make \
+    llvm-7 clang-7 llvm-7-dev libclang-7-dev \
+    odb libodb-sqlite-dev libodb-pgsql-dev \
+    libsqlite3-dev \
+    default-jdk \
+    libssl1.0-dev \
+    libgraphviz-dev \
+    libmagic-dev \
+    libgit2-dev \
+    nodejs-dev node-gyp npm \
+    ctags \
+    wget \
+    libgtest-dev \
+    # Install boost libraries.
+    libboost-filesystem-dev \
+    libboost-log-dev \
+    libboost-program-options-dev \
+    libboost-regex-dev
+# Build thrift.
+RUN wget "http://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=thrift/0.13.0/thrift-0.13.0.tar.gz" -O /opt/thrift-0.13.0.tar.gz; \
+    tar -xf /opt/thrift-0.13.0.tar.gz -C /opt; \
+    cd /opt/thrift-0.13.0 && \
+    ./configure \
+    --silent --without-python                                        \
+    --enable-libtool-lock --enable-tutorial=no --enable-tests=no     \
+    --with-libevent --with-zlib --without-nodejs --without-lua       \
+    --without-ruby --without-csharp --without-erlang --without-perl  \
+    --without-php --without-php_extension --without-dart             \
+    --without-haskell --without-go --without-rs --without-haxe       \
+    --without-dotnetcore --without-d --without-qt4 --without-qt5;    \
+    cd /; \
+    make -C /opt/thrift-0.13.0 -j4 --silent install; \
+    rm -rf /opt/thrift-0.13.0 /opt/thrift-0.13.0.tar.gz
+# Build GTest.
+RUN cd /usr/src/googletest/ && \
      mkdir build && \
      cd build && \
      cmake .. && \
      make install && \
      cd / && \
-     rm -rf /usr/src/googletest/build \
-  \
-  # Remove unnecessary packages.
-  && apt-get purge -y --auto-remove wget \
-  \
+     rm -rf /usr/src/googletest/build
+# Remove unnecessary packages.
+RUN apt-get purge --yes --auto-remove wget \
   # Erase downloaded archive files.
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/ \


### PR DESCRIPTION
This makes the build safer, and when the Dockerfile is changed and the rebuilding is more effective.
Also added some configuration options to the thrift install inside the container so it doesn't build unnecessary libraries.
At the purging I changed -y to --yes, because somehow the build failed for me with the -y, although  it should  not.