### PR TITLE
Print complete error and warning messages at parsing time

### DIFF
--- a/plugins/cpp/parser/src/cppparser.cpp
+++ b/plugins/cpp/parser/src/cppparser.cpp
@@ -12,7 +12,6 @@
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/topological_sort.hpp>
 
-#include "clang/Basic/LLVM.h"
 #include <clang/Frontend/CompilerInstance.h>
 #include <clang/Frontend/FrontendAction.h>
 
@@ -328,7 +327,7 @@ int CppParser::parseWorker(const clang::tooling::CompileCommand& command_)
   clang::tooling::ClangTool tool(*compilationDb, command_.Filename);
 
   llvm::IntrusiveRefCntPtr<clang::DiagnosticOptions> diagOpts = new clang::DiagnosticOptions();
-  DiagnosticMessageHandler diagMsgHandler(llvm::errs(), diagOpts.get(), _ctx.srcMgr, _ctx.db);
+  DiagnosticMessageHandler diagMsgHandler(diagOpts.get(), _ctx.srcMgr, _ctx.db);
   tool.setDiagnosticConsumer(&diagMsgHandler);
 
   int error = tool.run(&factory);

--- a/plugins/cpp/parser/src/cppparser.cpp
+++ b/plugins/cpp/parser/src/cppparser.cpp
@@ -12,6 +12,7 @@
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/topological_sort.hpp>
 
+#include "clang/Basic/LLVM.h"
 #include <clang/Frontend/CompilerInstance.h>
 #include <clang/Frontend/FrontendAction.h>
 
@@ -326,7 +327,8 @@ int CppParser::parseWorker(const clang::tooling::CompileCommand& command_)
   VisitorActionFactory factory(_ctx);
   clang::tooling::ClangTool tool(*compilationDb, command_.Filename);
 
-  DiagnosticMessageHandler diagMsgHandler(_ctx.srcMgr, _ctx.db);
+  llvm::IntrusiveRefCntPtr<clang::DiagnosticOptions> diagOpts = new clang::DiagnosticOptions();
+  DiagnosticMessageHandler diagMsgHandler(llvm::errs(), diagOpts.get(), _ctx.srcMgr, _ctx.db);
   tool.setDiagnosticConsumer(&diagMsgHandler);
 
   int error = tool.run(&factory);

--- a/plugins/cpp/parser/src/diagnosticmessagehandler.cpp
+++ b/plugins/cpp/parser/src/diagnosticmessagehandler.cpp
@@ -8,11 +8,10 @@ namespace parser
 {
 
 DiagnosticMessageHandler::DiagnosticMessageHandler(
-  llvm::raw_ostream& os,
   clang::DiagnosticOptions* diags,
   SourceManager& srcMgr_,
   std::shared_ptr<odb::database> db_)
-    : TextDiagnosticPrinter(os, diags), _srcMgr(srcMgr_), _db(db_)
+    : TextDiagnosticPrinter(llvm::errs(), diags), _srcMgr(srcMgr_), _db(db_)
 {
 }
 

--- a/plugins/cpp/parser/src/diagnosticmessagehandler.cpp
+++ b/plugins/cpp/parser/src/diagnosticmessagehandler.cpp
@@ -8,9 +8,11 @@ namespace parser
 {
 
 DiagnosticMessageHandler::DiagnosticMessageHandler(
+  llvm::raw_ostream& os,
+  clang::DiagnosticOptions* diags,
   SourceManager& srcMgr_,
   std::shared_ptr<odb::database> db_)
-    : _srcMgr(srcMgr_), _db(db_)
+    : TextDiagnosticPrinter(os, diags), _srcMgr(srcMgr_), _db(db_)
 {
 }
 
@@ -18,7 +20,7 @@ void DiagnosticMessageHandler::HandleDiagnostic(
   clang::DiagnosticsEngine::Level diagLevel_,
   const clang::Diagnostic& info_)
 {
-  clang::DiagnosticConsumer::HandleDiagnostic(diagLevel_, info_);
+  clang::TextDiagnosticPrinter::HandleDiagnostic(diagLevel_, info_);
 
   model::BuildLog buildLog;
 

--- a/plugins/cpp/parser/src/diagnosticmessagehandler.h
+++ b/plugins/cpp/parser/src/diagnosticmessagehandler.h
@@ -3,6 +3,8 @@
 
 #include <vector>
 #include <clang/Basic/Diagnostic.h>
+#include <clang/Frontend/TextDiagnosticPrinter.h>
+#include <llvm/Support/raw_ostream.h>
 #include <model/buildlog-odb.hxx>
 #include <parser/sourcemanager.h>
 
@@ -11,10 +13,12 @@ namespace cc
 namespace parser
 {
 
-class DiagnosticMessageHandler : public clang::DiagnosticConsumer
+class DiagnosticMessageHandler : public clang::TextDiagnosticPrinter
 {
 public:
   DiagnosticMessageHandler(
+    llvm::raw_ostream& os,
+    clang::DiagnosticOptions* diags,
     SourceManager& srcMgr_,
     std::shared_ptr<odb::database> db_);
   ~DiagnosticMessageHandler();

--- a/plugins/cpp/parser/src/diagnosticmessagehandler.h
+++ b/plugins/cpp/parser/src/diagnosticmessagehandler.h
@@ -4,7 +4,6 @@
 #include <vector>
 #include <clang/Basic/Diagnostic.h>
 #include <clang/Frontend/TextDiagnosticPrinter.h>
-#include <llvm/Support/raw_ostream.h>
 #include <model/buildlog-odb.hxx>
 #include <parser/sourcemanager.h>
 
@@ -17,7 +16,6 @@ class DiagnosticMessageHandler : public clang::TextDiagnosticPrinter
 {
 public:
   DiagnosticMessageHandler(
-    llvm::raw_ostream& os,
     clang::DiagnosticOptions* diags,
     SourceManager& srcMgr_,
     std::shared_ptr<odb::database> db_);


### PR DESCRIPTION
Fixes #437 
As @mcserep suggested in the ticket, the solution was to derive `DiagnosticMessageHandler` from `TextDiagnosticPrinter`. The `HandleDiagnostic` function of the latter class prints the warning and error messages that may occur while parsing a project.