### PR TITLE
Better AST value for nodes.

### DIFF
--- a/plugins/cpp/parser/src/symbolhelper.h
+++ b/plugins/cpp/parser/src/symbolhelper.h
@@ -30,6 +30,32 @@ bool isFunction(const clang::Type* type_);
 
 std::string getSignature(const clang::FunctionDecl* fn_);
 
+/**
+ * Returns the source range of the prototype part of a tag declaration. If it's
+ * a definition then this range ends before the opening curly brace, otherwise
+ * at the end of the declaration.
+ * For example:
+ * template <typename> struct S { int i; };
+ * ^                          ^
+ * enum Color;
+ * ^        ^
+ */
+std::string getDeclPartAsString(
+  const clang::SourceManager& srcMgr_,
+  const clang::TagDecl* td_);
+
+/**
+ * This function returns the source code fragment between the given source
+ * locations. inclusiveEnd determines whether the end of the range is
+ * inclusive, i.e. the token starting at "to" is also the part of returned code
+ * text.
+ */
+std::string getSourceText(
+  const clang::SourceManager& srcMgr_,
+  clang::SourceLocation from_,
+  clang::SourceLocation to_,
+  bool inclusiveEnd_ = false);
+
 }
 }
 


### PR DESCRIPTION
The AST value of a symbol should be a human-readable source code fragment which
contains the given AST node. In this patch we try to determine the best context
in which a given AST node resides and choose this as the astValue.

Fixes #358