### PR TITLE
Upgrade CMake to 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.12)
 project(CodeCompass)
 
 # Common config variables and settings


### PR DESCRIPTION
In order to use the subcommand JOIN with the list command in a CMake file, a CMake upgrade is needed to version 3.12 or newer. This does not affect CI, since it has already been using such a version.