### PR TITLE
Add CI test for parsing CodeCompass itself

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -306,13 +306,6 @@ services:
     make install -j $(nproc)
   fi
 
-cache:
-  directories:
-    - $HOME/build2_install
-    - $HOME/gtest_install
-    - $HOME/odb_install
-    - $HOME/thrift_install
-
 # ---------------------------------- Setup -----------------------------------
 
 before_script:
@@ -352,6 +345,7 @@ before_script:
 
 .build_postgres: &build_postgres
   - cd $TRAVIS_BUILD_DIR
+  - rm -rf install_pgsql
   - mkdir build_pgsql && cd build_pgsql
   - >
     cmake ..
@@ -361,11 +355,13 @@ before_script:
     -DTEST_DB="pgsql:host=localhost;port=5432;user=postgres;password=;database=cc_test"
     -DLLVM_DIR=/usr/lib/llvm-10/cmake
     -DClang_DIR=/usr/lib/cmake/clang-10
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=1
   - make install -j $(nproc)
   - make test ARGS=-V
 
 .build_sqlite: &build_sqlite
   - cd $TRAVIS_BUILD_DIR
+  - rm -rf install_sqlite
   - mkdir build_sqlite && cd build_sqlite
   - >
     cmake ..
@@ -375,8 +371,20 @@ before_script:
     -DTEST_DB="sqlite:database=$HOME/cc_test.sqlite"
     -DLLVM_DIR=/usr/lib/llvm-10/cmake
     -DClang_DIR=/usr/lib/cmake/clang-10
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=1
   - make install -j $(nproc)
   - make test ARGS=-V
+
+# ----------------------------------- Cache -----------------------------------
+
+cache:
+  directories:
+    - $HOME/build2_install
+    - $HOME/gtest_install
+    - $HOME/odb_install
+    - $HOME/thrift_install
+    - $TRAVIS_BUILD_DIR/install_pgsql
+    - $TRAVIS_BUILD_DIR/install_sqlite
 
 # ----------------------------------- Jobs -----------------------------------
 
@@ -478,20 +486,7 @@ jobs:
         - DATABASE=pgsql
       before_install:
         - *fix_focal_travis_postgresql_server
-      install:
-        - *install_gtest_focal
       script:
-        - cd $TRAVIS_BUILD_DIR
-        - mkdir build_pgsql && cd build_pgsql
-        - >
-          cmake ..
-          -DDATABASE=pgsql
-          -DCMAKE_BUILD_TYPE=Release
-          -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/install_pgsql
-          -DLLVM_DIR=/usr/lib/llvm-10/cmake
-          -DClang_DIR=/usr/lib/cmake/clang-10
-          -DCMAKE_EXPORT_COMPILE_COMMANDS=1
-        - make install -j $(nproc)
         - cd $TRAVIS_BUILD_DIR/install_pgsql/bin
         - >
           ./CodeCompass_parser

--- a/.travis.yml
+++ b/.travis.yml
@@ -345,7 +345,7 @@ before_script:
 
 .build_postgres: &build_postgres
   - cd $TRAVIS_BUILD_DIR
-  - rm -rf install_pgsql
+  - rm -rf build_pgsql install_pgsql
   - mkdir build_pgsql && cd build_pgsql
   - >
     cmake ..
@@ -361,7 +361,7 @@ before_script:
 
 .build_sqlite: &build_sqlite
   - cd $TRAVIS_BUILD_DIR
-  - rm -rf install_sqlite
+  - rm -rf build_sqlite install_sqlite
   - mkdir build_sqlite && cd build_sqlite
   - >
     cmake ..
@@ -385,6 +385,8 @@ cache:
     - $HOME/thrift_install
     - $TRAVIS_BUILD_DIR/install_pgsql
     - $TRAVIS_BUILD_DIR/install_sqlite
+    - $TRAVIS_BUILD_DIR/build_pgsql
+    - $TRAVIS_BUILD_DIR/build_sqlite
 
 # ----------------------------------- Jobs -----------------------------------
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -381,13 +381,15 @@ before_script:
 # ----------------------------------- Jobs -----------------------------------
 
 stages:
+  - compile
   - test
   - name: deploy
     if: (branch = master) AND (type = push) AND (fork = false)
 
 jobs:
   include:
-    - name: "Xenial Xerus (16.04), PostgreSQL"
+    - stage: compile
+      name: "Xenial Xerus (16.04), PostgreSQL"
       dist: xenial
       addons:
         apt:
@@ -464,6 +466,40 @@ jobs:
         - *install_gtest_focal
       script:
         *build_sqlite
+
+    - stage: test
+      name: "Parse CodeCompass"
+      dist: focal
+      addons:
+        apt:
+          <<: *apt_focal_pgsql
+        postgresql: "12"
+      env:
+        - DATABASE=pgsql
+      before_install:
+        - *fix_focal_travis_postgresql_server
+      install:
+        - *install_gtest_focal
+      script:
+        - cd $TRAVIS_BUILD_DIR
+        - mkdir build_pgsql && cd build_pgsql
+        - >
+          cmake ..
+          -DDATABASE=pgsql
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/install_pgsql
+          -DLLVM_DIR=/usr/lib/llvm-10/cmake
+          -DClang_DIR=/usr/lib/cmake/clang-10
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=1
+        - make install -j $(nproc)
+        - cd $TRAVIS_BUILD_DIR/install_pgsql/bin
+        - >
+          ./CodeCompass_parser
+          -d "pgsql:host=localhost;port=5432;user=postgres;password=;database=cc"
+          -w $HOME/ws_pgsql/
+          -n CodeCompass
+          -i $TRAVIS_BUILD_DIR
+          -i $TRAVIS_BUILD_DIR/build_pgsql/compile_commands.json
 
     - stage: deploy
       name: "DockerHub deployment"

--- a/.travis.yml
+++ b/.travis.yml
@@ -477,15 +477,17 @@ jobs:
 
     - stage: test
       name: "Parse CodeCompass"
-      dist: focal
+      dist: bionic
       addons:
         apt:
-          <<: *apt_focal_pgsql
-        postgresql: "12"
+          <<: *apt_bionic_pgsql
+        postgresql: "10"
       env:
         - DATABASE=pgsql
-      before_install:
-        - *fix_focal_travis_postgresql_server
+      install:
+        - *install_odb
+        - *install_thrift
+        - *install_gtest_bionic
       script:
         - cd $TRAVIS_BUILD_DIR/install_pgsql/bin
         - >


### PR DESCRIPTION
#425 seemingly introduced a bug, where CodeCompass compiles, the tests passes, but more complex projects (like CodeCompass) cannot be parsed, a segfault occurs (see #471).

To prevent such issues in the future, this PR adds a new job to the CI, where the built `CodeCompass_parser` has to parse the CodeCompass project itself.