### PR TITLE
Docker image upgrade to Ubuntu 20.04

### DIFF
--- a/Functions.cmake
+++ b/Functions.cmake
@@ -99,23 +99,6 @@ function(install_webplugin _dir)
   set_property(GLOBAL APPEND PROPERTY USERGUIDES "${_userguides}")
 endfunction(install_webplugin)
 
-# Finds the absolute paths for the given Boost libraries
-# Use variable arguments for the Boost libraries to link
-function(find_boost_libraries)
-  foreach(_lib ${ARGV})
-    foreach(_path ${Boost_LIBRARIES})
-      if(_path MATCHES ".*boost_${_lib}\.so$")
-        list(APPEND LIBS ${_path})
-      elseif(_path MATCHES "Boost::${_lib}$")
-        # There is no path for the lib, included as a module.
-        list(APPEND LIBS ${_path})
-      endif()
-    endforeach(_path)
-  endforeach(_lib)
-
-  set(Boost_LINK_LIBRARIES ${LIBS} PARENT_SCOPE)
-endfunction(find_boost_libraries)
-
 # Prints a coloured, and optionally bold message to the console.
 # _colour should be some ANSI colour name, like "blue" or "magenta".
 function(fancy_message _str _colour _isBold)

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,74 +1,47 @@
-# CodeCompass development dependencies
-FROM ubuntu:bionic
+FROM ubuntu:20.04
 
+# tzdata package is installed implicitly in the following command. This package
+# sets timezone interactively during the installation process. This environment
+# variable prevents this interaction.
+ARG DEBIAN_FRONTEND=noninteractive
+
+# CodeCompass development dependencies.
 RUN set -x && apt-get update -qq \
-    && apt-get -y install \
-    cmake make \
-    curl ctags \
-    default-jdk \
-    gcc-7 gcc-7-plugin-dev \
-    libboost-filesystem-dev \
-    libboost-log-dev \
-    libboost-program-options-dev \
-    libboost-regex-dev \
-    libgit2-dev \
-    libgraphviz-dev \
-    libgtest-dev \
-    libmagic-dev \
-    libsqlite3-dev \
-    libssl1.0-dev \
-    llvm-7 clang-7 llvm-7-dev libclang-7-dev \
-    nodejs-dev node-gyp npm
+  && apt-get -y install --no-install-recommends \
+  cmake make \
+  default-jdk \
+  ctags \
+  gcc-9 gcc-9-plugin-dev g++-9 \
+  libboost-filesystem-dev \
+  libboost-log-dev \
+  libboost-program-options-dev \
+  libboost-regex-dev \
+  libgit2-dev \
+  libgraphviz-dev \
+  libgtest-dev \
+  libmagic-dev \
+  libsqlite3-dev \
+  libssl-dev \
+  llvm-7 clang-7 llvm-7-dev libclang-7-dev \
+  npm \
+  thrift-compiler libthrift-dev \
+  odb libodb-sqlite-dev && \
+  ln -s /usr/bin/gcc-9 /usr/bin/gcc && \
+  ln -s /usr/bin/g++-9 /usr/bin/g++
 
-# Download the Thrift source code.
-ADD http://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=thrift/0.13.0/thrift-0.13.0.tar.gz /opt/thrift-0.13.0.tar.gz
-# Build Thrift
-RUN tar -xf /opt/thrift-0.13.0.tar.gz -C /opt; \
-    cd /opt/thrift-0.13.0 && \
-    ./configure --prefix=/opt/thrift_install \
-    --silent --without-python                                        \
-    --enable-libtool-lock --enable-tutorial=no --enable-tests=no     \
-    --with-libevent --with-zlib --without-nodejs --without-lua       \
-    --without-ruby --without-csharp --without-erlang --without-perl  \
-    --without-php --without-php_extension --without-dart             \
-    --without-haskell --without-go --without-rs --without-haxe       \
-    --without-dotnetcore --without-d --without-qt4 --without-qt5;    \
-    cd /; \
-    make -C /opt/thrift-0.13.0 -j $(nproc) --silent install; \
-    rm -rf /opt/thrift-0.13.0
 # Build GTest.
-RUN cd /usr/src/googletest/ && \
-     mkdir build && \
-     cd build && \
-     cmake .. && \
-     make install && \
-     cd / && \
-     rm -rf /usr/src/googletest/build
+RUN cd /usr/src/googletest && \
+  mkdir build && \
+  cd build && \
+  cmake .. && \
+  make install && \
+  cd / && \
+  rm -rf /usr/src/googletest/build
 
-# Download build2 toolchain install script.
-ADD https://download.build2.org/0.12.0/build2-install-0.12.0.sh /opt/build2-install-0.12.0.sh
-# Build build2, then ODB.
-RUN cd /opt/ && \
-    sh build2-install-0.12.0.sh --yes --trust yes; \
-    mkdir /opt/odb_build && \
-    cd /opt/odb_build && \
-    bpkg create --quiet --jobs $(nproc) cc \
-    config.cxx=g++ \
-    config.cc.coptions=-O3 \
-    config.bin.rpath=/opt/odb_install/lib \
-    config.install.root=/opt/odb_install && \
-    bpkg add https://pkg.cppget.org/1/beta --trust-yes && \
-    bpkg fetch --trust-yes && \
-    bpkg build odb --yes && \
-    bpkg build libodb --yes && \
-    bpkg build libodb-sqlite --yes && \
-    bpkg build libodb-pgsql --yes && \
-    bpkg install --all --recursive; \
-    rm -rf /opt/build2* && \
-    rm -rf /opt/odb_build
-
+# Adding CodeCompass builder script.
 COPY docker/dev/codecompass-build.sh /usr/local/bin
 
+# Setting the environment.
 ENV DATABASE=sqlite \
     BUILD_TYPE=Release \
     BUILD_DIR=/CodeCompass/build \
@@ -77,6 +50,4 @@ ENV DATABASE=sqlite \
     TEST_WORKSPACE=/CodeCompass/test_workspace \
     TEST_DB="sqlite:database=$TEST_WORKSPACE/cc_test.sqlite"
 
-ENV PATH="$INSTALL_DIR/bin:/opt/thrift_install/bin:/opt/odb_install/bin:$PATH"
-ENV CMAKE_PREFIX_PATH="/opt/thrift_install:/opt/odb_install:$CMAKE_PREFIX_PATH"
-ENV LD_LIBRARY_PATH="$INSTALL_DIR/lib:$LD_LIBRARY_PATH"
+ENV PATH="$INSTALL_DIR/bin:$PATH"

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -27,26 +27,33 @@ RUN mkdir /CodeCompass-build && \
     -DDATABASE=$CC_DATABASE \
     -DCMAKE_INSTALL_PREFIX=/CodeCompass-install \
     -DCMAKE_BUILD_TYPE=$CC_BUILD_TYPE && \
-  make && \
+  make -j $(nproc) && \
   make install
 
 ###############################################################################
 #--------------------------    PRODUCTION STAGE   ----------------------------#
 ###############################################################################
 
-FROM ubuntu:bionic
+FROM ubuntu:20.04
+
+# tzdata package is installed implicitly in the following command. This package
+# sets timezone interactively during the installation process. This environment
+# variable prevents this interaction.
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN set -x && apt-get update -qq \
   && apt-get install -qqy --no-install-recommends \
     llvm-7 \
     libboost-filesystem-dev libboost-log-dev libboost-program-options-dev \
     libsqlite3-dev \
-    postgresql-server-dev-10 \
+    postgresql-server-dev-12 \
     default-jre \
     libgit2-dev \
-    libssl1.0.0 \
+    libssl1.1 \
     libgvc6 \
     libmagic-dev \
+    libthrift-dev \
+    libodb-sqlite-dev \
     ctags \
     # To switch user and exec command.
     gosu \
@@ -69,14 +76,7 @@ RUN groupadd -r codecompass -g ${CC_GID} && \
 # Copy CodeCompass installed directory. (Change permission of the CodeCompass package.)
 COPY --from=builder --chown=codecompass:codecompass /CodeCompass-install /codecompass
 
-# Copy Thrift installed directory.
-COPY --from=builder /opt/thrift_install /opt/thrift
-
-# Copy ODB installed directory.
-COPY --from=builder /opt/odb_install /opt/odb
-
 ENV PATH="/codecompass/bin:$PATH"
-ENV LD_LIBRARY_PATH="/codecompass/lib:/opt/thrift/lib:/opt/odb/lib:$LD_LIBRARY_PATH"
 
 COPY --chown=codecompass:codecompass docker/web/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod a+x /usr/local/bin/entrypoint.sh

--- a/parser/CMakeLists.txt
+++ b/parser/CMakeLists.txt
@@ -15,16 +15,10 @@ add_executable(CodeCompass_parser
 set_target_properties(CodeCompass_parser
   PROPERTIES ENABLE_EXPORTS 1)
 
-find_boost_libraries(
-  filesystem
-  log
-  program_options
-  system
-  thread)
 target_link_libraries(CodeCompass_parser
   util
   model
-  ${Boost_LINK_LIBRARIES}
+  ${Boost_LIBRARIES}
   ${ODB_LIBRARIES}
   ${CMAKE_DL_LIBS}
   magic

--- a/plugins/cpp/test/CMakeLists.txt
+++ b/plugins/cpp/test/CMakeLists.txt
@@ -22,18 +22,12 @@ add_executable(cppparsertest
 target_compile_options(cppservicetest PUBLIC -Wno-unknown-pragmas)
 target_compile_options(cppparsertest PUBLIC -Wno-unknown-pragmas)
 
-find_boost_libraries(
-  filesystem
-  log
-  program_options
-  system)
-
 target_link_libraries(cppservicetest
   util
   model
   cppmodel
   cppservice
-  ${Boost_LINK_LIBRARIES}
+  ${Boost_LIBRARIES}
   ${GTEST_BOTH_LIBRARIES}
   pthread)
 
@@ -41,7 +35,7 @@ target_link_libraries(cppparsertest
   util
   model
   cppmodel
-  ${Boost_LINK_LIBRARIES}
+  ${Boost_LIBRARIES}
   ${GTEST_BOTH_LIBRARIES}
   pthread)
 

--- a/plugins/metrics/parser/CMakeLists.txt
+++ b/plugins/metrics/parser/CMakeLists.txt
@@ -8,13 +8,10 @@ include_directories(
 add_library(metricsparser SHARED
   src/metricsparser.cpp)
 
-find_boost_libraries(
-  filesystem
-  log)
 target_link_libraries(metricsparser
   metricsmodel
   util
-  ${Boost_LINK_LIBRARIES})
+  ${Boost_LIBRARIES})
 
 install(TARGETS metricsparser
   LIBRARY DESTINATION ${INSTALL_LIB_DIR}

--- a/plugins/search/indexer/CMakeLists.txt
+++ b/plugins/search/indexer/CMakeLists.txt
@@ -48,15 +48,11 @@ add_subdirectory(indexer-java)
 add_library(indexerservice SHARED
   src/indexerprocess.cpp)
 
-find_boost_libraries(
-  filesystem
-  log
-  system)
 target_link_libraries(indexerservice
   util
   searchindexerthrift
   ${THRIFT_LIBTHRIFT_LIBRARIES}
-  ${Boost_LINK_LIBRARIES})
+  ${Boost_LIBRARIES})
 
 install(TARGETS indexerservice DESTINATION ${INSTALL_LIB_DIR})
 install_jar(searchindexerthriftjava ${INSTALL_JAVA_LIB_DIR})

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -19,11 +19,8 @@ add_library(util STATIC
 
 target_compile_options(util PUBLIC -fPIC)
 
-find_boost_libraries(
-  regex)
-
 target_link_libraries(util
-  ${Boost_LINK_LIBRARIES})
+  ${Boost_LIBRARIES})
 
 string(TOLOWER "${DATABASE}" _database)
 if (${_database} STREQUAL "sqlite")

--- a/webserver/CMakeLists.txt
+++ b/webserver/CMakeLists.txt
@@ -22,16 +22,10 @@ target_include_directories(CodeCompass_webserver PUBLIC
   ${PROJECT_SOURCE_DIR}/model/include
   ${PROJECT_SOURCE_DIR}/util/include)
 
-find_boost_libraries(
-  filesystem
-  log
-  program_options
-  system
-  thread)
 target_link_libraries(CodeCompass_webserver
   util
   mongoose
-  ${Boost_LINK_LIBRARIES}
+  ${Boost_LIBRARIES}
   ${ODB_LIBRARIES}
   pthread
   dl)


### PR DESCRIPTION
The development Docker image has been upgraded to use Ubuntu 20.04.
This Ubuntu version contains ODB and Thrift in its package manager, so there is no need to build these tools from source code.