### PR TITLE
Fix session lifetime.

### DIFF
--- a/webserver/src/authentication.cpp
+++ b/webserver/src/authentication.cpp
@@ -10,7 +10,7 @@
 #include "authentication.h"
 
 #define INVALID_CFG_FILE_PATH "/dev/null"
-#define CODECOMPASS_DEFAULT_SESSION_LIFETIME 1440 // One hour.
+#define CODECOMPASS_DEFAULT_SESSION_LIFETIME 3600 // One hour.
 
 namespace fs = boost::filesystem;
 namespace pt = boost::property_tree;


### PR DESCRIPTION
The `CODECOMPASS_DEFAULT_SESSION_LIFETIME` macro was set to 1440 with the comment "One hour". I believe the number of seconds in an hour was mixed up with the number of minutes in a day.