### PR TITLE
Docker runtime image

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -127,7 +127,7 @@ variables:
 
 |       Variable       |                  Meaning                 |
 | -------------------- | ---------------------------------------- |
-| `CC_VERSION` |  The branch of the CodeCompass repository to use. |
+| `CC_VERSION` |  The branch, version hash or tag of the CodeCompass repository to use. |
 | `CC_DATABASE`|  Database type. Possible values are **sqlite**, **pgsql**. |
 | `CC_BUILD_TYPE` | Specifies the build type. Supported values are **`Debug`** and **`Release`**. |
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -34,8 +34,9 @@ Table of Contents
     * [How to parse a project](#how-to-parse-a-project)
     * [How to start a webserver](#how-to-start-a-webserver)
 * [Deployment](#deployment)
-  * [Build image for web](#build-image-for-web)
-  * [How to run CodeCompass webserver in docker](#how-to-run-codecompass-webserver-in-docker)
+  * [Build image for runtime](#build-image-for-runtime)
+  * [Build image for webserver](#build-image-for-webserver)
+    * [How to use the webserver executing container](#how-to-use-the-webserver-executing-container)
 
 # Development
 ## Build image from development
@@ -112,18 +113,44 @@ CodeCompass_webserver \
 
 # Deployment
 
-## Build image for web
-Build the web environment image from CodeCompass `master` branch:
+## Build image for runtime
+For a production environment you can build and use the runtime environment image, 
+which contains the built CodeCompass binaries and their dependencies:
+```bash
+docker build -t codecompass:runtime --no-cache --file docker/web/Dockerfile .
 ```
+
+By default this image download the `master` branch of the CodeCompass GitHub 
+repository and build it in `Release` mode with `sqlite` database configuration.
+You can override these default values through the following build-time
+variables:
+
+|       Variable       |                  Meaning                 |
+| -------------------- | ---------------------------------------- |
+| `CC_VERSION` |  The branch of the CodeCompass repository to use. |
+| `CC_DATABASE`|  Database type. Possible values are **sqlite**, **pgsql**. |
+| `CC_BUILD_TYPE` | Specifies the build type. Supported values are **`Debug`** and **`Release`**. |
+
+The below example builds the `codecompass:runtime` image with *pgsql* configuration:
+```bash
+docker build -t codecompass:runtime --build-arg CC_DATABASE=pgsql \
+  --no-cache --file docker/web/Dockerfile .
+```
+
+*Note*: the `codecompass:dev` is a prerequisite to build the `codecompass:runtime` image.
+
+## Build image for webserver
+You can use the `codecompass:runtime` image created
+[above](#build-image-for-runtime) to build an executing container for the webserver:
+```bash
 docker build -t codecompass:web --no-cache --file docker/web/Dockerfile .
 ```
 
 See more information [below](#how-to-run-codecompass-webserver-in-docker) how
 to use this image to start a CodeCompass webserver.
 
-## How to run CodeCompass webserver in docker
-You can use the `codecompass:web` image created
-[above](#build-image-for-web) to start a CodeCompass webserver.
+### How to use the webserver executing container
+You can use the `codecompass:web` image to start a CodeCompass webserver.
 For this run the following command:
 ```bash
 docker run \

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -25,7 +25,7 @@ RUN set -x && apt-get update -qq \
   llvm-7 clang-7 llvm-7-dev libclang-7-dev \
   npm \
   thrift-compiler libthrift-dev \
-  odb libodb-sqlite-dev && \
+  odb libodb-sqlite-dev libodb-pgsql-dev && \
   ln -s /usr/bin/gcc-9 /usr/bin/gcc && \
   ln -s /usr/bin/g++-9 /usr/bin/g++
 

--- a/docker/runtime/Dockerfile
+++ b/docker/runtime/Dockerfile
@@ -1,11 +1,37 @@
 ###############################################################################
-#----------------------------   IMPORT RUNTIME   -----------------------------#
+#-----------------------------    BUILD STAGE   ------------------------------#
 ###############################################################################
 
-FROM codecompass:runtime as runtime
+FROM codecompass:dev as builder
+
+ARG CC_VERSION=master
+ENV CC_VERSION ${CC_VERSION}
+
+ARG CC_DATABASE=sqlite
+ENV CC_DATABASE ${CC_DATABASE}
+
+ARG CC_BUILD_TYPE=Release
+ENV CC_BUILD_TYPE ${CC_BUILD_TYPE}
+
+RUN apt-get install -y git
+
+# Download CodeCompass release.
+RUN git clone https://github.com/Ericsson/CodeCompass.git /CodeCompass
+WORKDIR /CodeCompass
+RUN git checkout ${CC_VERSION}
+
+# Build CodeCompass.
+RUN mkdir /CodeCompass-build && \
+  cd /CodeCompass-build && \
+  cmake /CodeCompass \
+    -DDATABASE=$CC_DATABASE \
+    -DCMAKE_INSTALL_PREFIX=/CodeCompass-install \
+    -DCMAKE_BUILD_TYPE=$CC_BUILD_TYPE && \
+  make -j $(nproc) && \
+  make install
 
 ###############################################################################
-#------------------------    EXECUTABLE CONTAINER   --------------------------#
+#--------------------------    PRODUCTION STAGE   ----------------------------#
 ###############################################################################
 
 FROM ubuntu:20.04
@@ -25,39 +51,23 @@ RUN set -x && apt-get update -qq \
     libgit2-dev \
     libssl1.1 \
     libgvc6 \
+    libmagic-dev \
     libthrift-dev \
     libodb-sqlite-dev \
-    # To switch user and exec command.
-    gosu \
+    ctags \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/ \
   && set +x
 
-ARG CC_GID=960
-ARG CC_UID=960
-
-ENV CC_GID ${CC_GID}
-ENV CC_UID ${CC_UID}
-
 ENV TINI_VERSION v0.18.0
 
-# Create user and group for CodeCompass.
-RUN groupadd -r codecompass -g ${CC_GID} && \
-    useradd -r --no-log-init -M -u ${CC_UID} -g codecompass codecompass
-
 # Copy CodeCompass installed directory. (Change permission of the CodeCompass package.)
-COPY --from=runtime --chown=codecompass:codecompass /codecompass /codecompass
+COPY --from=builder /CodeCompass-install /codecompass
 
 ENV PATH="/codecompass/bin:$PATH"
-
-COPY --chown=codecompass:codecompass docker/web/entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod a+x /usr/local/bin/entrypoint.sh
 
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-EXPOSE 8080
+ENTRYPOINT ["/tini", "--"]
 
-ENTRYPOINT ["/tini", "--", "/usr/local/bin/entrypoint.sh"]
-
-CMD ["CodeCompass_webserver", "-w", "/workspace", "-p", "8080"]

--- a/docker/runtime/Dockerfile
+++ b/docker/runtime/Dockerfile
@@ -54,6 +54,7 @@ RUN set -x && apt-get update -qq \
     libmagic-dev \
     libthrift-dev \
     libodb-sqlite-dev \
+    libodb-pgsql-dev \
     ctags \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/ \

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -27,6 +27,7 @@ RUN set -x && apt-get update -qq \
     libgvc6 \
     libthrift-dev \
     libodb-sqlite-dev \
+    libodb-pgsql-dev \
     # To switch user and exec command.
     gosu \
   && apt-get clean \


### PR DESCRIPTION
Currently there are 2 docker images:
1. The `codecompass:dev` image holds the development environment for CodeCompass.
2. The `codecompass:web` contains a compiled CodeCompass with its runtime dependencies and is configured to easily launch the `CodeCompass_webserver` binary.

Unfortunately none of them suffices to use the `CodeCompass_parser` binary in a dockerized production environment.
* The `codecompass:dev` image is not self-contained, only the dependencies are installed inside the container, the source code and the binaries of CodeCompass are outside it to support development. Starting with this image CodeCompass has to be downloaded and built first, which is unnecessary extra time spent.
* The  `codecompass:web` image is a set up to create so called *executing containers*. Upon the start of a container the `CodeCompass_webserver` is started as a non-root `codecompass` user inside the container. It requires significant extra work to circumvent this and use this image as the root user without starting the webserver, so some parsing can be done. (Root privilege is required to install the dependencies of the project to be parsed.)

This pull request proposes to a third, `codecompass:runtime` image which contains the built CodeCompass binaries and their runtime dependencies (but not those required only for compilation time). Then the `codecompass:web` image can be based upon this `codecompass:runtime` and really only contain the dependencies of the webserver. (Smaller size.)

I have also done some completion on the documentation.