### PR TITLE
Cpp documentation comments in markdown format

### DIFF
--- a/plugins/cpp/model/include/model/cppdoccomment.h
+++ b/plugins/cpp/model/include/model/cppdoccomment.h
@@ -26,7 +26,7 @@ struct CppDocComment
   unsigned long long contentHash;
 
   #pragma db not_null
-  std::string contentHTML;
+  std::string content;
 
   #pragma db not_null index
   unsigned long long mangledNameHash;

--- a/plugins/cpp/parser/src/doccommentcollector.h
+++ b/plugins/cpp/parser/src/doccommentcollector.h
@@ -57,8 +57,8 @@ public:
     DocCommentFormatter dcFmt;
 
     model::CppDocCommentPtr pc(new model::CppDocComment);
-    pc->contentHTML = dcFmt.format(fc, _astContext);
-    pc->contentHash = util::fnvHash(pc->contentHTML);
+    pc->content = dcFmt.format(fc, _astContext);
+    pc->contentHash = util::fnvHash(pc->content);
     pc->mangledNameHash = _mangledNameCache.at(it->second);
     _docComments.insert(std::make_pair(
       std::make_pair(pc->mangledNameHash, pc->contentHash), pc));

--- a/plugins/cpp/parser/src/doccommentformatter.h
+++ b/plugins/cpp/parser/src/doccommentformatter.h
@@ -9,17 +9,17 @@ namespace parser
 {
 
 /**
- * Converts a clang::comments::FullComment into an HTML text.
+ * Converts a clang::comments::FullComment into a Markdown text.
  */
 class DocCommentFormatter
 {
 public:
 
   /**
-   * Converts a clang::comments::FullComment into an HTML text.
+   * Converts a clang::comments::FullComment into a Markdown text.
    *
    * @param fc The comment to be formatted.
-   * @return the HTML-formatted string.
+   * @return the Markdown-formatted string.
    */
   std::string format(
     clang::comments::FullComment* fc,

--- a/plugins/cpp/service/src/cppservice.cpp
+++ b/plugins/cpp/service/src/cppservice.cpp
@@ -169,7 +169,7 @@ void CppServiceHandler::getDocumentation(
       DocCommentQuery::mangledNameHash == node.mangledNameHash);
 
     if (!docComment.empty())
-      return_ = "<div class=\"main-doc\">" + docComment.begin()->contentHTML
+      return_ = "<div class=\"main-doc\">" + docComment.begin()->content
         + "</div>";
 
     switch (node.symbolType)
@@ -212,7 +212,7 @@ void CppServiceHandler::getDocumentation(
             DocCommentQuery::mangledNameHash == method.mangledNameHash);
 
           if (!doc.empty())
-            return_ += doc.begin()->contentHTML;
+            return_ += doc.begin()->content;
 
           return_ += "</div>";
         }

--- a/webgui/scripts/codecompass/view/infobox.js
+++ b/webgui/scripts/codecompass/view/infobox.js
@@ -65,7 +65,7 @@ function (declare, dom, style, topic, ContentPane, FloatingPane, TabContainer,
     },
 
     _setDocumentationAttr : function (documentation){
-      this._documentationPane.set('content', documentation);
+      this._documentationPane.set('content', marked(documentation));
       this._documentationPane.resize();
       this.resize();
     },


### PR DESCRIPTION
The `CppDocComment` table now contains documentation comments in markdown
format instead of HTML. With this change the SQLite database size of a Xerces
parsing is reduced to 219M from 302M.

Fixes a part of #418