### PR TITLE
DockerHub publish through CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -380,7 +380,6 @@ before_script:
 # ----------------------------------- Jobs -----------------------------------
 
 stages:
-  - compile
   - test
   - name: deploy
     if: (branch = master) AND (type = push) AND (fork = false)

--- a/.travis.yml
+++ b/.travis.yml
@@ -459,3 +459,19 @@ jobs:
       script:
         *build_sqlite
 
+    - stage: deploy
+      name: "DockerHub deployment"
+      dist: focal
+      services:
+        - docker
+      before_script:
+        - docker --version
+      script:
+        - docker build -t codecompass:dev -t modelcpp/codecompass:dev --file docker/dev/Dockerfile .
+        - docker build -t codecompass:web -t modelcpp/codecompass:web-sqlite --build-arg CC_DATABASE=sqlite --no-cache --file docker/web/Dockerfile .
+        - |
+          if [ -n "$DOCKER_USERNAME" ]; then
+            echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+            docker push modelcpp/codecompass:dev
+            docker push modelcpp/codecompass:web-sqlite
+          fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -379,6 +379,12 @@ before_script:
 
 # ----------------------------------- Jobs -----------------------------------
 
+stages:
+  - compile
+  - test
+  - name: deploy
+    if: (branch = master) AND (type = push) AND (fork = false)
+
 jobs:
   include:
     - name: "Xenial Xerus (16.04), PostgreSQL"

--- a/.travis.yml
+++ b/.travis.yml
@@ -473,11 +473,19 @@ jobs:
       before_script:
         - docker --version
       script:
-        - docker build -t codecompass:dev -t modelcpp/codecompass:dev --file docker/dev/Dockerfile .
-        - docker build -t codecompass:web -t modelcpp/codecompass:web-sqlite --build-arg CC_DATABASE=sqlite --no-cache --file docker/web/Dockerfile .
+        - docker build -t codecompass:dev     -t modelcpp/codecompass:dev            --file docker/dev/Dockerfile .
+        - docker build -t codecompass:runtime -t modelcpp/codecompass:runtime-sqlite --file docker/runtime/Dockerfile --no-cache --build-arg CC_DATABASE=sqlite .
+        - docker build -t codecompass:web     -t modelcpp/codecompass:web-sqlite     --file docker/web/Dockerfile --no-cache .
+        - docker build -t codecompass:runtime -t modelcpp/codecompass:runtime-pgsql  --file docker/runtime/Dockerfile --no-cache --build-arg CC_DATABASE=pgsql .
+        - docker build -t codecompass:web     -t modelcpp/codecompass:web-pgsql      --file docker/web/Dockerfile --no-cache .
+        - docker tag modelcpp/codecompass:runtime-pgsql modelcpp/codecompass:latest
         - |
           if [ -n "$DOCKER_USERNAME" ]; then
             echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
             docker push modelcpp/codecompass:dev
+            docker push modelcpp/codecompass:runtime-sqlite
+            docker push modelcpp/codecompass:runtime-pgsql
             docker push modelcpp/codecompass:web-sqlite
+            docker push modelcpp/codecompass:web-pgsql
+            docker push modelcpp/codecompass:latest
           fi

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -47,6 +47,7 @@ RUN groupadd -r codecompass -g ${CC_GID} && \
     useradd -r --no-log-init -M -u ${CC_UID} -g codecompass codecompass
 
 # Copy CodeCompass installed directory. (Change permission of the CodeCompass package.)
+# TODO: only the webserver's binaries should be included in this image.
 COPY --from=runtime --chown=codecompass:codecompass /codecompass /codecompass
 
 ENV PATH="/codecompass/bin:$PATH"


### PR DESCRIPTION
This PR extends the continuous integration workflow to following the successful compiling and testing of CodeCompass, build the Docker images and publish them to DockerHub, to:
https://hub.docker.com/r/modelcpp/codecompass

The following images are built and published:

- [x] `modelcpp/codecompass:dev`, the development image (ready!)
- [x] `modelcpp/codecompass:runtime-sqlite`, the runtime image containing CodeCompass binaries built against SQLite (can be done after #409 merged)
- [x] `modelcpp/codecompass:runtime-pgsql`, the runtime image containing CodeCompass binaries built against PostrgreSQL (can be done after #409 merged)
- [x] `modelcpp/codecompass:web-sqlite`, the webserver executing container image built against SQLite (ready!)
- [x] `modelcpp/codecompass:web-pgsql`, the webserver executing container image built against PostgreSQL (can be done after #410 merged)

I propose that the default `:latest` tag should be an alias to `:runtime-pgsql`.