### PR TITLE
Update Build2 version from 0.12.0 to 0.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -242,8 +242,8 @@ services:
     echo "Building Build2..."
     mkdir /tmp/build2src
     cd /tmp/build2src
-    curl -sSfO https://download.build2.org/0.12.0/build2-install-0.12.0.sh
-    sh build2-install-0.12.0.sh --yes --trust yes "$HOME/build2_install/"
+    curl -sSfO https://download.build2.org/0.13.0/build2-install-0.13.0.sh
+    sh build2-install-0.13.0.sh --yes --trust yes "$HOME/build2_install/"
   fi
   export PATH=$PATH:$HOME/build2_install/bin/
   if [ ! -f "$HOME/odb_install/bin/odb" ]; then

--- a/doc/deps.md
+++ b/doc/deps.md
@@ -133,8 +133,8 @@ The ODB installation uses the build2 build system. (Build2 is not needed for
 CodeCompass so you may delete it right after the installation of ODB.)
 
 ```bash
-wget https://download.build2.org/0.12.0/build2-install-0.12.0.sh
-sh build2-install-0.12.0.sh --yes --trust yes "<build2_install_dir>"
+wget https://download.build2.org/0.13.0/build2-install-0.13.0.sh
+sh build2-install-0.13.0.sh --yes --trust yes "<build2_install_dir>"
 ```
 
 Now, utilizing the *Build2* toolchain, we can build the *ODB* compiler and


### PR DESCRIPTION
For some reasons unknown to me, Build2 version 0.12.0 no longer succeeds to build on Ubuntu 18.04.

When executing this as per the documentation:
```bash
wget https://download.build2.org/0.12.0/build2-install-0.12.0.sh
sh build2-install-0.12.0.sh --yes --trust yes "<build2_install_dir>"
```
The error message is the following:
```
[...]
+ bpkg-stage --fetch-timeout 600 --trust-yes fetch
fetching pkg:cppget.org/alpha
fetching pkg:cppget.org/beta (complements pkg:cppget.org/alpha)
fetching pkg:cppget.org/testing (complements pkg:cppget.org/beta)
fetching pkg:cppget.org/stable (complements pkg:cppget.org/testing)
74 package(s) in 4 repository(s)
+ bpkg-stage --fetch-timeout 600 build --for install --yes --plan= build2 bpkg bdep
error: unable to satisfy constraint (build2 >= 0.13.0) for package build2
  info: available build2 version is 0.12.0
info: while satisfying build2/0.13.0
```

It seems like build2 version 0.12.0 cannot be built because it is required to be at least version 0.13.0. (During the compilation it downloads a lot of stuff dynamically.)
Travis also fails for Bionic, the only reason we not see the error is that the previous successful build of Build2 is cached and loaded for the newer jobs.

Updating to the new 0.13.0 version solves the issue, but I hope we don't have to do this every time a new Build2 version is released.
