### PR TITLE
Correct syntax highlight after click on word

### DIFF
--- a/webgui/scripts/codecompass/view/component/Text.js
+++ b/webgui/scripts/codecompass/view/component/Text.js
@@ -387,6 +387,13 @@ function (declare, domClass, dom, style, query, topic, ContentPane, Dialog,
       this._marks = {};
     },
 
+    clearSelection : function () {
+      for (var markId in this._marks) {
+        if (this._marks[markId].className === 'cb-marked-select')
+          this.clearMark(markId);
+      }
+    },
+
     _eventHandler : function (event) {
       //--- Select the clicked word ---//
 
@@ -439,7 +446,7 @@ function (declare, domClass, dom, style, query, topic, ContentPane, Dialog,
         astNodeInfo.id,
         refTypes['Usage']);
 
-      this.clearAllMarks();
+      this.clearSelection();
 
       var fl = that._codeMirror.options.firstLineNumber;
       usages.forEach(function (astNodeInfo) {
@@ -490,8 +497,6 @@ function (declare, domClass, dom, style, query, topic, ContentPane, Dialog,
       while (end < line.length && line[end] && line[end].match(pattern))
         ++end;
 
-      this._getSyntaxHighlight(this._fileInfo);
-
       return {
         string : line.substring(start, end),
         start  : start + 1,
@@ -513,7 +518,6 @@ function (declare, domClass, dom, style, query, topic, ContentPane, Dialog,
       }
 
       setTimeout(function () {
-        that.clearAllMarks();
         var lines = urlHandler.getFileContent().split('\n').length;
         for (var i = 0; i < lines; i += that._syntaxHighlightStep) {
           var range = new FileRange({
@@ -528,7 +532,7 @@ function (declare, domClass, dom, style, query, topic, ContentPane, Dialog,
             syntax.forEach(function (s) {
               this.markText(s.range.startpos, s.range.endpos, {
                 className: s.className
-              }, true);
+              });
             }, that);
           });
         }
@@ -586,8 +590,6 @@ function (declare, domClass, dom, style, query, topic, ContentPane, Dialog,
     _setSelectionAttr : function (range) {
       var that = this;
       this.selection = range;
-
-      this.clearAllMarks();
 
       setTimeout(function () {
         var fl = that._codeMirror.options.firstLineNumber;

--- a/webgui/scripts/codecompass/view/component/Text.js
+++ b/webgui/scripts/codecompass/view/component/Text.js
@@ -490,6 +490,8 @@ function (declare, domClass, dom, style, query, topic, ContentPane, Dialog,
       while (end < line.length && line[end] && line[end].match(pattern))
         ++end;
 
+      this._getSyntaxHighlight(this._fileInfo);
+
       return {
         string : line.substring(start, end),
         start  : start + 1,


### PR DESCRIPTION
Fixes #442 
The problem was `getSyntaxHighlight` was not called when any word was clicked in a file. Calling this method puts the correct highlight on all words.