### PR TITLE
Do not check for virtual tag on FunctionPtr definitions

### DIFF
--- a/plugins/cpp/service/src/cppservice.cpp
+++ b/plugins/cpp/service/src/cppservice.cpp
@@ -1523,14 +1523,17 @@ CppServiceHandler::getTags(const std::vector<model::CppAstNode>& nodes_)
             tags[node.id].push_back(visibility);
         }
 
-        //--- Virtual Tag ---//
+        if (defNode.symbolType == model::CppAstNode::SymbolType::Function)
+        {
+          //--- Virtual Tag ---//
 
-        FuncResult funcNodes = _db->query<cc::model::CppFunction>(
-          FuncQuery::entityHash == defNode.entityHash);
-        const model::CppFunction& funcNode = *funcNodes.begin();
+          FuncResult funcNodes = _db->query<cc::model::CppFunction>(
+            FuncQuery::entityHash == defNode.entityHash);
+          const model::CppFunction& funcNode = *funcNodes.begin();
 
-        for (const model::Tag& tag : funcNode.tags)
-          tags[node.id].push_back(model::tagToString(tag));
+          for (const model::Tag& tag : funcNode.tags)
+            tags[node.id].push_back(model::tagToString(tag));
+        }
 
         break;
       }


### PR DESCRIPTION
As reported in #476, clicking a function pointer call results in a web server crash with a segmentation fault.
Example code (here `OpenProtocol` is a public data member of `gBS`, a function pointer):
![](https://user-images.githubusercontent.com/3271389/96219762-1a080900-0fba-11eb-8e97-4b3ba3782ff8.png)

The cause of the segmentation fault is that in `CppServiceHandler::getTags()` we assumed that if the observed AST node had the `symbolType` *Function*, then its definition node should also have the `symbolType` *Function*. However, the definition node can have the `symbolType` *FunctionPtr*; in such case the `funcNodes` variable will be empty, thus dereferencing its first element is UB.
https://github.com/Ericsson/CodeCompass/blob/173a3cf15e15be6de38b476fa7ff5eb258829e8c/plugins/cpp/service/src/cppservice.cpp#L1526-L1533

This PR adds a check on the definition node `symbolType`, so the segmentation fault is avoided.