### PR TITLE
Wire in SSL certificate support

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -199,6 +199,56 @@ CodeCompass_webserver -w <workdir> -p <port> -d <connection_string>
 
 For full documentation see `CodeCompass_webserver -h`.
 
+### Enabling HTTPS (SSL/TLS) secure server
+
+By default, CodeCompass starts a conventional, plain-text HTTP server on the
+port specified.
+In case a `certificate.pem` file exists under the `--workpace` directory, the
+server *will* start in SSL mode.
+
+The certificate file shall be in PEM format, which looks like shown below. If
+the certificate you received from your Certificate Authority (or self-created)
+isn't in PEM format, use an SSL tool like [OpenSSL](http://openssl.org) to
+convert it.
+
+Normally, the private and public key (the certificate) are created as separate
+files. They **must** be concatenated to *one* `certificate.pem` file, to look
+like the following.
+[Further details on SSL](http://github.com/cesanta/mongoose/blob/5.4/docs/SSL.md#how-to-create-ssl-certificate-file)
+is available from Mongoose, the library CodeCompass uses for HTTP server.
+
+~~~{.pem}
+-----BEGIN RSA PRIVATE KEY-----
+MIIEogIBAAKCAQEAwONaLOP7EdegqjRuQKSDXzvHmFMZfBufjhELhNjo5KsL4ieH
+hYN0Zii2yTb63jGxKY6gH1R/r9dL8kXaJmcZrfSa3AgywnteJWg=
+-----END RSA PRIVATE KEY-----
+-----BEGIN CERTIFICATE-----
+MIIDBjCCAe4CCQCX05m0b053QzANBgkqhkiG9w0BAQQFADBFMQswCQYDVQQGEwJB
+SEGI4JSxV56lYg==
+-----END CERTIFICATE-----
+~~~
+
+> **Note:** Make sure your certificate file itself is not password-protected,
+> as requiring the password to be entered will make the server unable to start
+> on its own.
+
+If intermediate certificates are used because your certificate isn't signed
+by a Root CA (this is common), the certificate chain's elements (also in, or
+converted to PEM format) should also be concatenate into the `certificate.pem`
+file:
+
+~~~{.pem}
+-----BEGIN RSA PRIVATE KEY-----
+Your certificate's private key
+-----END RSA PRIVATE KEY-----
+-----BEGIN CERTIFICATE-----
+Your certificate (the public key)
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+The certificate of the CA that signed your certificate
+-----END CERTIFICATE-----
+~~~
+
 ### Usage example
 
 ```bash

--- a/service/workspace/src/workspaceservice.cpp
+++ b/service/workspace/src/workspaceservice.cpp
@@ -21,11 +21,19 @@ void WorkspaceServiceHandler::getWorkspaces(std::vector<WorkspaceInfo>& _return)
     it != fs::directory_iterator();
     ++it)
   {
-    std::string filename = it->path().filename().native();
+    if (!fs::is_directory(it->path()))
+      // Ignore plain files in the workspace directory - projects are always
+      // directories.
+      continue;
+    if (!fs::is_regular_file(fs::path{it->path()}.append("project_info.json")))
+      // Ignore directories that do not have a project information for them.
+      // (cf. webserver/pluginhelper.h)
+      continue;
 
+    std::string filename = it->path().filename().native();
     WorkspaceInfo info;
-    info.__set_id(filename);
-    info.__set_description(filename);
+    info.id = filename;
+    info.description = filename;
 
     _return.push_back(std::move(info));
   }

--- a/webserver/CMakeLists.txt
+++ b/webserver/CMakeLists.txt
@@ -7,9 +7,10 @@ set_target_properties(CodeCompass_webserver
   PROPERTIES ENABLE_EXPORTS 1)
 
 add_library(mongoose STATIC src/mongoose.c )
-
+target_compile_definitions(mongoose PRIVATE -DNS_ENABLE_SSL)
 target_include_directories(mongoose PUBLIC include)
 target_compile_options(mongoose PUBLIC -fPIC)
+target_link_libraries(mongoose PRIVATE ssl)
 
 target_include_directories(CodeCompass_webserver PUBLIC
   include


### PR DESCRIPTION
If a `certificate.pem` is found under the workspace, start the server with SSL enabled. Turns out the Mongoose we currently use actually does support this.