### PR TITLE
Remove mangledName column from CppAstNode table

### DIFF
--- a/plugins/cpp/model/include/model/cppastnode.h
+++ b/plugins/cpp/model/include/model/cppastnode.h
@@ -70,9 +70,6 @@ struct CppAstNode
   #pragma db null
   FileLoc location;
 
-  #pragma db null
-  std::string mangledName;
-
   std::uint64_t mangledNameHash;
 
   SymbolType symbolType = SymbolType::Other;
@@ -145,7 +142,6 @@ inline std::string CppAstNode::toString() const
   return std::string("CppAstNode")
     .append("\nid = ").append(std::to_string(id))
     .append("\nastValue = ").append(astValue)
-    .append("\nmangledName = ").append(mangledName)
     .append("\nlocation = ").append(location.file->path).append(" (")
     .append(std::to_string(
       static_cast<signed>(location.range.start.line))).append(":")
@@ -187,7 +183,6 @@ inline std::uint64_t createIdentifier(const CppAstNode& astNode_)
 
   res
     .append(astNode_.astValue).append(":")
-    .append(astNode_.mangledName).append(":")
     .append(std::to_string(
       static_cast<SymbolTypeInt>(astNode_.symbolType))).append(":")
     .append(std::to_string(

--- a/plugins/cpp/parser/src/clangastvisitor.h
+++ b/plugins/cpp/parser/src/clangastvisitor.h
@@ -289,9 +289,8 @@ public:
     astNode->location = getFileLoc(tl_.getLocStart(), tl_.getLocEnd());
     astNode->astType = model::CppAstNode::AstType::TypeLocation;
     astNode->astValue = td->getNameAsString();
-    astNode->mangledName = getMangledName(_mngCtx, td);
     astNode->symbolType = model::CppAstNode::SymbolType::Typedef;
-    astNode->mangledNameHash = util::fnvHash(astNode->mangledName);
+    astNode->mangledNameHash = util::fnvHash(getMangledName(_mngCtx, td));
 
     _locToTypeLoc[tl_.getLocStart().getRawEncoding()] = astNode;
 
@@ -310,9 +309,8 @@ public:
     astNode->location = getFileLoc(tl_.getLocStart(), tl_.getLocEnd());
     astNode->astType = model::CppAstNode::AstType::TypeLocation;
     astNode->astValue = ed->getNameAsString();
-    astNode->mangledName = getMangledName(_mngCtx, ed);
     astNode->symbolType = model::CppAstNode::SymbolType::Enum;
-    astNode->mangledNameHash = util::fnvHash(astNode->mangledName);
+    astNode->mangledNameHash = util::fnvHash(getMangledName(_mngCtx, ed));
 
     _locToTypeLoc[tl_.getLocStart().getRawEncoding()] = astNode;
 
@@ -331,9 +329,8 @@ public:
     astNode->location = getFileLoc(tl_.getLocStart(), tl_.getLocEnd());
     astNode->astType = model::CppAstNode::AstType::TypeLocation;
     astNode->astValue = rd->getNameAsString();
-    astNode->mangledName = getMangledName(_mngCtx, rd);
     astNode->symbolType = model::CppAstNode::SymbolType::Type;
-    astNode->mangledNameHash = util::fnvHash(astNode->mangledName);
+    astNode->mangledNameHash = util::fnvHash(getMangledName(_mngCtx, rd));
 
     _locToTypeLoc[tl_.getLocStart().getRawEncoding()] = astNode;
 
@@ -355,8 +352,8 @@ public:
 
     astNode->astValue = rd_->getNameAsString();
     astNode->location = getFileLoc(rd_->getLocStart(), rd_->getLocEnd());
-    astNode->mangledName = getMangledName(_mngCtx, rd_, astNode->location);
-    astNode->mangledNameHash = util::fnvHash(astNode->mangledName);
+    astNode->mangledNameHash = util::fnvHash(
+      getMangledName(_mngCtx, rd_, astNode->location));
     astNode->symbolType = model::CppAstNode::SymbolType::Type;
     astNode->astType
       = rd_->isThisDeclarationADefinition()
@@ -468,8 +465,7 @@ public:
 
     astNode->astValue = ed_->getNameAsString();
     astNode->location = getFileLoc(ed_->getLocStart(), ed_->getLocEnd());
-    astNode->mangledName = getMangledName(_mngCtx, ed_);
-    astNode->mangledNameHash = util::fnvHash(astNode->mangledName);
+    astNode->mangledNameHash = util::fnvHash(getMangledName(_mngCtx, ed_));
     astNode->symbolType = model::CppAstNode::SymbolType::Enum;
     astNode->astType
       = ed_->isThisDeclarationADefinition()
@@ -507,8 +503,7 @@ public:
 
     astNode->astValue = ec_->getNameAsString();
     astNode->location = getFileLoc(ec_->getLocStart(), ec_->getLocEnd());
-    astNode->mangledName = getMangledName(_mngCtx, ec_);
-    astNode->mangledNameHash = util::fnvHash(astNode->mangledName);
+    astNode->mangledNameHash = util::fnvHash(getMangledName(_mngCtx, ec_));
     astNode->symbolType = model::CppAstNode::SymbolType::EnumConstant;
     astNode->astType = model::CppAstNode::AstType::Definition;
 
@@ -545,8 +540,7 @@ public:
 
     astNode->astValue = td_->getNameAsString();
     astNode->location = getFileLoc(td_->getLocStart(), td_->getLocEnd());
-    astNode->mangledName = getMangledName(_mngCtx, td_);
-    astNode->mangledNameHash = util::fnvHash(astNode->mangledName);
+    astNode->mangledNameHash = util::fnvHash(getMangledName(_mngCtx, td_));
     astNode->symbolType = model::CppAstNode::SymbolType::Typedef;
     astNode->astType = model::CppAstNode::AstType::Definition;
 
@@ -593,8 +587,7 @@ public:
 
     astNode->astValue = getSignature(fn_);
     astNode->location = getFileLoc(fn_->getLocStart(), fn_->getLocEnd());
-    astNode->mangledName = getMangledName(_mngCtx, fn_);
-    astNode->mangledNameHash = util::fnvHash(astNode->mangledName);
+    astNode->mangledNameHash = util::fnvHash(getMangledName(_mngCtx, fn_));
     astNode->symbolType = model::CppAstNode::SymbolType::Function;
     astNode->astType
       = fn_->isThisDeclarationADefinition()
@@ -682,8 +675,8 @@ public:
       astNode->location = getFileLoc(
         init->getSourceRange().getBegin(),
         init->getSourceRange().getEnd());
-      astNode->mangledName = getMangledName(_mngCtx, member);
-      astNode->mangledNameHash = util::fnvHash(astNode->mangledName);
+      astNode->mangledNameHash = util::fnvHash(
+        getMangledName(_mngCtx, member));
       astNode->symbolType
         = isFunctionPointer(member)
         ? model::CppAstNode::SymbolType::FunctionPtr
@@ -707,8 +700,7 @@ public:
 
     astNode->astValue = fd_->getNameAsString();
     astNode->location = getFileLoc(fd_->getLocStart(), fd_->getLocEnd());
-    astNode->mangledName = getMangledName(_mngCtx, fd_);
-    astNode->mangledNameHash = util::fnvHash(astNode->mangledName);
+    astNode->mangledNameHash = util::fnvHash(getMangledName(_mngCtx, fd_));
     astNode->symbolType
       = isFunctionPointer(fd_)
       ? model::CppAstNode::SymbolType::FunctionPtr
@@ -765,8 +757,8 @@ public:
 
     astNode->astValue = vd_->getNameAsString();
     astNode->location = getFileLoc(vd_->getLocation(), vd_->getLocation());
-    astNode->mangledName = getMangledName(_mngCtx, vd_, astNode->location);
-    astNode->mangledNameHash = util::fnvHash(astNode->mangledName);
+    astNode->mangledNameHash = util::fnvHash(
+      getMangledName(_mngCtx, vd_, astNode->location));
     astNode->symbolType
       = isFunctionPointer(vd_)
       ? model::CppAstNode::SymbolType::FunctionPtr
@@ -858,8 +850,8 @@ public:
 
     astNode->astValue = nd_->getNameAsString();
     astNode->location = getFileLoc(nd_->getLocStart(), nd_->getLocEnd());
-    astNode->mangledName = getMangledName(_mngCtx, nd_, astNode->location);
-    astNode->mangledNameHash = util::fnvHash(astNode->mangledName);
+    std::string mangledName = getMangledName(_mngCtx, nd_, astNode->location);
+    astNode->mangledNameHash = util::fnvHash(mangledName);
     astNode->symbolType = model::CppAstNode::SymbolType::Namespace;
     astNode->astType = model::CppAstNode::AstType::Definition;
 
@@ -878,7 +870,7 @@ public:
     ns->astNodeId = astNode->id;
     ns->mangledNameHash = astNode->mangledNameHash;
     ns->name = nd_->getNameAsString();
-    ns->qualifiedName = astNode->mangledName;
+    ns->qualifiedName = mangledName;
 
     return true;
   }
@@ -891,8 +883,7 @@ public:
 
     astNode->astValue = getSignature(ctor);
     astNode->location = getFileLoc(ce_->getLocStart(), ce_->getLocEnd());
-    astNode->mangledName = getMangledName(_mngCtx, ctor);
-    astNode->mangledNameHash = util::fnvHash(astNode->mangledName);
+    astNode->mangledNameHash = util::fnvHash(getMangledName(_mngCtx, ctor));
     astNode->symbolType = model::CppAstNode::SymbolType::Function;
     astNode->astType = model::CppAstNode::AstType::Usage;
     astNode->visibleInSourceCode = false;
@@ -920,8 +911,8 @@ public:
 
     astNode->astValue = getSignature(functionDecl);
     astNode->location = getFileLoc(ne_->getLocStart(), ne_->getLocEnd());
-    astNode->mangledName = getMangledName(_mngCtx, functionDecl);
-    astNode->mangledNameHash = util::fnvHash(astNode->mangledName);
+    astNode->mangledNameHash = util::fnvHash(
+      getMangledName(_mngCtx, functionDecl));
     astNode->symbolType = model::CppAstNode::SymbolType::Function;
     astNode->astType = model::CppAstNode::AstType::Usage;
 
@@ -948,8 +939,8 @@ public:
 
     astNode->astValue = getSignature(functionDecl);
     astNode->location = getFileLoc(de_->getLocStart(), de_->getLocEnd());
-    astNode->mangledName = getMangledName(_mngCtx, functionDecl);
-    astNode->mangledNameHash = util::fnvHash(astNode->mangledName);
+    astNode->mangledNameHash = util::fnvHash(
+      getMangledName(_mngCtx, functionDecl));
     astNode->symbolType = model::CppAstNode::SymbolType::Function;
     astNode->astType = model::CppAstNode::AstType::Usage;
     astNode->id = model::createIdentifier(*astNode);
@@ -975,16 +966,17 @@ public:
 
     model::CppAstNodePtr astNode = std::make_shared<model::CppAstNode>();
 
+    std::string mangledName = getMangledName(
+      _mngCtx,
+      namedCallee,
+      getFileLoc(namedCallee->getLocStart(), namedCallee->getLocEnd()));
+
     astNode->astValue
       = funcCallee
       ? getSignature(funcCallee)
       : namedCallee->getNameAsString();
     astNode->location = getFileLoc(ce_->getLocStart(), ce_->getLocEnd());
-    astNode->mangledName = getMangledName(
-      _mngCtx,
-      namedCallee,
-      getFileLoc(namedCallee->getLocStart(), namedCallee->getLocEnd()));
-    astNode->mangledNameHash = util::fnvHash(astNode->mangledName);
+    astNode->mangledNameHash = util::fnvHash(mangledName);
     astNode->symbolType = model::CppAstNode::SymbolType::Function;
     astNode->astType
       = isVirtualCall(ce_)
@@ -1014,8 +1006,8 @@ public:
 
       astNode->astValue = vd->getNameAsString();
       astNode->location = getFileLoc(dr_->getLocStart(), dr_->getLocEnd());
-      astNode->mangledName = getMangledName(_mngCtx, vd, location);
-      astNode->mangledNameHash = util::fnvHash(astNode->mangledName);
+      astNode->mangledNameHash = util::fnvHash(
+        getMangledName(_mngCtx, vd, location));
       astNode->symbolType
         = isFunctionPointer(vd)
         ? model::CppAstNode::SymbolType::FunctionPtr
@@ -1034,8 +1026,7 @@ public:
 
       astNode->astValue = ec->getNameAsString();
       astNode->location = getFileLoc(dr_->getLocStart(), dr_->getLocEnd());
-      astNode->mangledName = getMangledName(_mngCtx, ec);
-      astNode->mangledNameHash = util::fnvHash(astNode->mangledName);
+      astNode->mangledNameHash = util::fnvHash(getMangledName(_mngCtx, ec));
       astNode->symbolType = model::CppAstNode::SymbolType::EnumConstant;
       astNode->astType = model::CppAstNode::AstType::Usage;
 
@@ -1060,8 +1051,7 @@ public:
 
     astNode->astValue = method ? getSignature(method) : vd->getNameAsString();
     astNode->location = getFileLoc(me_->getLocStart(), me_->getLocEnd());
-    astNode->mangledName = getMangledName(_mngCtx, vd);
-    astNode->mangledNameHash = util::fnvHash(astNode->mangledName);
+    astNode->mangledNameHash = util::fnvHash(getMangledName(_mngCtx, vd));
     astNode->symbolType
       = method
       ? model::CppAstNode::SymbolType::Function

--- a/plugins/cpp/parser/src/ppincludecallback.cpp
+++ b/plugins/cpp/parser/src/ppincludecallback.cpp
@@ -40,8 +40,7 @@ model::CppAstNodePtr PPIncludeCallback::createFileAstNode(
   model::CppAstNodePtr astNode(new model::CppAstNode());
 
   astNode->astValue = file_->path;
-  astNode->mangledName = std::to_string(file_->id);
-  astNode->mangledNameHash = util::fnvHash(astNode->mangledName);
+  astNode->mangledNameHash = util::fnvHash(std::to_string(file_->id));
   astNode->symbolType = model::CppAstNode::SymbolType::File;
   astNode->astType = model::CppAstNode::AstType::Usage;
 

--- a/plugins/cpp/parser/src/ppmacrocallback.cpp
+++ b/plugins/cpp/parser/src/ppmacrocallback.cpp
@@ -201,8 +201,7 @@ model::CppAstNodePtr PPMacroCallback::createMacroAstNode(
   model::CppAstNodePtr astNode(new model::CppAstNode);
 
   astNode->astValue = macroNameTok_.getIdentifierInfo()->getName().str();
-  astNode->mangledName = getMangledName(mi_);
-  astNode->mangledNameHash = util::fnvHash(astNode->mangledName);
+  astNode->mangledNameHash = util::fnvHash(getMangledName(mi_));
   astNode->symbolType = model::CppAstNode::SymbolType::Macro;
 
   return astNode;

--- a/plugins/cpp/test/src/cppparsertest.cpp
+++ b/plugins/cpp/test/src/cppparsertest.cpp
@@ -5,8 +5,16 @@
 
 #include <model/cppastnode.h>
 #include <model/cppastnode-odb.hxx>
+#include <model/cppenum.h>
+#include <model/cppenum-odb.hxx>
 #include <model/cppfunction.h>
 #include <model/cppfunction-odb.hxx>
+#include <model/cppnamespace.h>
+#include <model/cppnamespace-odb.hxx>
+#include <model/cpptype.h>
+#include <model/cpptype-odb.hxx>
+#include <model/cppvariable.h>
+#include <model/cppvariable-odb.hxx>
 #include <model/file.h>
 #include <model/file-odb.hxx>
 
@@ -18,6 +26,12 @@ extern const char* dbConnectionString;
 using namespace cc;
 
 using QCppAstNode = odb::query<model::CppAstNode>;
+using QCppFunction = odb::query<model::CppFunction>;
+using QCppEnum = odb::query<model::CppEnum>;
+using QCppEnumConstant = odb::query<model::CppEnumConstant>;
+using QCppNamespace = odb::query<model::CppNamespace>;
+using QCppType = odb::query<model::CppType>;
+using QCppVariable = odb::query<model::CppVariable>;
 using QFile = odb::query<model::File>;
 using RCppAstNode = odb::result<model::CppAstNode>;
 
@@ -73,11 +87,12 @@ TEST_F(CppParserTest, SimpleFunction)
     model::File simpleFile = _db->query_value<model::File>(
       QFile::filename == "function.cpp");
 
+    model::CppFunction simpleFunc = _db->query_value<model::CppFunction>(
+      QCppFunction::name == "singleFunc");
     model::CppAstNode simpleFuncAstNode = _db->query_value<model::CppAstNode>(
-      QCppAstNode::mangledName == "_Z10singleFuncv");
+      QCppAstNode::mangledNameHash == simpleFunc.mangledNameHash);
 
     EXPECT_EQ(simpleFuncAstNode.astValue, "void singleFunc()");
-    EXPECT_EQ(simpleFuncAstNode.mangledName, "_Z10singleFuncv");
     EXPECT_EQ(
       simpleFuncAstNode.symbolType,
       model::CppAstNode::SymbolType::Function);
@@ -103,8 +118,10 @@ TEST_F(CppParserTest, SimpleFunction)
 TEST_F(CppParserTest, FunctionDeclarationOnly)
 {
   _transaction([&, this]() {
+    model::CppFunction funcDecl = _db->query_value<model::CppFunction>(
+      QCppFunction::name == "funcDecl");
     model::CppAstNode funcDeclAstNode = _db->query_value<model::CppAstNode>(
-      QCppAstNode::mangledName == "_Z8funcDeclv");
+      QCppAstNode::mangledNameHash == funcDecl.mangledNameHash);
 
     EXPECT_EQ(
       funcDeclAstNode.symbolType,
@@ -118,8 +135,10 @@ TEST_F(CppParserTest, FunctionDeclarationOnly)
 TEST_F(CppParserTest, FunctionWithMultipleDeclarations)
 {
   _transaction([&, this]() {
+    model::CppFunction callee = _db->query_value<model::CppFunction>(
+      QCppFunction::name == "multiFunction");
     RCppAstNode multiFuncAstNode = _db->query<model::CppAstNode>(
-      QCppAstNode::mangledName == "_Z13multiFunctionv");
+      QCppAstNode::mangledNameHash == callee.mangledNameHash);
 
     int numDecl = 0, numDef = 0, numOther = 0;
     for (const model::CppAstNode& n : multiFuncAstNode)
@@ -139,8 +158,10 @@ TEST_F(CppParserTest, FunctionWithMultipleDeclarations)
 TEST_F(CppParserTest, FunctionCall)
 {
   _transaction([&, this]() {
+    model::CppFunction callee = _db->query_value<model::CppFunction>(
+      QCppFunction::name == "callee");
     RCppAstNode astNodes = _db->query<model::CppAstNode>(
-      QCppAstNode::mangledName == "_Z6calleecb");
+      QCppAstNode::mangledNameHash == callee.mangledNameHash);
 
     for (const model::CppAstNode& n : astNodes)
       switch (n.location.range.start.line)
@@ -159,7 +180,7 @@ TEST_F(CppParserTest, FunctionCall)
       }
 
     astNodes = _db->query<model::CppAstNode>(
-      QCppAstNode::astValue.like("%MyClass(%") &&
+      QCppAstNode::astValue == "MyClass::MyClass()" &&
       QCppAstNode::symbolType == model::CppAstNode::SymbolType::Function &&
       QCppAstNode::astType == model::CppAstNode::AstType::Usage);
 
@@ -168,35 +189,44 @@ TEST_F(CppParserTest, FunctionCall)
     int numDefault = 0, numMove = 0, numCopy = 0;
 
     for (const model::CppAstNode& n : astNodes)
-      if (n.mangledName == "_ZN7MyClassC1Ev") // Default constructor.
-      {
-        EXPECT_TRUE(
-          n.location.range.start.line == 10 || // Global variable.
-          n.location.range.start.line == 15 || // Local variable.
-          n.location.range.start.line == 20 || // Temporary object.
-          n.location.range.start.line == 34 || // Parent constructor.
-          n.location.range.start.line == 35 || // Temporary object.
-          n.location.range.start.line == 38 || // New object.
-          n.location.range.start.line == 42);  // New object.
-        ++numDefault;
-      }
-      else if (n.mangledName == "_ZN7MyClassC1EOS_") // Move constructor.
-      {
-        EXPECT_TRUE(
-          n.location.range.start.line == 20 || // Throwing an exception.
-          n.location.range.start.line == 25 || // Returning a value.
-          n.location.range.start.line == 35);  // Initializing a field.
-        ++numMove;
-      }
-      else if (n.mangledName == "_ZN7MyClassC1ERKS_") // Copy constructor.
-      {
-        EXPECT_TRUE(
-          n.location.range.start.line == 16 || // Local variable.
-          n.location.range.start.line == 17);  // Local variable.
-        ++numCopy;
-      }
-      else
-        EXPECT_TRUE(false);
+    {
+      EXPECT_TRUE(
+        n.location.range.start.line == 10 || // Global variable.
+        n.location.range.start.line == 15 || // Local variable.
+        n.location.range.start.line == 20 || // Temporary object.
+        n.location.range.start.line == 34 || // Parent constructor.
+        n.location.range.start.line == 35 || // Temporary object.
+        n.location.range.start.line == 38 || // New object.
+        n.location.range.start.line == 42);  // New object.
+      ++numDefault;
+    }
+
+    astNodes = _db->query<model::CppAstNode>(
+      QCppAstNode::astValue == "MyClass::MyClass(MyClass &&)" &&
+      QCppAstNode::symbolType == model::CppAstNode::SymbolType::Function &&
+      QCppAstNode::astType == model::CppAstNode::AstType::Usage);
+
+    for (const model::CppAstNode& n : astNodes)
+    {
+      EXPECT_TRUE(
+        n.location.range.start.line == 20 || // Throwing an exception.
+        n.location.range.start.line == 25 || // Returning a value.
+        n.location.range.start.line == 35);  // Initializing a field.
+      ++numMove;
+    }
+
+    astNodes = _db->query<model::CppAstNode>(
+      QCppAstNode::astValue == "MyClass::MyClass(const MyClass &)" &&
+      QCppAstNode::symbolType == model::CppAstNode::SymbolType::Function &&
+      QCppAstNode::astType == model::CppAstNode::AstType::Usage);
+
+    for (const model::CppAstNode& n : astNodes)
+    {
+      EXPECT_TRUE(
+        n.location.range.start.line == 16 || // Local variable.
+        n.location.range.start.line == 17);  // Local variable.
+      ++numCopy;
+    }
 
     EXPECT_EQ(numDefault, 7);
     EXPECT_EQ(numMove, 3);
@@ -208,13 +238,13 @@ TEST_F(CppParserTest, FunctionCall)
       QCppAstNode::astType == model::CppAstNode::AstType::Usage);
 
     for (const model::CppAstNode& n : astNodes)
-      if (n.mangledName == "_Znwm") // operator new()
+      if (n.astValue == "void * operator new(unsigned long)")
         EXPECT_EQ(n.location.range.start.line, 38);
-      else if (n.mangledName == "_Znam") // operator new[]()
+      else if (n.astValue == "void * operator new[](unsigned long)")
         EXPECT_EQ(n.location.range.start.line, 42);
-      else if (n.mangledName == "_ZdlPv") // operator delete()
+      else if (n.astValue == "void operator delete(void *)")
         EXPECT_EQ(n.location.range.start.line, 41);
-      else if (n.mangledName == "_ZdaPv") // operator delete[]()
+      else if (n.astValue == "void operator delete[](void *)")
         EXPECT_EQ(n.location.range.start.line, 43);
 
     astNodes = _db->query<model::CppAstNode>(
@@ -266,8 +296,10 @@ TEST_F(CppParserTest, FunctionCall)
 TEST_F(CppParserTest, Typedef)
 {
   _transaction([&, this]() {
+    model::CppEnum integer = _db->query_value<model::CppEnum>(
+      QCppEnum::name == "Integer");
     RCppAstNode astNodes = _db->query<model::CppAstNode>(
-      QCppAstNode::mangledName == "Integer");
+      QCppAstNode::mangledNameHash == integer.mangledNameHash);
 
     for (const model::CppAstNode& n : astNodes)
     {
@@ -312,23 +344,23 @@ TEST_F(CppParserTest, Typedef)
 TEST_F(CppParserTest, Record)
 {
   _transaction([&, this] {
+    model::CppType myClass = _db->query_value<model::CppType>(
+      QCppType::name == "MyClass");
     RCppAstNode astNodes = _db->query<model::CppAstNode>(
-      QCppAstNode::mangledName.like("%MyClass%"));
+      QCppAstNode::mangledNameHash == myClass.mangledNameHash);
 
     for (const model::CppAstNode& n : astNodes)
     {
-      if (n.symbolType != model::CppAstNode::SymbolType::Type)
-        continue;
+      EXPECT_EQ(n.symbolType, model::CppAstNode::SymbolType::Type);
 
       switch (n.location.range.start.line)
       {
         case -1: 
           EXPECT_TRUE(
-            // Compiler generated copy and move constructor parameter.
-            n.astType == model::CppAstNode::AstType::ParameterTypeLoc ||
             // Compiler generated assignment operator return value.
-            // TODO: We lose the information that it is a return type loc.
-            //n.astType == model::CppAstNode::AstType::ReturnTypeLoc
+            n.astType == model::CppAstNode::AstType::ReturnTypeLoc ||
+            // TODO: What's this? Maybe a compiler generated copy constructor
+            // parameter's type? Then why isn't this a ParameterTypeLoc?
             n.astType == model::CppAstNode::AstType::TypeLocation);
           break;
 
@@ -414,13 +446,14 @@ TEST_F(CppParserTest, Record)
 TEST_F(CppParserTest, Enum)
 {
   _transaction([&, this] {
+    model::CppEnum enumeration = _db->query_value<model::CppEnum>(
+      QCppEnum::name == "Enumeration");
     RCppAstNode astNodes = _db->query<model::CppAstNode>(
-      QCppAstNode::mangledName.like("%Enumeration%"));
+      QCppAstNode::mangledNameHash == enumeration.mangledNameHash);
 
     for (const model::CppAstNode& n : astNodes)
     {
-      if (n.symbolType != model::CppAstNode::SymbolType::Enum)
-        continue;
+      EXPECT_EQ(n.symbolType, model::CppAstNode::SymbolType::Enum);
 
       switch (n.location.range.start.line)
       {
@@ -465,13 +498,14 @@ TEST_F(CppParserTest, Enum)
       }
     }
 
+    model::CppEnumConstant first = _db->query_value<model::CppEnumConstant>(
+      QCppEnumConstant::name == "First");
     astNodes = _db->query<model::CppAstNode>(
-      QCppAstNode::mangledName.like("%First%"));
+      QCppAstNode::mangledNameHash == first.mangledNameHash);
 
     for (const model::CppAstNode& n : astNodes)
     {
-      if (n.symbolType != model::CppAstNode::SymbolType::EnumConstant)
-        continue;
+      EXPECT_EQ(n.symbolType, model::CppAstNode::SymbolType::EnumConstant);
 
       switch (n.location.range.start.line)
       {
@@ -489,8 +523,35 @@ TEST_F(CppParserTest, Enum)
       }
     }
 
+    model::CppFunction fieldFunction = _db->query_value<model::CppFunction>(
+      QCppFunction::name == "fieldFunction");
     astNodes = _db->query<model::CppAstNode>(
-      QCppAstNode::mangledName.like("%field%"));
+      QCppAstNode::mangledNameHash == fieldFunction.mangledNameHash);
+
+    for (const model::CppAstNode& n : astNodes)
+    {
+      switch (n.location.range.start.line)
+      {
+        case 33:
+          EXPECT_EQ(n.astType, model::CppAstNode::AstType::Definition);
+          EXPECT_EQ(n.symbolType, model::CppAstNode::SymbolType::FunctionPtr);
+          break;
+
+        case 36:
+          EXPECT_EQ(n.astType, model::CppAstNode::AstType::Write);
+          EXPECT_EQ(n.symbolType, model::CppAstNode::SymbolType::FunctionPtr);
+          break;
+
+        default:
+          EXPECT_TRUE(false);
+          break;
+      }
+    }
+
+    model::CppVariable fieldVariable = _db->query_value<model::CppVariable>(
+      QCppVariable::name == "fieldVariable");
+    astNodes = _db->query<model::CppAstNode>(
+      QCppAstNode::mangledNameHash == fieldVariable.mangledNameHash);
 
     for (const model::CppAstNode& n : astNodes)
     {
@@ -501,19 +562,9 @@ TEST_F(CppParserTest, Enum)
           EXPECT_EQ(n.symbolType, model::CppAstNode::SymbolType::Variable);
           break;
 
-        case 33:
-          EXPECT_EQ(n.astType, model::CppAstNode::AstType::Definition);
-          EXPECT_EQ(n.symbolType, model::CppAstNode::SymbolType::FunctionPtr);
-          break;
-
         case 35:
           EXPECT_EQ(n.astType, model::CppAstNode::AstType::Write);
           EXPECT_EQ(n.symbolType, model::CppAstNode::SymbolType::Variable);
-          break;
-
-        case 36:
-          EXPECT_EQ(n.astType, model::CppAstNode::AstType::Write);
-          EXPECT_EQ(n.symbolType, model::CppAstNode::SymbolType::FunctionPtr);
           break;
 
         default:
@@ -527,25 +578,17 @@ TEST_F(CppParserTest, Enum)
 TEST_F(CppParserTest, Variable)
 {
   _transaction([&, this] {
+    model::CppVariable variableDefinition
+      = _db->query_value<model::CppVariable>(
+        QCppVariable::name == "variableDefinition");
     RCppAstNode astNodes = _db->query<model::CppAstNode>(
-      QCppAstNode::mangledName.like("%variable%"));
+      QCppAstNode::mangledNameHash == variableDefinition.mangledNameHash);
 
     for (const model::CppAstNode& n : astNodes)
       switch (n.location.range.start.line)
       {
         case 8:
-        case 11:
           EXPECT_EQ(n.symbolType, model::CppAstNode::SymbolType::Variable);
-          EXPECT_EQ(n.astType, model::CppAstNode::AstType::Definition);
-          break;
-
-        case 9:
-          EXPECT_EQ(n.symbolType, model::CppAstNode::SymbolType::Variable);
-          EXPECT_EQ(n.astType, model::CppAstNode::AstType::Declaration);
-          break;
-
-        case 10:
-          EXPECT_EQ(n.symbolType, model::CppAstNode::SymbolType::FunctionPtr);
           EXPECT_EQ(n.astType, model::CppAstNode::AstType::Definition);
           break;
 
@@ -564,8 +607,30 @@ TEST_F(CppParserTest, Variable)
           break;
       }
 
+    model::CppVariable variableDeclaration
+      = _db->query_value<model::CppVariable>(
+        QCppVariable::name == "variableDeclaration");
+    model::CppAstNode astNode = _db->query_value<model::CppAstNode>(
+      QCppAstNode::mangledNameHash == variableDeclaration.mangledNameHash);
+
+    EXPECT_EQ(astNode.location.range.start.line, 9);
+    EXPECT_EQ(astNode.symbolType, model::CppAstNode::SymbolType::Variable);
+    EXPECT_EQ(astNode.astType, model::CppAstNode::AstType::Declaration);
+
+    model::CppVariable variableFunctionPointer
+      = _db->query_value<model::CppVariable>(
+        QCppVariable::name == "variableFunctionPointer");
+    astNode = _db->query_value<model::CppAstNode>(
+      QCppAstNode::mangledNameHash == variableFunctionPointer.mangledNameHash);
+
+    EXPECT_EQ(astNode.location.range.start.line, 10);
+    EXPECT_EQ(astNode.symbolType, model::CppAstNode::SymbolType::FunctionPtr);
+    EXPECT_EQ(astNode.astType, model::CppAstNode::AstType::Definition);
+
+    model::CppVariable memberVariable = _db->query_value<model::CppVariable>(
+      QCppVariable::name == "memberVariable");
     astNodes = _db->query<model::CppAstNode>(
-      QCppAstNode::astValue.like("%memberVariable%"));
+      QCppAstNode::mangledNameHash == memberVariable.mangledNameHash);
 
     for (const model::CppAstNode& n : astNodes)
       switch (n.location.range.start.line)
@@ -593,25 +658,22 @@ TEST_F(CppParserTest, Variable)
 TEST_F(CppParserTest, Namespace)
 {
   _transaction([&, this] {
-    RCppAstNode astNodes = _db->query<model::CppAstNode>(
-      QCppAstNode::mangledName.like("%MyNamespace%"));
+    model::CppNamespace myNamespace1 = _db->query_value<model::CppNamespace>(
+      QCppNamespace::name == "MyNamespace1");
+    model::CppAstNode astNode = _db->query_value<model::CppAstNode>(
+      QCppAstNode::mangledNameHash == myNamespace1.mangledNameHash);
 
-    for (const model::CppAstNode& n : astNodes)
-    {
-      if (n.symbolType != model::CppAstNode::SymbolType::Namespace)
-        continue;
+    EXPECT_EQ(astNode.symbolType, model::CppAstNode::SymbolType::Namespace);
+    EXPECT_EQ(astNode.location.range.start.line, 1);
+    EXPECT_EQ(astNode.astType, model::CppAstNode::AstType::Definition);
 
-      switch (n.location.range.start.line)
-      {
-        case 1:
-        case 3:
-          EXPECT_EQ(n.astType, model::CppAstNode::AstType::Definition);
-          break;
+    model::CppNamespace myNamespace2 = _db->query_value<model::CppNamespace>(
+      QCppNamespace::name == "MyNamespace2");
+    astNode = _db->query_value<model::CppAstNode>(
+      QCppAstNode::mangledNameHash == myNamespace2.mangledNameHash);
 
-        default:
-          EXPECT_TRUE(false);
-          break;
-      }
-    }
+    EXPECT_EQ(astNode.symbolType, model::CppAstNode::SymbolType::Namespace);
+    EXPECT_EQ(astNode.location.range.start.line, 3);
+    EXPECT_EQ(astNode.astType, model::CppAstNode::AstType::Definition);
   });
 }


### PR DESCRIPTION
Column mangledName is not used anywhere and it consumes too much space
unnecessarily. So this column has been removed.

Fixes #417