### PR TITLE
Left side and file content menu fix

### DIFF
--- a/plugins/cpp/service/src/cppservice.cpp
+++ b/plugins/cpp/service/src/cppservice.cpp
@@ -1238,7 +1238,7 @@ void CppServiceHandler::getFileDiagramTypes(
     return_["This module depends on"]               = EXTERNAL_DEPENDENCY;
     return_["Users of this module"]                 = EXTERNAL_USERS;
   }
-  else
+  else if (file->parseStatus != model::File::PSNone)
   {
     return_["Include Dependency"]                   = INCLUDE_DEPENDENCY;
     return_["Component Users"]                      = COMPONENT_USERS;

--- a/plugins/cpp/service/src/cppservice.cpp
+++ b/plugins/cpp/service/src/cppservice.cpp
@@ -1238,7 +1238,7 @@ void CppServiceHandler::getFileDiagramTypes(
     return_["This module depends on"]               = EXTERNAL_DEPENDENCY;
     return_["Users of this module"]                 = EXTERNAL_USERS;
   }
-  else if (file->parseStatus != model::File::PSNone)
+  else if (file->type == "CPP")
   {
     return_["Include Dependency"]                   = INCLUDE_DEPENDENCY;
     return_["Component Users"]                      = COMPONENT_USERS;

--- a/webgui/scripts/codecompass/view/component/Text.js
+++ b/webgui/scripts/codecompass/view/component/Text.js
@@ -431,6 +431,9 @@ function (declare, domClass, dom, style, query, topic, ContentPane, Dialog,
 
       var astNodeInfo = astHelper.getAstNodeInfoByPosition(position, fileInfo);
 
+      if (!astNodeInfo)
+        return;
+
       var refTypes = model.cppservice.getReferenceTypes(astNodeInfo.id);
       var usages = model.cppservice.getReferences(
         astNodeInfo.id,


### PR DESCRIPTION
Fixed the File Manager menu to not show C++ options if the file is not parsed. 
Fixed the file content menu to not show menu options that depend on AST node info. 
Closes #219 