### PR TITLE
Use the Dojo Build System

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ nbproject/
 .idea/
 *.swp
 build/
-
+build_*/

--- a/service/plugin/include/pluginservice/pluginservice.h
+++ b/service/plugin/include/pluginservice/pluginservice.h
@@ -22,6 +22,8 @@ public:
 
   void getPlugins(std::vector<std::string>& return_) override;
 
+  void getThriftPlugins(std::vector<std::string> & _return) override;
+
   void getWebPlugins(std::vector<std::string> & _return) override;
 
   void getWebStylePlugins(std::vector<std::string> & _return) override;

--- a/service/plugin/plugin.thrift
+++ b/service/plugin/plugin.thrift
@@ -8,8 +8,12 @@ service PluginService
   list<string> getPlugins()
 
   /**
-   * Returns a list of javascript plugins from install web directory
-   * (eg. generated thrift files, modules)
+   * Returns a list of generated Thrift javascript plugins from install web directory
+   */
+  list<string> getThriftPlugins()
+
+  /**
+   * Returns a list of custom javascript plugins from install web directory
    */
   list<string> getWebPlugins()
   

--- a/service/plugin/src/pluginservice.cpp
+++ b/service/plugin/src/pluginservice.cpp
@@ -1,4 +1,5 @@
 #include <pluginservice/pluginservice.h>
+#include <boost/regex.hpp>
 
 namespace
 {
@@ -37,20 +38,36 @@ void PluginServiceHandler::getPlugins(std::vector<std::string>& return_)
     return_.push_back(it.first);
 }
 
-void PluginServiceHandler::getWebPlugins(std::vector<std::string>& return_)
+void PluginServiceHandler::getThriftPlugins(std::vector<std::string>& return_)
 {
   std::string webrootDir = _configuration["webguiDir"].as<std::string>();
 
   std::vector<std::string> generatedFiles = getFiles(
     webrootDir + "/scripts/codecompass/generated");
 
-  std::vector<std::string> jsModules = getFiles(
-    webrootDir + "/scripts/codecompass/view");
-
   for (const std::string& file_ : generatedFiles)
     return_.push_back(file_.substr(webrootDir.size() + 1)); // +1 to remove starting slash
+}
+
+void PluginServiceHandler::getWebPlugins(std::vector<std::string>& return_)
+{
+  std::string webrootDir = _configuration["webguiDir"].as<std::string>();
+
+  std::vector<std::string> jsModules = getFiles(
+    webrootDir + "/scripts/release/codecompass/view");
+
+  /*
+   * Pattern to match only *.js files which does not contain the '.js.' substring, to exclude:
+   * *.js.uncompressed.js
+   * *.js.consoleStripped.js
+   * *.js.map
+   */
+  static const boost::regex pattern("^((?!\\.js\\.).)*\\.js$");
   for (const std::string& file_ : jsModules)
-    return_.push_back(file_.substr(webrootDir.size() + 1)); // +1 to remove starting slash
+  {
+    if (boost::regex_match(file_, pattern))
+      return_.push_back(file_.substr(webrootDir.size() + 1)); // +1 to remove starting slash
+  }
 }
 
 void PluginServiceHandler::getWebStylePlugins(std::vector<std::string>& return_)

--- a/webgui/CMakeLists.txt
+++ b/webgui/CMakeLists.txt
@@ -15,5 +15,7 @@ install(FILES
 
 # Install npm packages
 install(CODE "set(CC_PACKAGE \"${CMAKE_CURRENT_SOURCE_DIR}/package.json\")")
+install(CODE "set(CC_PROFILE \"${CMAKE_CURRENT_SOURCE_DIR}/codecompass.profile.js.in\")")
 install(CODE "set(INSTALL_SCRIPTS_DIR \"${INSTALL_WEBROOT_DIR}/scripts/\")")
+install(CODE "set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE})")
 install(SCRIPT InstallGUI.cmake)

--- a/webgui/InstallGUI.cmake
+++ b/webgui/InstallGUI.cmake
@@ -2,7 +2,41 @@ message("Install npm packages...")
 
 execute_process(
   COMMAND cp ${CC_PACKAGE} ${INSTALL_SCRIPTS_DIR}/package.json
+  WORKING_DIRECTORY ${INSTALL_SCRIPTS_DIR})
+
+execute_process(
   COMMAND npm install
   WORKING_DIRECTORY ${INSTALL_SCRIPTS_DIR})
 
+execute_process(
+  COMMAND ${CMAKE_COMMAND} -E create_symlink dojo-util node_modules/util
+  WORKING_DIRECTORY ${INSTALL_SCRIPTS_DIR})
+
 message("Installation of npm packages are finished.")
+
+message("Initiating the Dojo Build System...")
+
+# Collect CodeCompass view JavaScript files
+set(DOJO_VIEWLIST "")
+file(GLOB _jsfiles RELATIVE "${INSTALL_SCRIPTS_DIR}" "${INSTALL_SCRIPTS_DIR}/codecompass/view/[^A-Z]*.js")
+foreach(_jsfile ${_jsfiles})
+  string(REGEX REPLACE "\\.js*$" "" _jsfile ${_jsfile})
+  list(APPEND DOJO_VIEWLIST "'${_jsfile}'")
+endforeach()
+list(JOIN DOJO_VIEWLIST  ", " DOJO_VIEWLIST)
+
+set(DOJO_OPTIMIZE "")       # optimization for non-layer modules
+set(DOJO_LAYEROPTIMIZE "")  # optimization for layer modules
+if (CMAKE_BUILD_TYPE STREQUAL "Release")
+  set(DOJO_LAYEROPTIMIZE "closure")
+endif()
+configure_file(${CC_PROFILE} ${INSTALL_SCRIPTS_DIR}/codecompass.profile.js)
+
+execute_process(
+  COMMAND node_modules/util/buildscripts/build.sh --profile codecompass.profile.js
+  WORKING_DIRECTORY ${INSTALL_SCRIPTS_DIR})
+
+# The build-report may leak sensitive information
+file(REMOVE ${INSTALL_SCRIPTS_DIR}/release/build-report.txt)
+
+message("The Dojo Build System finished.")

--- a/webgui/codecompass.profile.js.in
+++ b/webgui/codecompass.profile.js.in
@@ -1,0 +1,91 @@
+// Based on the dojo-boilerplate
+// https://github.com/csnover/dojo-boilerplate
+
+var profile = {
+    // `basePath` is relative to the directory containing this profile file; in this case, it is being set to the
+    // src/ directory, which is the same place as the `baseUrl` directory in the loader configuration. (If you change
+    // this, you will also need to update run.js.)
+    basePath: './',
+
+    // This is the root directory where the build should go.
+    // The builder will attempt to create this directly and will overwrite anything it finds there.
+    // It is relative to the `basePath`
+    releaseDir: './release',
+
+    // Builds a new release.
+    action: 'release',
+
+    // Strips all comments and whitespace from CSS files and inlines @imports where possible.
+    cssOptimize: 'comments',
+
+    // Excludes tests, demos, and original template files from being included in the built version.
+    mini: true,
+
+    // Uses Closure Compiler as the JavaScript minifier. This can also be set to "shrinksafe" to use ShrinkSafe,
+    // though ShrinkSafe is deprecated and not recommended.
+    // This option defaults to "" (no compression) if not provided.
+    optimize: '@DOJO_OPTIMIZE@', // CMake will insert the value
+
+    // We're building layers, so we need to set the minifier to use for those, too.
+    // This defaults to "shrinksafe" if not provided.
+    layerOptimize: '@DOJO_LAYEROPTIMIZE@', // CMake will insert the value
+
+    // A list of packages that will be built. The same packages defined in the loader should be defined here in the
+    // build profile.
+    packages: [
+        // Using a string as a package is shorthand for `{ name: 'app', location: 'app' }`
+        //'app',
+        { name: 'dojo',  location: 'node_modules/dojo'  },
+        { name: 'dijit', location: 'node_modules/dijit' },
+        { name: 'dojox', location: 'node_modules/dojox' },
+        { name: 'codecompass', location: 'codecompass' },
+        { name: 'login', location: 'login' }
+    ],
+
+    // Strips all calls to console functions within the code. You can also set this to "warn" to strip everything
+    // but console.error, and any other truthy value to strip everything but console.warn and console.error.
+    // This defaults to "normal" (strip all but warn and error) if not provided.
+    stripConsole: 'normal', // all | warn | normal | none
+
+    // The default selector engine is not included by default in a dojo.js build in order to make mobile builds
+    // smaller. We add it back here to avoid that extra HTTP request. There is also an "acme" selector available; if
+    // you use that, you will need to set the `selectorEngine` property in index.html, too.
+    selectorEngine: 'lite',
+
+    // Any module in an application can be converted into a "layer" module, which consists of the original module +
+    // additional dependencies built into the same file. Using layers allows applications to reduce the number of HTTP
+    // requests by combining all JavaScript into a single file.
+    layers: {
+        // This is the main loader module. It is a little special because it is treated like an AMD module even though
+        // it is actually just plain JavaScript. There is some extra magic in the build system specifically for this
+        // module ID.
+        'dojo/dojo': {
+            // By default, the build system will try to include `dojo/main` in the built `dojo/dojo` layer, which adds
+            // a bunch of stuff we do not want or need. We want the initial script load to be as small and quick to
+            // load as possible, so we configure it as a custom, bootable base.
+            boot: true,
+            customBase: true,
+
+            include: [
+                'dojo/_base/array',
+                'dojo/dom-construct',
+                'dojo/domReady'
+            ]
+        },
+
+        // Further application-specific layers. Note that when you create a new layer, the module referenced by the
+        // layer is always included in the layer, so it does not need to be explicitly defined in the `include` array.
+        'codecompass/bundle': {
+            include: [
+                'codecompass/codecompass',
+                @DOJO_VIEWLIST@ // CMake will insert the list of files
+            ]
+        },
+
+        'login/bundle': {
+            include: [
+                'login/login'
+            ]
+        }
+    }
+};

--- a/webgui/index.html
+++ b/webgui/index.html
@@ -12,12 +12,12 @@
     <link rel="stylesheet" href="scripts/node_modules/codemirror/lib/codemirror.css" />
     <link rel="stylesheet" href="scripts/node_modules/codemirror/addon/dialog/dialog.css" />
     <link rel="stylesheet" href="scripts/node_modules/codemirror/addon/fold/foldgutter.css" />
-    <link rel="stylesheet" href="scripts/node_modules/dojo/resources/dojo.css" />
-    <link rel="stylesheet" href="scripts/node_modules/dijit/themes/claro/claro.css"/>
-    <link rel="stylesheet" href="scripts/node_modules/dojox/layout/resources/ResizeHandle.css" />
-    <link rel="stylesheet" href="scripts/node_modules/dojox/layout/resources/FloatingPane.css" />
-    <link rel="stylesheet" href="scripts/node_modules/dojox/image/resources/Lightbox.css" />
-    <link rel="stylesheet" href="scripts/node_modules/dojox/grid/resources/claroGrid.css" />
+    <link rel="stylesheet" href="scripts/release/dojo/resources/dojo.css" />
+    <link rel="stylesheet" href="scripts/release/dijit/themes/claro/claro.css"/>
+    <link rel="stylesheet" href="scripts/release/dojox/layout/resources/ResizeHandle.css" />
+    <link rel="stylesheet" href="scripts/release/dojox/layout/resources/FloatingPane.css" />
+    <link rel="stylesheet" href="scripts/release/dojox/image/resources/Lightbox.css" />
+    <link rel="stylesheet" href="scripts/release/dojox/grid/resources/claroGrid.css" />
 
     <!-- Third party libraries -->
 
@@ -44,24 +44,29 @@
     <script type="text/javascript" src="scripts/node_modules/svg-pan-zoom/dist/svg-pan-zoom.min.js"></script>
     <script type="text/javascript" src="scripts/node_modules/marked/lib/marked.js"></script>
     <script type="text/javascript" src="scripts/node_modules/d3/d3.min.js"></script>
-    
+    <script type="text/javascript" src="scripts/node_modules/js-cookie/src/js.cookie.js"></script>
 
     <script type="text/javascript">
+      if (Cookies.get('dojo-cache') === undefined) {
+        Cookies.set('dojo-cache', Date.now(), { expires: 7 });
+      }
+
       var dojoConfig = {
-        baseUrl: 'scripts/',
+        baseUrl: 'scripts/release/',
         tlmSiblingOfDojo: false,
         defaultDuration: 1,
         async: true,
-        cacheBust: true,
+        cacheBust: Cookies.get('dojo-cache'),
         packages: [
-          { name: 'dojo',  location: 'node_modules/dojo'  },
-          { name: 'dijit', location: 'node_modules/dijit' },
-          { name: 'dojox', location: 'node_modules/dojox' }
+          { name: 'dojo',  location: 'dojo'  },
+          { name: 'dijit', location: 'dijit' },
+          { name: 'dojox', location: 'dojox' },
+          { name: 'codecompass', location: 'codecompass' }
         ]
       };
     </script>
 
-    <script type="text/javascript" src="scripts/node_modules/dojo/dojo.js"></script>
+    <script type="text/javascript" src="scripts/release/dojo/dojo.js"></script>
 
     <script type="text/javascript">
       var commonModules = [
@@ -78,7 +83,7 @@
         'scripts/codecompass/generated/WorkspaceService.js'
       ];
 
-      require(commonModules, function(){
+      require(commonModules, function(){ // load common thrift modules
         require([
           'dojo/_base/array',
           'dojo/dom-construct',
@@ -93,16 +98,21 @@
             }, document.getElementsByTagName('head')[0]);
           });
 
-          var modules = model.plugin.getWebPlugins();
-          var diffModule = array.filter(modules, function(module){
+          var thriftModules = model.plugin.getThriftPlugins();
+          var diffModules = array.filter(thriftModules, function(module){
             return commonModules.indexOf(module) < 0;
           });
-          require(diffModule, function(){
-            require([
-              'codecompass/codecompass',
-              'dojo/domReady!'],
-            function (codecompass) {
-              codecompass();
+          require(diffModules, function() { // load plugin thrift modules
+            require(['scripts/release/codecompass/bundle.js'], function() { // load codecompass bundle
+              var webModules = model.plugin.getWebPlugins();
+              require(webModules, function() { // load any module not in bundle
+                require([
+                  'codecompass/codecompass',
+                  'dojo/domReady!'
+                ], function (codecompass) {
+                  codecompass();
+                });
+              });
             });
           });
         });

--- a/webgui/login.html
+++ b/webgui/login.html
@@ -13,31 +13,37 @@
     <link rel="stylesheet" href="style/codecompass.css" />
     <link rel="stylesheet" href="style/icons.css" />
 
-    <link rel="stylesheet" href="scripts/node_modules/dojo/resources/dojo.css" />
-    <link rel="stylesheet" href="scripts/node_modules/dijit/themes/claro/claro.css"/>
+    <link rel="stylesheet" href="scripts/release/dojo/resources/dojo.css" />
+    <link rel="stylesheet" href="scripts/release/dijit/themes/claro/claro.css"/>
 
     <!-- Third party libraries -->
 
     <script type="text/javascript" src="scripts/node_modules/thrift/src/thrift.js"></script>
     <script type="text/javascript" src="scripts/node_modules/jquery/dist/jquery.min.js"></script>
     <script type="text/javascript" src="scripts/node_modules/jsplumb/dist/js/jsPlumb-2.2.1-min.js"></script>
+    <script type="text/javascript" src="scripts/node_modules/js-cookie/src/js.cookie.js"></script>
 
     <script type="text/javascript">
+        if (Cookies.get('dojo-cache') === undefined) {
+            Cookies.set('dojo-cache', Date.now(), { expires: 7 });
+        }
+
         var dojoConfig = {
-            baseUrl: 'scripts/',
+            baseUrl: 'scripts/release/',
             tlmSiblingOfDojo: false,
             defaultDuration: 1,
             async: true,
-            cacheBust: true,
+            cacheBust: Cookies.get('dojo-cache'),
             packages: [
-                { name: 'dojo',  location: 'node_modules/dojo'  },
-                { name: 'dijit', location: 'node_modules/dijit' },
-                { name: 'dojox', location: 'node_modules/dojox' }
+                { name: 'dojo',  location: 'dojo'  },
+                { name: 'dijit', location: 'dijit' },
+                { name: 'dojox', location: 'dojox' },
+                { name: 'login', location: 'login' }
             ]
         };
     </script>
 
-    <script type="text/javascript" src="scripts/node_modules/dojo/dojo.js"></script>
+    <script type="text/javascript" src="scripts/release/dojo/dojo.js"></script>
 
     <script type="text/javascript">
         var commonModules = [
@@ -45,11 +51,12 @@
             'scripts/codecompass/generated/AuthenticationService.js'
         ];
 
-        require(commonModules, function(){
-            require([
-              'login/login'], function(login){
-              login();
-            })
+        require(commonModules, function() { // load common thrift modules
+            require(['scripts/release/login/bundle.js'], function() { // load codecompass bundle for login
+                require(['login/login'], function (login) {
+                    login();
+                });
+            });
         });
     </script>
 </head>

--- a/webgui/package.json
+++ b/webgui/package.json
@@ -8,6 +8,7 @@
     "dojo"             : ">=1.11.2",
     "dijit"            : ">=1.11.2",
     "dojox"            : ">=1.11.2",
+    "dojo-util"        : ">=1.11.2",
     "d3"               : "3.5.6",
     "thrift"           : "0.13.0",
     "codemirror"       : ">=5.19.0",
@@ -15,7 +16,8 @@
     "svg-pan-zoom"     : ">=2.19.0",
     "marked"           : ">=0.3.6",
     "jsplumb"          : "2.2.1",
-    "jquery"           : ">=3.1.1"
+    "jquery"           : ">=3.1.1",
+    "js-cookie"        : "^2.2.1"
   },
   "repository" : {
     "type" : "git",


### PR DESCRIPTION
Currently loading the front page of the CodeCompass web interface requires 450-500 HTTP requests, most of them JavaScript resources, as the Dojo library dynamically loads the modules.

This PR utilizes the [Dojo Build System](https://dojotoolkit.org/documentation/tutorials/1.10/build/) to create a custom build for the WebGUI. The build system collects all the required Dojo modules (also traversing their dependencies) and bundle them into a single JavaScript file, so the number of HTTP requests can be drastically reduced. These bundles are written into the `share/codecompass/webgui/scripts/release/` directory of the installation path.
The Dojo Build System for CodeCompass was configured to have 3 bundles:
1. Bundle for Core dojo modules.
2. Bundle of custom Dojo-compliant JavaScript files and their dependencies of Dojo modules.
3. Bundle of custom Dojo-compliant JavaScript files for the login page and their dependencies of Dojo modules.

When CodeCompass is compiled in **Release** mode, the [*Google Closure Compiler*](https://developers.google.com/closure/compiler) is also utilized for minification through comments and whitespace removal, and also dead-code removal.
The Dojo Build System is utilized in the installation phase of CodeCompass and have the following time footprint:
- in *Debug* mode an extra 4-5 sec;
- in *Release mode an extra 10-15 sec (Google Closure Compiler also has to be run).

As a result only ca. 100 HTTP requests are done on the load of the front page. About 50 of them are JavaScript files, but this can hardly be further reduced, as other 3rd party libraries like CodeMirror or the Thrift generated JS files are not loaded through Dojo.

**The page load time for me was reduced from 2.7-3.2 sec to 0.7-1.2 sec, which is around 60% of page load reduction.** Therefore I hope this PR will radically reduce the page load time on weaker machines where it was around 20-30 sec previously.