### PR TITLE
Bugfix for forced full parse

### DIFF
--- a/parser/include/parser/sourcemanager.h
+++ b/parser/include/parser/sourcemanager.h
@@ -41,6 +41,12 @@ public:
   }
 
   /**
+   * This function (re)populates the cache with the files that are
+   * reloaded from the database.
+   */
+  void cacheFiles();
+
+  /**
    * This function returns a pointer to the corresponding model::File object
    * based on the given path_. The object is read from a cache. If the file is
    * not in the cache yet then a model::File entry is created, persisted in the

--- a/parser/src/parser.cpp
+++ b/parser/src/parser.cpp
@@ -378,6 +378,7 @@ int main(int argc, char* argv[])
     cc::util::createTables(db, SQL_DIR);
 
     srcMgr.cacheFiles();
+    ctx.fileStatus.clear();
   }
 
   if (!vm.count("force"))

--- a/parser/src/parser.cpp
+++ b/parser/src/parser.cpp
@@ -373,6 +373,11 @@ int main(int argc, char* argv[])
     LOG(info) << "The number of changed files exceeds the given incremental "
                  "threshold ratio, full parse will be forced.";
     vm.insert(std::make_pair("force", po::variable_value()));
+
+    cc::util::removeTables(db, SQL_DIR);
+    cc::util::createTables(db, SQL_DIR);
+
+    srcMgr.cacheFiles();
   }
 
   if (!vm.count("force"))

--- a/parser/src/sourcemanager.cpp
+++ b/parser/src/sourcemanager.cpp
@@ -16,19 +16,9 @@ namespace parser
 SourceManager::SourceManager(std::shared_ptr<odb::database> db_)
   : _db(db_), _transaction(db_), _magicCookie(nullptr)
 {
-  _transaction([&, this]() {
+  //--- Reload files from database ---//
 
-    //--- Reload files from database ---//
-
-    for (const model::File& file : db_->query<model::File>())
-    {
-      _files[file.path] = std::make_shared<model::File>(file);
-      _persistedFiles.insert(file.id);
-    }
-
-    for (const auto& fileContentId : db_->query<model::FileContentIds>())
-      _persistedContents.insert(fileContentId.hash);
-  });
+  cacheFiles();
 
   //--- Initialize magic for plain text testing ---//
 
@@ -54,6 +44,25 @@ SourceManager::~SourceManager()
 
   if (_magicCookie)
     ::magic_close(_magicCookie);
+}
+
+void SourceManager::cacheFiles()
+{
+  _files.clear();
+  _persistedFiles.clear();
+  _persistedContents.clear();
+
+  _transaction([&, this]() {
+
+    for (const model::File& file : _db->query<model::File>())
+    {
+      _files[file.path] = std::make_shared<model::File>(file);
+      _persistedFiles.insert(file.id);
+    }
+
+    for (const auto& fileContentId : _db->query<model::FileContentIds>())
+      _persistedContents.insert(fileContentId.hash);
+  });
 }
 
 model::FileContentPtr SourceManager::createFileContent(


### PR DESCRIPTION
In case the user wanted to incrementally parse a project but a full parse was forced due to the large number of changed files, the database was not dropped and recreated which caused database errors. This fix aims to recreate the database tables in case of a forced full parse.