### PR TITLE
Show diagram legend for directories

### DIFF
--- a/plugins/cpp/service/src/cppservice.cpp
+++ b/plugins/cpp/service/src/cppservice.cpp
@@ -127,6 +127,7 @@ CppServiceHandler::CppServiceHandler(
 void CppServiceHandler::getFileTypes(std::vector<std::string>& return_)
 {
   return_.push_back("CPP");
+  return_.push_back("Dir");
 }
 
 void CppServiceHandler::getAstNodeInfo(


### PR DESCRIPTION
`Dir` was missing from file types.