### PR TITLE
Use PostgreSQL in Docker containers

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -25,7 +25,7 @@ RUN set -x && apt-get update -qq \
   llvm-7 clang-7 llvm-7-dev libclang-7-dev \
   npm \
   thrift-compiler libthrift-dev \
-  odb libodb-sqlite-dev && \
+  odb libodb-sqlite-dev libodb-pgsql-dev && \
   ln -s /usr/bin/gcc-9 /usr/bin/gcc && \
   ln -s /usr/bin/g++-9 /usr/bin/g++
 

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -54,6 +54,7 @@ RUN set -x && apt-get update -qq \
     libmagic-dev \
     libthrift-dev \
     libodb-sqlite-dev \
+    libodb-pgsql-dev \
     ctags \
     # To switch user and exec command.
     gosu \


### PR DESCRIPTION
The `libodb-pgsql-dev` dependency is missing from the new Ubuntu 20.04 docker images.
PostgreSQL supersedes SQLite in performance, therefore we shall support it also in the docker images for production systems.