### PR TITLE
Adding C++ compiler diagnostic messages to the database

### DIFF
--- a/model/include/model/buildlog.h
+++ b/model/include/model/buildlog.h
@@ -43,10 +43,6 @@ struct BuildLog
   #pragma db not_null
   BuildLogMessage log;
 
-  #pragma db not_null
-  #pragma db on_delete(cascade)
-  std::shared_ptr<BuildAction> action;
-
   #pragma db null
   FileLoc location;
 };

--- a/plugins/cpp/parser/CMakeLists.txt
+++ b/plugins/cpp/parser/CMakeLists.txt
@@ -35,7 +35,8 @@ add_library(cppparser SHARED
   src/ppincludecallback.cpp
   src/ppmacrocallback.cpp
   src/relationcollector.cpp
-  src/doccommentformatter.cpp)
+  src/doccommentformatter.cpp
+  src/diagnosticmessagehandler.cpp)
 
 target_link_libraries(cppparser
   cppmodel

--- a/plugins/cpp/parser/include/cppparser/filelocutil.h
+++ b/plugins/cpp/parser/include/cppparser/filelocutil.h
@@ -85,7 +85,7 @@ public:
    */
   std::string getFilePath(const clang::SourceLocation& loc_)
   {
-    clang::SourceLocation expLoc =_clangSrcMan.getExpansionLoc(loc_);
+    clang::SourceLocation expLoc = _clangSrcMan.getExpansionLoc(loc_);
     clang::FileID fid = _clangSrcMan.getFileID(expLoc);
 
     if (fid.isInvalid())

--- a/plugins/cpp/parser/src/cppparser.cpp
+++ b/plugins/cpp/parser/src/cppparser.cpp
@@ -35,6 +35,7 @@
 #include "ppincludecallback.h"
 #include "ppmacrocallback.h"
 #include "doccommentcollector.h"
+#include "diagnosticmessagehandler.h"
 
 namespace cc
 {
@@ -324,6 +325,9 @@ int CppParser::parseWorker(const clang::tooling::CompileCommand& command_)
 
   VisitorActionFactory factory(_ctx);
   clang::tooling::ClangTool tool(*compilationDb, command_.Filename);
+
+  DiagnosticMessageHandler diagMsgHandler(_ctx.srcMgr, _ctx.db);
+  tool.setDiagnosticConsumer(&diagMsgHandler);
 
   int error = tool.run(&factory);
 

--- a/plugins/cpp/parser/src/diagnosticmessagehandler.cpp
+++ b/plugins/cpp/parser/src/diagnosticmessagehandler.cpp
@@ -18,7 +18,6 @@ void DiagnosticMessageHandler::HandleDiagnostic(
   clang::DiagnosticsEngine::Level diagLevel_,
   const clang::Diagnostic& info_)
 {
-  // TODO: Is this needed?
   clang::DiagnosticConsumer::HandleDiagnostic(diagLevel_, info_);
 
   model::BuildLog buildLog;

--- a/plugins/cpp/parser/src/diagnosticmessagehandler.cpp
+++ b/plugins/cpp/parser/src/diagnosticmessagehandler.cpp
@@ -1,0 +1,76 @@
+#include <llvm/ADT/SmallString.h>
+#include <cppparser/filelocutil.h>
+#include "diagnosticmessagehandler.h"
+
+namespace cc
+{
+namespace parser
+{
+
+DiagnosticMessageHandler::DiagnosticMessageHandler(
+  SourceManager& srcMgr_,
+  std::shared_ptr<odb::database> db_)
+    : _srcMgr(srcMgr_), _db(db_)
+{
+}
+
+void DiagnosticMessageHandler::HandleDiagnostic(
+  clang::DiagnosticsEngine::Level diagLevel_,
+  const clang::Diagnostic& info_)
+{
+  // TODO: Is this needed?
+  clang::DiagnosticConsumer::HandleDiagnostic(diagLevel_, info_);
+
+  model::BuildLog buildLog;
+
+  //--- Message type ---//
+
+  switch (diagLevel_)
+  {
+    case clang::DiagnosticsEngine::Note:
+      buildLog.log.type = model::BuildLogMessage::Note;
+      break;
+    case clang::DiagnosticsEngine::Warning:
+      buildLog.log.type = model::BuildLogMessage::Warning;
+      break;
+    case clang::DiagnosticsEngine::Error:
+      buildLog.log.type = model::BuildLogMessage::Error;
+      break;
+    case clang::DiagnosticsEngine::Fatal:
+      buildLog.log.type = model::BuildLogMessage::FatalError;
+      break;
+  }
+
+  //--- Message content ---//
+
+  llvm::SmallString<512> content;
+  info_.FormatDiagnostic(content);
+  buildLog.log.message = content.c_str();
+
+  //--- Message location ---//
+
+  if (info_.getLocation().isValid() && info_.hasSourceManager())
+  {
+    FileLocUtil fileLocUtil(info_.getSourceManager());
+    const clang::SourceLocation& loc = info_.getLocation();
+
+    model::Range fileLoc;
+    fileLocUtil.setRange(loc, loc, fileLoc);
+
+    buildLog.location.range = fileLoc;
+    buildLog.location.file = _srcMgr.getFile(fileLocUtil.getFilePath(loc));
+  }
+
+  _messages.push_back(buildLog);
+}
+
+DiagnosticMessageHandler::~DiagnosticMessageHandler()
+{
+  util::OdbTransaction{_db}([this](){
+    for (model::BuildLog& message : _messages)
+      _db->persist(message);
+  });
+}
+
+}
+}

--- a/plugins/cpp/parser/src/diagnosticmessagehandler.h
+++ b/plugins/cpp/parser/src/diagnosticmessagehandler.h
@@ -1,0 +1,35 @@
+#ifndef CC_PARSER_DIAGNOSTICMESSAGEHANDLER_H
+#define CC_PARSER_DIAGNOSTICMESSAGEHANDLER_H
+
+#include <vector>
+#include <clang/Basic/Diagnostic.h>
+#include <model/buildlog-odb.hxx>
+#include <parser/sourcemanager.h>
+
+namespace cc
+{
+namespace parser
+{
+
+class DiagnosticMessageHandler : public clang::DiagnosticConsumer
+{
+public:
+  DiagnosticMessageHandler(
+    SourceManager& srcMgr_,
+    std::shared_ptr<odb::database> db_);
+  ~DiagnosticMessageHandler();
+
+  void HandleDiagnostic(
+    clang::DiagnosticsEngine::Level diagLevel_,
+    const clang::Diagnostic& info_) override;
+
+private:
+  SourceManager& _srcMgr;
+  std::vector<model::BuildLog> _messages;
+  std::shared_ptr<odb::database> _db;
+};
+
+}
+}
+
+#endif


### PR DESCRIPTION
`clang::DiagnosticConsumer` is handling the diagnostic messages (compilation errors, warnings, notes, etc.) during C/C++ compilation. These diagnostic messages are collected and stored in the database.