### PR TITLE
Lower required CMake version to 3.5.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.5.1)
 project(CodeCompass)
 
 # Common config variables and settings

--- a/Functions.cmake
+++ b/Functions.cmake
@@ -117,3 +117,11 @@ function(fancy_message _str _colour _isBold)
     ${CMAKE_COMMAND} -E env CLICOLOR_FORCE=1
     ${CMAKE_COMMAND} -E cmake_echo_color ${COLOUR_TAG} ${BOLD_TAG} ${_str})
 endfunction(fancy_message)
+
+# Joins a list of elements with a given glue string.
+# See: https://stackoverflow.com/questions/7172670/best-shortest-way-to-join-a-list-in-cmake
+function(join _values _glue _output)
+  string (REGEX REPLACE "([^\\]|^);" "\\1${_glue}" _tmpStr "${_values}")
+  string (REGEX REPLACE "[\\](.)" "\\1" _tmpStr "${_tmpStr}") #fixes escaping
+  set (${_output} "${_tmpStr}" PARENT_SCOPE)
+endfunction(join)

--- a/webgui/InstallGUI.cmake
+++ b/webgui/InstallGUI.cmake
@@ -1,3 +1,6 @@
+# Utility functions
+include(../Functions.cmake)
+
 message("Install npm packages...")
 
 if(${CC_PACKAGE} IS_NEWER_THAN ${INSTALL_SCRIPTS_DIR}/package.json)
@@ -25,7 +28,7 @@ foreach(_jsfile ${_jsfiles})
   string(REGEX REPLACE "\\.js*$" "" _jsfile ${_jsfile})
   list(APPEND DOJO_VIEWLIST "'${_jsfile}'")
 endforeach()
-list(JOIN DOJO_VIEWLIST  ", " DOJO_VIEWLIST)
+join("${DOJO_VIEWLIST}"  ", " DOJO_VIEWLIST)
 
 set(DOJO_OPTIMIZE "")       # optimization for non-layer modules
 set(DOJO_LAYEROPTIMIZE "")  # optimization for layer modules


### PR DESCRIPTION
#402 added the usage of the `list(JOIN)` CMake function, hence the minimum required CMake version was raised to 3.12 (#472). 

This PR replaces the `list(JOIN)` CMake function with custom implementation, so required CMake version can be lowered. The selected version is 3.5.1, which is the CMake version in the default APT package repository of Ubuntu 16.04. (The oldest officially supported OS version of the project.)