### PR TITLE
Relative import path for JS and CSS assets in webGUI

### DIFF
--- a/service/plugin/src/pluginservice.cpp
+++ b/service/plugin/src/pluginservice.cpp
@@ -48,9 +48,9 @@ void PluginServiceHandler::getWebPlugins(std::vector<std::string>& return_)
     webrootDir + "/scripts/codecompass/view");
 
   for (const std::string& file_ : generatedFiles)
-    return_.push_back(file_.substr(webrootDir.size()));
+    return_.push_back(file_.substr(webrootDir.size() + 1)); // +1 to remove starting slash
   for (const std::string& file_ : jsModules)
-    return_.push_back(file_.substr(webrootDir.size()));
+    return_.push_back(file_.substr(webrootDir.size() + 1)); // +1 to remove starting slash
 }
 
 void PluginServiceHandler::getWebStylePlugins(std::vector<std::string>& return_)
@@ -60,7 +60,7 @@ void PluginServiceHandler::getWebStylePlugins(std::vector<std::string>& return_)
   std::vector<std::string> cssFiles = getFiles(webrootDir + "/style");
 
   for (const std::string& file_ : cssFiles)
-    return_.push_back(file_.substr(webrootDir.size()));
+    return_.push_back(file_.substr(webrootDir.size() + 1)); // +1 to remove starting slash
 }
 
 }

--- a/webgui/index.html
+++ b/webgui/index.html
@@ -48,7 +48,7 @@
 
     <script type="text/javascript">
       var dojoConfig = {
-        baseUrl: '/scripts/',
+        baseUrl: 'scripts/',
         tlmSiblingOfDojo: false,
         defaultDuration: 1,
         async: true,

--- a/webgui/login.html
+++ b/webgui/login.html
@@ -24,7 +24,7 @@
 
     <script type="text/javascript">
         var dojoConfig = {
-            baseUrl: '/scripts/',
+            baseUrl: 'scripts/',
             tlmSiblingOfDojo: false,
             defaultDuration: 1,
             async: true,


### PR DESCRIPTION
In a production environment, the Mongoose webserver hosting CodeCompass would be most likely hidden behind Apache, Nginx, IIS, etc. with a reverse proxy configuration and would not be placed in the document root, but be accessible as a virtual subdirectory, e.g. *https://domain.com/codecompass/*.

Currently some URLs to JS and CSS assets are given as absolute paths, assuming that CodeCompass is available in the document root of the webserver. This PR fixes that.