### PR TITLE
Incremental parsing of projects with circular dependencies

### DIFF
--- a/plugins/cpp/parser/src/cppparser.cpp
+++ b/plugins/cpp/parser/src/cppparser.cpp
@@ -427,7 +427,10 @@ std::vector<std::vector<std::string>> CppParser::createCleanupOrder()
       {
         order[index].push_back(item.first);
       }
+      
       fileNameToVertex.clear();
+
+      LOG(debug) << "[cppparser] Circular dependency detected.";
     }
 
     ++index;

--- a/plugins/cpp/parser/src/cppparser.cpp
+++ b/plugins/cpp/parser/src/cppparser.cpp
@@ -415,6 +415,21 @@ std::vector<std::vector<std::string>> CppParser::createCleanupOrder()
       fileNameToVertex.erase(path);
     }
 
+    /* Circular dependencies in the parsed code would cause
+     * this loop to be infinite. If no files were put in
+     * the current cleanup level, there is probably a
+     * circular dependency somewhere. The rest of the
+     * to-be-cleaned up files can be put in an additional level.
+     */
+    if (order[index].size() == 0)
+    {
+      for (const auto& item : fileNameToVertex)
+      {
+        order[index].push_back(item.first);
+      }
+      fileNameToVertex.clear();
+    }
+
     ++index;
   }
   LOG(debug) << "[cppparser] Topology has " << index << " levels.";


### PR DESCRIPTION
At the cleanup phase of incremental parsing, files to be cleaned up are organized into levels (topological order). Trying to make the topological order in a project that contains circular dependencies in the to-be-cleaned up files caused an infinite loop. This PR fixes this issue by putting the files with the circular dependencies into an additional level in the topological order thus the loop is guaranteed to terminate.