### PR TITLE
Excluding node sort at function parameters.

### DIFF
--- a/plugins/cpp/service/src/cppservice.cpp
+++ b/plugins/cpp/service/src/cppservice.cpp
@@ -958,7 +958,9 @@ void CppServiceHandler::getReferences(
         break;
     }
 
-    if (referenceId_ != PARAMETER)
+    if (referenceId_ != PARAMETER &&
+        referenceId_ != ENUM_CONSTANTS &&
+        referenceId_ != LOCAL_VAR)
       std::sort(nodes.begin(), nodes.end(), compareByValue);
 
     return_.reserve(nodes.size());

--- a/plugins/cpp/service/src/cppservice.cpp
+++ b/plugins/cpp/service/src/cppservice.cpp
@@ -959,8 +959,7 @@ void CppServiceHandler::getReferences(
     }
 
     if (referenceId_ != PARAMETER &&
-        referenceId_ != ENUM_CONSTANTS &&
-        referenceId_ != LOCAL_VAR)
+        referenceId_ != ENUM_CONSTANTS)
       std::sort(nodes.begin(), nodes.end(), compareByValue);
 
     return_.reserve(nodes.size());

--- a/plugins/cpp/service/src/cppservice.cpp
+++ b/plugins/cpp/service/src/cppservice.cpp
@@ -958,7 +958,8 @@ void CppServiceHandler::getReferences(
         break;
     }
 
-    std::sort(nodes.begin(), nodes.end(), compareByValue);
+    if (referenceId_ != PARAMETER)
+      std::sort(nodes.begin(), nodes.end(), compareByValue);
 
     return_.reserve(nodes.size());
     _transaction([this, &return_, &nodes](){


### PR DESCRIPTION
Fixes #440 
The `cppservice` gets the parameters in a good order but sorts them at the end. Now the sorting is excluded when querying funtion parameters.