### PR TITLE
Guide and update for Ubuntu 20.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,19 @@
 os: linux
-sudo: require
-
+dist: bionic
 language: generic
-
 services:
   - postgresql
 
-.apt_xenial: &apt_xenial
+# ---------------------------- APT configuration -----------------------------
+
+.apt_xenial_config: &apt_xenial_config
   update: true
   sources:
     - ubuntu-toolchain-r-test
     - llvm-toolchain-xenial-7
+
+.apt_xenial_sqlite: &apt_xenial_sqlite
+  <<: *apt_xenial_config
   packages:
     # Boost
     - libboost-all-dev
@@ -27,6 +30,37 @@ services:
     # SQLite
     - libodb-sqlite-dev
     - libsqlite3-dev
+    # Parser
+    - libmagic-dev
+    - libgit2-dev
+    - ctags
+    # Service
+    - libgraphviz-dev
+    - nodejs-legacy
+    - npm
+    # GTest
+    - libgtest-dev
+    # Thrift
+    - libssl-dev
+    # Thrift (compile)
+    - byacc
+    - flex
+
+.apt_xenial_pgsql: &apt_xenial_pgsql
+  <<: *apt_xenial_config
+  packages:
+    # Boost
+    - libboost-all-dev
+    # LLVM/clang
+    - llvm-7
+    - llvm-7-dev
+    - clang-7
+    - libclang-7-dev
+    # Java
+    - default-jdk
+    # ODB
+    - odb
+    - libodb-dev
     # PostgreSQL
     - libodb-pgsql-dev
     - postgresql-server-dev-9.5
@@ -46,24 +80,166 @@ services:
     - byacc
     - flex
 
-.install_bionic: &install_bionic
-  >
-  sudo apt-get install -y
-  libboost-all-dev
-  llvm-7 llvm-7-dev clang-7 libclang-7-dev
-  default-jdk
-  gcc-7-plugin-dev
-  libsqlite3-dev
-  postgresql-server-dev-10
-  libmagic-dev libgit2-dev ctags
-  libgraphviz-dev npm
-  libgtest-dev
-  libssl1.0-dev
-  byacc flex
+.apt_bionic_config: &apt_bionic_config
+  update: true
+
+.apt_bionic_sqlite: &apt_bionic_sqlite
+  <<: *apt_bionic_config
+  packages:
+    # Boost
+    - libboost-all-dev
+    # LLVM/clang
+    - llvm-7
+    - llvm-7-dev
+    - clang-7
+    - libclang-7-dev
+    # Java
+    - default-jdk
+    # ODB
+    - gcc-7-plugin-dev
+    # SQLite
+    - libsqlite3-dev
+    # Parser
+    - libmagic-dev
+    - libgit2-dev
+    - ctags
+    # Service
+    - libgraphviz-dev
+    - npm
+    # GTest
+    - libgtest-dev
+    # Thrift
+    - libssl1.0-dev
+    # Thrift (compile)
+    - byacc
+    - flex
+
+.apt_bionic_pgsql: &apt_bionic_pgsql
+  <<: *apt_bionic_config
+  packages:
+    # Boost
+    - libboost-all-dev
+    # LLVM/clang
+    - llvm-7
+    - llvm-7-dev
+    - clang-7
+    - libclang-7-dev
+    # Java
+    - default-jdk
+    # ODB
+    - gcc-7-plugin-dev
+    # PostgreSQL
+    - postgresql-server-dev-10
+    # Parser
+    - libmagic-dev
+    - libgit2-dev
+    - ctags
+    # Service
+    - libgraphviz-dev
+    - npm
+    # GTest
+    - libgtest-dev
+    # Thrift
+    - libssl1.0-dev
+    # Thrift (compile)
+    - byacc
+    - flex
+
+.apt_focal_config: &apt_focal_config
+  update: true
+
+.apt_focal_sqlite: &apt_focal_sqlite
+  <<: *apt_focal_config
+  packages:
+    # Boost
+    - libboost-all-dev
+    # LLVM/clang
+    - llvm-7
+    - llvm-7-dev
+    - clang-7
+    - libclang-7-dev
+    # Java
+    - default-jdk
+    # ODB
+    - odb
+    - libodb-dev
+    # SQLite
+    - libodb-sqlite-dev
+    - libsqlite3-dev
+    # Parser
+    - libmagic-dev
+    - libgit2-dev
+    - ctags
+    # Service
+    - libgraphviz-dev
+    - npm
+    # GTest
+    - libgtest-dev
+    # Thrift
+    - thrift-compiler
+    - libthrift-dev
+    - libssl-dev
+
+.apt_focal_pgsql: &apt_focal_pgsql
+  <<: *apt_focal_config
+  packages:
+    # Boost
+    - libboost-all-dev
+    # LLVM/clang
+    - llvm-7
+    - llvm-7-dev
+    - clang-7
+    - libclang-7-dev
+    # Java
+    - default-jdk
+    # ODB
+    - odb
+    - libodb-dev
+    # PostgreSQL
+    - libodb-pgsql-dev
+    # (Travis can't automatically spin up a running PostgreSQL instance for
+    # 20.04.)
+    - postgresql-12
+    - postgresql-server-dev-12
+    # Parser
+    - libmagic-dev
+    - libgit2-dev
+    - ctags
+    # Service
+    - libgraphviz-dev
+    - npm
+    # GTest
+    - libgtest-dev
+    # Thrift
+    - thrift-compiler
+    - libthrift-dev
+    - libssl-dev
+
+# ------------------------ Self-compiled dependencies ------------------------
+
+.install_thrift: &install_thrift
+  |
+  if [ ! -f "$HOME/thrift_install/bin/thrift" ]; then
+    echo "Building Thrift..."
+    cd $HOME
+    wget -O thrift-0.13.0.tar.gz "http://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=thrift/0.13.0/thrift-0.13.0.tar.gz"
+    tar -xvf ./thrift-0.13.0.tar.gz
+    cd thrift-0.13.0
+    ./configure --prefix=$HOME/thrift_install --without-python         \
+      --enable-libtool-lock --enable-tutorial=no --enable-tests=no     \
+      --with-libevent --with-zlib --without-nodejs --without-lua       \
+      --without-ruby --without-csharp --without-erlang --without-perl  \
+      --without-php --without-php_extension --without-dart             \
+      --without-haskell --without-go --without-rs --without-haxe       \
+      --without-dotnetcore --without-d --without-qt4 --without-qt5     \
+      --without-java
+    make install -j $(nproc)
+  fi
 
 .install_odb: &install_odb
   |
   if [ ! -f "$HOME/build2_install/bin/bpkg" ]; then
+    echo "Building Build2..."
     mkdir /tmp/build2src
     cd /tmp/build2src
     curl -sSfO https://download.build2.org/0.12.0/build2-install-0.12.0.sh
@@ -74,46 +250,30 @@ services:
     mkdir /tmp/odb_build
     cd /tmp/odb_build
     bpkg create --quiet --jobs $(nproc) cc \
-    config.cxx=g++ config.cc.coptions=-O3 \
-    config.bin.rpath="$HOME/odb_install/lib" config.install.root="$HOME/odb_install" \
-    config.install.sudo=sudo
+      config.cxx=g++ config.cc.coptions=-O3 \
+      config.bin.rpath="$HOME/odb_install/lib" config.install.root="$HOME/odb_install" \
+      config.install.sudo=sudo
     bpkg add https://pkg.cppget.org/1/beta --trust-yes
     bpkg fetch --trust-yes
+    echo "Building ODB..."
     bpkg build odb --yes
     bpkg build libodb --yes
-    bpkg build libodb-sqlite --yes
-    bpkg build libodb-pgsql --yes
+    [ "$DATABASE" == "sqlite" ] && (echo "Building ODB/SQLite..."; bpkg build libodb-sqlite --yes) || echo "Skip building ODB/SQLite!"
+    [ "$DATABASE" == "pgsql" ] && (echo "Building ODB/PostgreSQL..."; bpkg build libodb-pgsql --yes) || echo "Skip building ODB/PostgreSQL!"
     bpkg install --all --recursive
-  fi
-
-.install_thrift: &install_thrift
-  |
-  if [ ! -f "$HOME/thrift_install/bin/thrift" ]; then
-    cd $HOME
-    wget -O thrift-0.13.0.tar.gz "http://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=thrift/0.13.0/thrift-0.13.0.tar.gz"
-    tar -xvf ./thrift-0.13.0.tar.gz
-    cd thrift-0.13.0
-    ./configure --prefix=$HOME/thrift_install --without-python       \
-    --enable-libtool-lock --enable-tutorial=no --enable-tests=no     \
-    --with-libevent --with-zlib --without-nodejs --without-lua       \
-    --without-ruby --without-csharp --without-erlang --without-perl  \
-    --without-php --without-php_extension --without-dart             \
-    --without-haskell --without-go --without-rs --without-haxe       \
-    --without-dotnetcore --without-d --without-qt4 --without-qt5     \
-    --without-java
-    make install
   fi
 
 .install_gtest_xenial: &install_gtest_xenial
   |
   if [ ! -f "$HOME/gtest_install/lib/libgtest.a" ]; then
+    echo "Building GoogleTest..."
     cd $HOME
     mkdir gtest
     cp -R /usr/src/gtest/* ./gtest
     cd gtest
     mkdir build && cd build
     cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/gtest_install
-    make
+    make -j $(nproc)
 
     mkdir -p $HOME/gtest_install/lib
     cp libgtest.a libgtest_main.a $HOME/gtest_install/lib/
@@ -122,14 +282,37 @@ services:
 .install_gtest_bionic: &install_gtest_bionic
   |
   if [ ! -f "$HOME/gtest_install/lib/libgtest.a" ]; then
+    echo "Building GoogleTest..."
     cd $HOME
     mkdir gtest
     cp -R /usr/src/googletest/* ./gtest
     cd gtest
     mkdir build && cd build
     cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/gtest_install
-    make install
+    make install -j $(nproc)
   fi
+
+.install_gtest_focal: &install_gtest_focal
+  |
+  if [ ! -f "$HOME/gtest_install/lib/libgtest.a" ]; then
+    echo "Building GoogleTest..."
+    cd $HOME
+    mkdir gtest
+    cp -R /usr/src/googletest/* ./gtest
+    cd gtest
+    mkdir build && cd build
+    cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/gtest_install
+    make install -j $(nproc)
+  fi
+
+cache:
+  directories:
+    - $HOME/build2_install
+    - $HOME/gtest_install
+    - $HOME/odb_install
+    - $HOME/thrift_install
+
+# ---------------------------------- Setup -----------------------------------
 
 before_script:
   # Default locations and versions
@@ -145,13 +328,26 @@ before_script:
   # ODB
   - export CMAKE_PREFIX_PATH=$HOME/odb_install:$CMAKE_PREFIX_PATH
   - export PATH=$HOME/odb_install/bin:$PATH
+  - which odb
   - odb --version
   # Thrift
   - export CMAKE_PREFIX_PATH=$HOME/thrift_install:$CMAKE_PREFIX_PATH
   - export PATH=$HOME/thrift_install/bin:$PATH
+  - which thrift
   - thrift --version
   # GTest
   - export GTEST_ROOT=$HOME/gtest_install
+
+.fix_focal_travis_postgresql_server: &fix_focal_travis_postgresql_server
+  # Newer PostgreSQL servers on Travis don't automatically allow connecting
+  # with the 'postgresql' user.
+  # !! YOU SHOULD **NEVER** DO THIS ON A LIVE SYSTEM !!
+  - sudo cat /etc/postgresql/*/main/pg_hba.conf
+  - sudo sed -i "s/peer/trust/g" /etc/postgresql/*/main/pg_hba.conf
+  - sudo sed -i "s/md5/trust/g" /etc/postgresql/*/main/pg_hba.conf
+  - sudo cat /etc/postgresql/*/main/pg_hba.conf
+  - sudo service postgresql restart 12
+  - sudo service postgresql status
 
 .build_postgres: &build_postgres
   - cd $TRAVIS_BUILD_DIR
@@ -163,8 +359,8 @@ before_script:
     -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/install_pgsql
     -DTEST_DB="pgsql:host=localhost;port=5432;user=postgres;password=;database=cc_test"
     -DLLVM_DIR=/usr/lib/llvm-7/cmake
-    -DClang_DIR:PATH=/usr/lib/cmake/clang-7
-  - make install
+    -DClang_DIR=/usr/lib/cmake/clang-7
+  - make install -j $(nproc)
   - make test ARGS=-V
 
 .build_sqlite: &build_sqlite
@@ -177,62 +373,89 @@ before_script:
     -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/install_sqlite
     -DTEST_DB="sqlite:database=$HOME/cc_test.sqlite"
     -DLLVM_DIR=/usr/lib/llvm-7/cmake
-    -DClang_DIR:PATH=/usr/lib/cmake/clang-7
-  - make install
+    -DClang_DIR=/usr/lib/cmake/clang-7
+  - make install -j $(nproc)
   - make test ARGS=-V
+
+# ----------------------------------- Jobs -----------------------------------
 
 jobs:
   include:
-    - name: "Xenial PostgreSQL build"
+    - name: "Xenial Xerus (16.04), PostgreSQL"
       dist: xenial
       addons:
         apt:
-          <<: *apt_xenial
+          <<: *apt_xenial_pgsql
         postgresql: "9.5"
+      env:
+        - DATABASE=pgsql
       install:
         - *install_thrift
         - *install_gtest_xenial
       script:
         *build_postgres
-    - name: "Xenial SQLite build"
+    - name: "Xenial Xerus (16.04), SQLite"
       dist: xenial
       addons:
         apt:
-          <<: *apt_xenial
-        postgresql: "9.5"
+          <<: *apt_xenial_sqlite
+      env:
+        - DATABASE=sqlite
       install:
         - *install_thrift
         - *install_gtest_xenial
       script:
         *build_sqlite
-    - name: "Bionic PostgreSQL build"
+    - name: "Bionic Beaver (18.04), PostgreSQL"
       dist: bionic
       addons:
+        apt:
+          <<: *apt_bionic_pgsql
         postgresql: "10"
+      env:
+        - DATABASE=pgsql
       install:
-        - sudo apt-get update -y
-        - *install_bionic
         - *install_odb
         - *install_thrift
         - *install_gtest_bionic
       script:
         *build_postgres
-    - name: "Bionic SQLite build"
+    - name: "Bionic Beaver (18.04), SQLite"
       dist: bionic
       addons:
-        postgresql: "10"
+        apt:
+          <<: *apt_bionic_sqlite
+      env:
+        - DATABASE=sqlite
       install:
-        - sudo apt-get update -y
-        - *install_bionic
         - *install_odb
         - *install_thrift
         - *install_gtest_bionic
+      script:
+        *build_sqlite
+    - name: "Focal Fossa (20.04), PostgreSQL"
+      dist: focal
+      addons:
+        apt:
+          <<: *apt_focal_pgsql
+        postgresql: "12"
+      env:
+        - DATABASE=pgsql
+      before_install:
+        - *fix_focal_travis_postgresql_server
+      install:
+        - *install_gtest_focal
+      script:
+        *build_postgres
+    - name: "Focal Fossa (20.04), SQLite"
+      dist: focal
+      addons:
+        apt:
+          <<: *apt_focal_sqlite
+      env:
+        - DATABASE=sqlite
+      install:
+        - *install_gtest_focal
       script:
         *build_sqlite
 
-cache:
-  directories:
-    - $HOME/thrift_install
-    - $HOME/gtest_install
-    - $HOME/build2_install
-    - $HOME/odb_install

--- a/Functions.cmake
+++ b/Functions.cmake
@@ -106,7 +106,10 @@ function(find_boost_libraries)
     foreach(_path ${Boost_LIBRARIES})
       if(_path MATCHES ".*boost_${_lib}\.so$")
         list(APPEND LIBS ${_path})
-      endif(_path MATCHES ".*boost_${_lib}\.so$")
+      elseif(_path MATCHES "Boost::${_lib}$")
+        # There is no path for the lib, included as a module.
+        list(APPEND LIBS ${_path})
+      endif()
     endforeach(_path)
   endforeach(_lib)
 

--- a/doc/deps.md
+++ b/doc/deps.md
@@ -1,9 +1,10 @@
 # Build Environment
-We build CodeCompass under Linux. Currently, we are supporting Ubuntu 16.04 LTS
-and Ubuntu 18.04 LTS. It is recommended to use a 64-bit operating system.
+We build CodeCompass in a Linux environment. Currently, Ubuntu Long-Term
+Support releases are the main targets: Ubuntu 16.04 LTS, Ubuntu 18.04 LTS and
+Ubuntu 20.04 LTS.
 
 We also provide a Docker image that can be used as developer environment to
-CodeCompass. See its usage at the [bottom](#docker) of this page.
+CodeCompass. See its usage [in a seperate document](/docker/README.md).
 
 # Dependencies
 The following third-party tools are needed for building CodeCompass. These can
@@ -15,8 +16,8 @@ be installed from the official repository of the given Linux distribution.
   is required. (Alternatively, you can compile with Clang.)
 - **`gcc-X`, `gcc-X-plugin-dev`**: For building ODB.
 - **`libboost-all-dev`**: Boost can be used during the development.
-- **`llvm-7-dev`**, **`clang-7`**, **`libclang-7-dev`**: C++ parser uses LLVM/Clang for
-  parsing the source code.
+- **`llvm-7-dev`**, **`clang-7`**, **`libclang-7-dev`**: C++ parser uses
+  LLVM/Clang for parsing the source code.
 - **`odb`**, **`libodb-dev`**: For persistence ODB can be used which is an
   Object Relation Mapping (ORM) system.
 - **`libsqlite3-dev`**, **`libodb-sqlite-dev`**: SQLite library and the
@@ -27,22 +28,25 @@ be installed from the official repository of the given Linux distribution.
   database system is used.
 - **`default-jdk`**: For search parsing CodeCompass uses an indexer written in
   Java.
-- **`libssl-dev`** / **`libssl1.0-dev`**: OpenSSL libs are required by Thrift, and NodeJS.
-- **`libgraphviz-dev`**: GraphViz is used for generating diagram visualizations.
+- **`thrift-compiler`**, **`libthrift-dev`**: Thrift is used as the Web RPC API.
+- **`libssl-dev`** / **`libssl1.0-dev`**: OpenSSL libs are required by Thrift,
+  and NodeJS.
+- **`libgraphviz-dev`**: GraphViz is used for generating diagram
+  visualizations.
 - **`libmagic-dev`**: For detecting file types.
 - **`libgit2-dev`**: For compiling Git plugin in CodeCompass.
 - **`npm`** (and **`nodejs-legacy`** for Ubuntu 16.04): For handling
   JavaScript dependencies for CodeCompass web GUI.
 - **`ctags`**: For search parsing.
-- **`libgtest-dev`**: For testing CodeCompass.  ***See [Known
-  issues](#known-issues)!***
+- **`libgtest-dev`**: For testing CodeCompass.
+  ***See [Known issues](#known-issues)!***
 
 ## Quick guide
 
 The following command installs the packages except for those which have some
 known issues.
 
-#### Ubuntu 16.04 LTS
+#### Ubuntu 16.04 ("Xenial Xerus") LTS
 
 The standard Ubuntu Xenial package repository contains only LLCM/Clang version
 6, which is not sufficient for CodeCompass, as at least version 7.0 is
@@ -54,12 +58,13 @@ sudo deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main
 sudo deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main
 
 sudo apt-get install git cmake make g++ libboost-all-dev \
-  llvm-7-dev libclang-7-dev odb libodb-dev \
+  llvm-7-dev libclang-7-dev \
+  odb libodb-dev \
   default-jdk libssl-dev libgraphviz-dev libmagic-dev libgit2-dev ctags \
   libgtest-dev npm nodejs-legacy
 ```
 
-#### Ubuntu 18.04 LTS
+#### Ubuntu 18.04 ("Bionic Beaver") LTS
 
 ```bash
 sudo apt install git cmake make g++ gcc-7-plugin-dev libboost-all-dev \
@@ -68,10 +73,22 @@ sudo apt install git cmake make g++ gcc-7-plugin-dev libboost-all-dev \
   libgtest-dev npm
 ```
 
+#### Ubuntu 20.04 ("Focal Fossa") LTS
+
+```bash
+sudo apt install git cmake make g++ libboost-all-dev \
+  llvm-7-dev clang-7 libclang-7-dev \
+  odb libodb-dev thrift-compiler libthrift-dev \
+  default-jdk libssl-dev libgraphviz-dev libmagic-dev libgit2-dev ctags \
+  libgtest-dev npm
+```
+
 #### Database engine support
 
 Depending on the desired database engines to be supported, the following
 packages should be installed:
+
+##### Ubuntu 16.04 ("Xenial Xerus") LTS and 20.04 ("Focal Fossa") LTS
 
 ```bash
 # For SQLite database systems:
@@ -79,6 +96,20 @@ sudo apt-get install libodb-sqlite-dev libsqlite3-dev
 
 # For PostgreSQL database systems:
 sudo apt-get install libodb-pgsql-dev postgresql-server-dev-<version>
+```
+
+##### Ubuntu 18.04 ("Bionic Beaver")
+
+The database connector library must be compiled manually for this release,
+however, the database programs themselves should be installed from the
+package manager.
+
+```bash
+# For SQLite database systems:
+sudo apt install libsqlite3-dev
+
+# For PostgreSQL database systems:
+sudo apt install postgresql-server-dev-<version>
 ```
 
 ## Known issues
@@ -94,22 +125,28 @@ other commands below, unless *explicitly* specified!**
 
 ### ODB (for Ubuntu 18.04)
 ODB is an Object Relational Mapping tool, that is required by CodeCompass.
-For Ubuntu 18.04, the official release of ODB conflicts with the official compiler (GNU G++ 7) of the distribution.
-A newer version of ODB must be compiled manually.
+For Ubuntu 18.04, the official release of ODB conflicts with the official
+compiler (GNU G++ 7) of the distribution. A newer version of ODB must be
+compiled manually.
 
-The ODB installation uses the build2 build system.
-(Build2 is not needed for CodeCompass so you may delete it right after the installation of ODB.)
+The ODB installation uses the build2 build system. (Build2 is not needed for
+CodeCompass so you may delete it right after the installation of ODB.)
+
 ```bash
 wget https://download.build2.org/0.12.0/build2-install-0.12.0.sh
 sh build2-install-0.12.0.sh --yes --trust yes "<build2_install_dir>"
 ```
 
-Now, utilizing the *build2* toolchain, we can build the *odb* library. In the script below, we assume that ODB is built in the `<odb_build_dir>` directory and installed in the `<odb_install_dir>` directory.
+Now, utilizing the *Build2* toolchain, we can build the *ODB* compiler and
+libraries. In the script below, we assume that ODB is built in the
+`<odb_build_dir>` directory and installed in the `<odb_install_dir>` directory.
+
 ```bash
 export PATH="<build2_install_dir>/bin:$PATH"
+
 # Configuring the build
 cd <odb_build_dir>
-bpkg create --quiet --jobs <number_of_threads> cc \
+bpkg create --quiet --jobs $(nproc) cc \
   config.cxx=g++ \
   config.cc.coptions=-O3 \
   config.bin.rpath=<odb_install_dir>/lib \
@@ -126,16 +163,18 @@ bpkg build libodb-sqlite --yes
 bpkg build libodb-pgsql --yes
 bpkg install --all --recursive
 ```
-Please take into consideration that the ODB installation can take up a long time (depending on the machine one is using),
-but you can increase the used threads with the `--jobs` option.
 
-> **Note:** now you may delete the *build2* toolchain installed in the `<build2_install_dir>` folder, if you do not need any longer.
+Please take into consideration that the ODB installation can take up a long
+time (depending on the machine one is using).
 
-### Thrift
+> **Note:** now you may delete the *Build2* toolchain installed in the
+> `<build2_install_dir>` folder, if you do not need any longer.
+
+### Thrift (for Ubuntu 16.04 and 18.04)
 CodeCompass needs [Thrift](https://thrift.apache.org/) which provides Remote
-Procedure Call (RPC) between the server and the client. Thrift is not part of
-the official Ubuntu 16.04 LTS and 18.04 LTS repositories, but you can download
-it and build from source:
+Procedure Call (RPC) between the server and the client. A suitable version of
+Thrift is, unfortunately, not part of the official Ubuntu repositories for
+these versions, so you should download and build from source.
 
 Thrift can generate stubs for many programming languages. The configure
 script looks at the development environment and if it finds the environment
@@ -148,7 +187,8 @@ In certain cases, installation may fail if development libraries for
 languages are not installed on the target machine. E.g. if Python is
 installed but the Python development headers are not, Thrift will unable to
 install. Python, PHP and such other Thrift builds are NOT required by
-CodeCompass, and can significantly increase compile time so it is advised to avoid using them if it's not necessary.
+CodeCompass, and can significantly increase compile time so it is advised to
+avoid using them if it's not necessary.
 
 ```bash
 # Download and uncompress Thrift:
@@ -165,14 +205,14 @@ cd thrift-0.13.0
   --without-haskell --without-go --without-rs --without-haxe        \
   --without-dotnetcore --without-d --without-qt4 --without-qt5
 
-make install
+make install -j $(nproc)
 ```
 
 ### GTest/Googletest
 The `libgtest-dev` package contains only the source files of GTest, but the
 binaries are missing. You have to compile GTest manually.
 
-#### Ubuntu 16.04 LTS
+#### Ubuntu 16.04 ("Xenial Xerus") LTS
 As further complications, under Ubuntu Xenial, the *install* instructions
 are also missing from GTest's build system, so the target binaries
 have to copied manually to the install location.
@@ -186,13 +226,13 @@ mkdir build
 cd build
 
 cmake ..
-make
+make -j $(nproc)
 
 mkdir -p <gtest_install_dir>/lib
 cp libgtest.a libgtest_main.a <gtest_install_dir>/lib/
 ```
 
-#### Ubuntu 18.04 LTS
+#### Ubuntu 18.04 ("Bionic Beaver") and 20.04 ("Focal Fossa") LTS
 ```bash
 mkdir gtest
 cp -R /usr/src/googletest/* ./gtest
@@ -202,43 +242,48 @@ mkdir build
 cd build
 
 cmake .. -DCMAKE_INSTALL_PREFIX=<gtest_install_dir>
-make install
+make install -j $(nproc)
 ```
 
 # Build CodeCompass
-The dependencies which are installed manually because of known issues have to
-be seen by CMake build system:
+The previously self-compiled and installed dependencies are not automatically
+seen by CMake. Please set this environment before executing the build.
 
 ```bash
 export GTEST_ROOT=<gtest_install_dir>
+
+# If using Ubuntu 16.04 or 18.04:
 export CMAKE_PREFIX_PATH=<thrift_install_dir>:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=<odb_install_directory>:$CMAKE_PREFIX_PATH
+
 export PATH=<thrift_install_dir>/bin:$PATH
-export PATH=<odb_install_directory>/bin>:$PATH
+export PATH=<odb_install_directory>/bin:$PATH
 ```
 
 Use the following instructions to build CodeCompass with CMake.
 
 ```bash
 # Obtain CodeCompass source code.
-git clone https://github.com/Ericsson/CodeCompass.git
+git clone https://github.com/Ericsson/CodeCompass.git --origin upstream
 cd CodeCompass
 
 # Create build directory.
-mkdir build
-cd build
+mkdir Build
+cd Build
 
 # Run CMake
 cmake .. \
   -DCMAKE_INSTALL_PREFIX=<CodeCompass_install_dir> \
   -DDATABASE=<database_type> \
-  -DCMAKE_BUILD_TYPE=<build_type>
+  -DCMAKE_BUILD_TYPE=<build_type> \
+  -DLLVM_DIR=/usr/lib/llvm-7/cmake \
+  -DClang_DIR=/usr/lib/cmake/clang-7
 
-#To specify linker for building CodeCompass use
-# -DCODECOMPASS_LINKER=<path_to_linker>
+# To specify linker for building CodeCompass use
+#   -DCODECOMPASS_LINKER=<path_to_linker>
 
 # Build project.
-make -j<number_of_threads>
+make -j $(nproc)
 
 # Copy files to install directory.
 make install
@@ -246,20 +291,15 @@ make install
 
 ## CMake variables
 Besides the common CMake configuration variables you can set the database to be
-used. The following table contains a few CMake variables whic might be relevant
-during compilation.
+used. The following table contains a few CMake variables which might be
+relevant during compilation.
 
-| Variable | Meaning |
-| -------- | ------- |
-| [`CMAKE_INSTALL_PREFIX`](http://cmake.org/cmake/help/v3.0/variable/CMAKE_INSTALL_PREFIX.html) | Install directory. |
-| [`CMAKE_BUILD_TYPE`](http://cmake.org/cmake/help/v3.0/variable/CMAKE_BUILD_TYPE.html)| Specifies the build type on single-configuration generators. Possible values are empty, **`Debug`**, **`Release`**. |
-| `CMAKE_CXX_COMPILER` | If the official repository of your Linux distribution doesn't contain a C++ compiler which supports C++14 then you can install one manually and set to use it. For more information see: https://cmake.org/Wiki/CMake_Useful_Variables |
+|       Variable       |                  Meaning                 |
+| -------------------- | ---------------------------------------- |
+| [`CMAKE_INSTALL_PREFIX`](http://cmake.org/cmake/help/v3.4/variable/CMAKE_INSTALL_PREFIX.html) | Install directory. |
+| [`CMAKE_BUILD_TYPE`](http://cmake.org/cmake/help/v3.4/variable/CMAKE_BUILD_TYPE.html)| Specifies the build type. Supported values are **`Debug`** and **`Release`**. |
+| `CMAKE_CXX_COMPILER` | If the official repository of your Linux distribution doesn't contain a C++ compiler which supports C++14 then you can install one manually and set to use it. For more information see: ['Useful variables'](https://cmake.org/Wiki/CMake_Useful_Variables) |
 | `DATABASE` | Database type. Possible values are **sqlite**, **pgsql**. The default value is `sqlite`. |
-| `TEST_DB` | The connection string for the database that will be used when executing tests with `make test`. |
-| `CODECOMPASS_LINKER` | The variable used to specify the linker. |
+| `TEST_DB` | The connection string for the database that will be used when executing tests with `make test`. Optional. |
+| `CODECOMPASS_LINKER` | The path of the linker, if the system's default linker is to be overridden. |
 
-# Docker
-[![Docker](images/docker.jpg)](https://www.docker.com/)
-
-You can develop CodeCompass in docker containers. For more information
-[see](/docker/README.md).

--- a/plugins/cpp_reparse/service/CMakeLists.txt
+++ b/plugins/cpp_reparse/service/CMakeLists.txt
@@ -32,7 +32,7 @@ add_custom_command(
     ${CMAKE_CURRENT_BINARY_DIR}/gen-cpp
     ${CMAKE_CURRENT_BINARY_DIR}/gen-js
   COMMAND
-    thrift --gen cpp --gen js:jquery
+    ${THRIFT_EXECUTABLE} --gen cpp --gen js:jquery
       -o ${CMAKE_CURRENT_BINARY_DIR}
       -I ${PROJECT_SOURCE_DIR}/service
       ${CMAKE_CURRENT_SOURCE_DIR}/cppreparse.thrift

--- a/plugins/git/service/git.thrift
+++ b/plugins/git/service/git.thrift
@@ -2,14 +2,14 @@ namespace cpp cc.service.git
 
 enum GitObjectType
 {
-  GIT_OBJ__EXT1 = 0,      /**< Reserved for future use. */
-  GIT_OBJ_COMMIT = 1,     /**< A commit object. */
-  GIT_OBJ_TREE = 2,       /**< A tree (directory listing) object. */
-  GIT_OBJ_BLOB = 3,       /**< A file revision object. */
-  GIT_OBJ_TAG = 4,        /**< An annotated tag object. */
-  GIT_OBJ__EXT2 = 5,      /**< Reserved for future use. */
-  GIT_OBJ_OFS_DELTA = 6,  /**< A delta, base is given by an offset. */
-  GIT_OBJ_REF_DELTA = 7,  /**< A delta, base is given by object id. */
+  Reserved1 = 0,  /**< Reserved for future use in Libgit2. */
+  Commit = 1,     /**< A commit object. */
+  Tree = 2,       /**< A tree (directory listing) object. */
+  Blob = 3,       /**< A file revision object. */
+  Tag = 4,        /**< An annotated tag object. */
+  Reserved2 = 5,  /**< Reserved for future use in Libgit2. */
+  OffetDelta = 6, /**< A delta, base is given by an offset. */
+  RefDelta = 7,   /**< A delta, base is given by object id. */
 }
 
 struct GitSignature

--- a/plugins/git/webgui/js/gitNavigator.js
+++ b/plugins/git/webgui/js/gitNavigator.js
@@ -230,7 +230,7 @@ function (Tooltip, ObjectStoreModel, declare, Memory, Observable, topic,
             var topObj = model.gitservice.getReferenceTopObject(
               repo.id, branchName);
 
-            if (topObj.type === GitObjectType.GIT_OBJ_COMMIT) {
+            if (topObj.type === GitObjectType.Commit) {
               that._data.push({
                 id          : branchCommitsId + "_view",
                 name        : '(branches view)',
@@ -271,7 +271,7 @@ function (Tooltip, ObjectStoreModel, declare, Memory, Observable, topic,
             var topObj = model.gitservice.getReferenceTopObject(
               repo.id, tagName);
 
-            if (topObj.type === GitObjectType.GIT_OBJ_TAG) {
+            if (topObj.type === GitObjectType.Tag) {
               var tag = model.gitservice.getTag(repo.id, topObj.oid);
 
               that._data.push({

--- a/util/include/util/hash.h
+++ b/util/include/util/hash.h
@@ -1,11 +1,16 @@
-#ifndef CC_PARSER_HASH_H
-#define CC_PARSER_HASH_H
+#ifndef CC_UTIL_HASH_H
+#define CC_UTIL_HASH_H
 
 #include <cstdint>
 #include <string>
 #include <sstream>
 
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 106800 /* 1.68.0 */
+#include <boost/uuid/detail/sha1.hpp>
+#else
 #include <boost/uuid/sha1.hpp>
+#endif
 
 namespace cc
 {
@@ -50,4 +55,4 @@ inline std::string sha1Hash(const std::string& data_)
 } // util
 } // cc
 
-#endif // CC_PARSER_HASH_H
+#endif // CC_UTIL_HASH_H


### PR DESCRIPTION
> **Note:** Depends on #385.

Closes #392.

 - Tidied up the Travis file, use APT addon, use as many cores as allowed in the VM. (Currently two.)
 - Worked around some backwards-incompatbile minor API breaks of Libgit2 and Boost.
 - Tidied up the user guide.
