### PR TITLE
Set RelWithDebInfo as default build type

### DIFF
--- a/Config.cmake
+++ b/Config.cmake
@@ -1,3 +1,12 @@
+# Set a default build type if none was specified
+set(DEFAULT_BUILD_TYPE "RelWithDebInfo")
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${DEFAULT_BUILD_TYPE}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${DEFAULT_BUILD_TYPE}" CACHE STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
 # Installation directory for libraries
 set(INSTALL_LIB_DIR_NAME "lib")
 set(INSTALL_LIB_DIR "${CMAKE_INSTALL_PREFIX}/${INSTALL_LIB_DIR_NAME}")
@@ -74,9 +83,13 @@ set(ODBFLAGS
   --include-with-brackets
   --default-pointer "std::shared_ptr")
 
+# Set CXX standard
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 # Set CXX flags
 set(CMAKE_CXX_FLAGS "-W -Wall -Wextra -pedantic\
-  -std=c++14 \
   -DDATABASE_${DATABASE_U} \
   -DBOOST_LOG_DYN_LINK")
 
@@ -87,11 +100,13 @@ endif()
 
 set(CMAKE_LINKER "${CODECOMPASS_LINKER}")
 
-
-
 # Cmake module directory (FindOdb, FindThrift etc.)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}")
 
-# Debug and Release version flags
-set(CMAKE_CXX_FLAGS_DEBUG "-ggdb3 -O0")
-set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG -O3")
+# Set build type specific flags here. Default values are:
+# CMAKE_CXX_FLAGS_DEBUG:          -g
+# CMAKE_CXX_FLAGS_RELEASE:        -O3 -DNDEBUG
+# CMAKE_CXX_FLAGS_RELWITHDEBINFO: -O2 -g -DNDEBUG
+# CMAKE_CXX_FLAGS_MINSIZEREL:     -Os -DNDEBUG
+set(CMAKE_CXX_FLAGS_DEBUG "-O0 -ggdb3")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -ggdb3 -DNDEBUG")

--- a/doc/deps.md
+++ b/doc/deps.md
@@ -298,7 +298,7 @@ relevant during compilation.
 |       Variable       |                  Meaning                 |
 | -------------------- | ---------------------------------------- |
 | [`CMAKE_INSTALL_PREFIX`](http://cmake.org/cmake/help/v3.4/variable/CMAKE_INSTALL_PREFIX.html) | Install directory. |
-| [`CMAKE_BUILD_TYPE`](http://cmake.org/cmake/help/v3.4/variable/CMAKE_BUILD_TYPE.html)| Specifies the build type. Supported values are **`Debug`** and **`Release`**. |
+| [`CMAKE_BUILD_TYPE`](http://cmake.org/cmake/help/v3.4/variable/CMAKE_BUILD_TYPE.html)| Specifies the build type. Supported values are **`Debug`**, **`Release`**, **`RelWithDebInfo`** and **`MinSizeRel`**. Default is **`RelWithDebInfo`** if not specified. |
 | `CMAKE_CXX_COMPILER` | If the official repository of your Linux distribution doesn't contain a C++ compiler which supports C++14 then you can install one manually and set to use it. For more information see: ['Useful variables'](https://cmake.org/Wiki/CMake_Useful_Variables) |
 | `DATABASE` | Database type. Possible values are **sqlite**, **pgsql**. The default value is `sqlite`. |
 | `TEST_DB` | The connection string for the database that will be used when executing tests with `make test`. Optional. |


### PR DESCRIPTION
Support for **`RelWithDebInfo`** and **`MinSizeRel`** build types. Default to **`RelWithDebInfo`** if not specified otherwise.