### PR TITLE
Tarball binary package release through GitLab CI

### DIFF
--- a/.gitlab/README.md
+++ b/.gitlab/README.md
@@ -1,0 +1,17 @@
+How to use
+==========
+
+Configure environment
+---------------------
+Source the `cc-env.sh` file.
+
+Now the important binaries are available on the `PATH` environment variable:  
+`CodeCompass_parser`, `CodeCompass_webserver`, `CodeCompass_logger`, `ccdb-tool`.
+
+
+Start a database
+----------------
+The tarball contains a CodeCompass instance linked against PostgreSQL, therefore two options are available.
+  - Use the PostgreSQL database server on your machine.
+  - The extracted tarball contains a PostgreSQL installation in the `runtime-deps/postgresql-install/bin` folder.
+    Use the `initdb` and `postgres` binaries to create and start a new PostgreSQL database cluster.

--- a/.gitlab/build-codecompass.sh
+++ b/.gitlab/build-codecompass.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -x
+set -e
+
+#####################
+# Build CodeCompass #
+#####################
+
+export PATH=$DEPS_INSTALL_BUILD_DIR/gcc-install/bin\
+:$DEPS_INSTALL_BUILD_DIR/cmake-install/bin\
+:$DEPS_INSTALL_RUNTIME_DIR/libmagic-install/bin\
+:$DEPS_INSTALL_RUNTIME_DIR/odb-install/bin\
+:$DEPS_INSTALL_RUNTIME_DIR/thrift-install/bin\
+:$DEPS_INSTALL_RUNTIME_DIR/jdk-install/bin\
+:$DEPS_INSTALL_RUNTIME_DIR/python-install/bin\
+:$DEPS_INSTALL_RUNTIME_DIR/node-install/bin\
+:$PATH
+
+export CPLUS_INCLUDE_PATH=$DEPS_INSTALL_BUILD_DIR/gtest-install/include\
+:$DEPS_INSTALL_RUNTIME_DIR/libgit2-install/include\
+:$DEPS_INSTALL_RUNTIME_DIR/libmagic-install/include\
+:$DEPS_INSTALL_RUNTIME_DIR/graphviz-install/include\
+:$DEPS_INSTALL_RUNTIME_DIR/boost-install/include\
+:$DEPS_INSTALL_RUNTIME_DIR/openssl-install/include
+
+export C_INCLUDE_PATH=$DEPS_INSTALL_BUILD_DIR/gtest-install/include\
+:$DEPS_INSTALL_RUNTIME_DIR/libgit2-install/include\
+:$DEPS_INSTALL_RUNTIME_DIR/libmagic-install/include\
+:$DEPS_INSTALL_RUNTIME_DIR/graphviz-install/include\
+:$DEPS_INSTALL_RUNTIME_DIR/boost-install/include\
+:$DEPS_INSTALL_RUNTIME_DIR/openssl-install/include
+
+export LIBRARY_PATH=$DEPS_INSTALL_RUNTIME_DIR/graphviz-install/lib\
+:$DEPS_INSTALL_RUNTIME_DIR/libmagic-install/lib\
+:$DEPS_INSTALL_RUNTIME_DIR/libgit2-install/lib\
+:$DEPS_INSTALL_RUNTIME_DIR/libgit2-install/lib64\
+:$DEPS_INSTALL_RUNTIME_DIR/openssl-install/lib
+# Note: libgit2-install/lib required on Ubuntu; libgit2-install/lib64 on SUSE
+
+export LDFLAGS="-Wl,-rpath-link,$DEPS_INSTALL_RUNTIME_DIR/openssl-install/lib "\
+"-Wl,-rpath-link,$DEPS_INSTALL_RUNTIME_DIR/postgresql-install/lib"
+
+export LD_LIBRARY_PATH=$DEPS_INSTALL_RUNTIME_DIR/odb-install/lib\
+:$LD_LIBRARY_PATH
+
+export CMAKE_PREFIX_PATH=$DEPS_INSTALL_RUNTIME_DIR/libgit2-install\
+:$DEPS_INSTALL_RUNTIME_DIR/odb-install\
+:$DEPS_INSTALL_RUNTIME_DIR/thrift-install\
+:$DEPS_INSTALL_RUNTIME_DIR/boost-install\
+:$DEPS_INSTALL_RUNTIME_DIR/llvm-install
+
+export GTEST_ROOT=$DEPS_INSTALL_BUILD_DIR/gtest-install
+
+export CXX=$DEPS_INSTALL_BUILD_DIR/gcc-install/bin/g++
+export CC=$DEPS_INSTALL_BUILD_DIR/gcc-install/bin/gcc
+
+mkdir $CC_BUILD_DIR
+cd $CC_BUILD_DIR
+cmake $CC_SRC_DIR \
+  -DCMAKE_INSTALL_PREFIX=$CC_INSTALL_DIR \
+  -DDATABASE=pgsql \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DLLVM_DIR=$DEPS_INSTALL_RUNTIME_DIR/llvm/lib/cmake/llvm/ \
+  -DClang_DIR=$DEPS_INSTALL_RUNTIME_DIR/llvm/lib/cmake/clang/
+make install --quiet --jobs $(nproc)

--- a/.gitlab/build-deps.sh
+++ b/.gitlab/build-deps.sh
@@ -292,12 +292,14 @@ rm -f $PACKAGES_DIR/libgit2-1.1.0.tar.gz
 #########
 
 cd $PACKAGES_DIR
-wget --no-verbose --no-clobber http://prdownloads.sourceforge.net/ctags/ctags-5.8.tar.gz
-tar -xf ctags-5.8.tar.gz
-cd ctags-5.8
+wget --no-verbose --no-clobber https://github.com/universal-ctags/ctags/archive/p5.9.20201129.0.tar.gz \
+  -O ctags-p5.9.20201129.0.tar.gz
+tar -xf ctags-p5.9.20201129.0.tar.gz
+cd ctags-p5.9.20201129.0
+./autogen.sh
 ./configure --quiet --prefix=$DEPS_INSTALL_RUNTIME_DIR/ctags-install
 make install --quiet --jobs $(nproc)
-rm -f $PACKAGES_DIR/ctags-5.8.tar.gz
+rm -f $PACKAGES_DIR/ctags-p5.9.20201129.0.tar.gz
 
 #########
 # Boost #

--- a/.gitlab/build-deps.sh
+++ b/.gitlab/build-deps.sh
@@ -1,0 +1,403 @@
+#!/bin/bash
+set -x
+set -e
+
+mkdir -p $PACKAGES_DIR
+
+#######
+# GCC #
+#######
+
+if [ ! -f $DEPS_INSTALL_BUILD_DIR/gcc-install/bin/g++ ]; then
+  cd $PACKAGES_DIR
+  wget --no-verbose --no-clobber http://robotlab.itk.ppke.hu/gcc/releases/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.xz
+  tar -xf gcc-$GCC_VERSION.tar.xz
+  cd gcc-$GCC_VERSION
+  ./contrib/download_prerequisites
+  mkdir gcc-build
+  cd gcc-build
+  $PACKAGES_DIR/gcc-$GCC_VERSION/configure \
+    --quiet \
+    --enable-languages=c,c++ \
+    --disable-multilib \
+    --prefix=$DEPS_INSTALL_BUILD_DIR/gcc-install
+  make --quiet --jobs $(nproc)
+  make install --quiet
+  rm -f $PACKAGES_DIR/gcc-$GCC_VERSION.tar.xz
+else
+  echo "Found GCC in cache."
+fi
+export PATH=$DEPS_INSTALL_BUILD_DIR/gcc-install/bin:$PATH
+export CXX=$DEPS_INSTALL_BUILD_DIR/gcc-install/bin/g++
+export CC=$DEPS_INSTALL_BUILD_DIR/gcc-install/bin/gcc
+
+#########
+# CMake #
+#########
+
+cd $PACKAGES_DIR
+wget --no-verbose --no-clobber https://github.com/Kitware/CMake/releases/download/v3.19.0/cmake-3.19.0-Linux-x86_64.tar.gz
+tar -xf cmake-3.19.0-Linux-x86_64.tar.gz -C $DEPS_INSTALL_BUILD_DIR
+rm -rf cmake-3.19.0-Linux-x86_64.tar.gz
+
+cd $DEPS_INSTALL_BUILD_DIR
+mv cmake-3.19.0-Linux-x86_64 cmake-install
+
+export PATH=$DEPS_INSTALL_BUILD_DIR/cmake-install/bin:$PATH
+
+######
+# m4 #
+######
+
+cd $PACKAGES_DIR
+wget --no-verbose --no-clobber https://ftp.gnu.org/gnu/m4/m4-1.4.18.tar.gz
+tar -xf m4-1.4.18.tar.gz
+cd m4-1.4.18
+./configure --quiet --prefix=$DEPS_INSTALL_BUILD_DIR/m4-install
+make install --quiet --jobs $(nproc)
+rm -rf $PACKAGES_DIR/m4-1.4.18.tar.gz
+
+###########
+# libtool #
+###########
+
+cd $PACKAGES_DIR
+wget --no-verbose --no-clobber https://quantum-mirror.hu/mirrors/pub/gnu/libtool/libtool-2.4.6.tar.gz
+tar -xf libtool-2.4.6.tar.gz
+cd libtool-2.4.6
+PATH=$DEPS_INSTALL_BUILD_DIR/m4-install/bin:$PATH \
+./configure --quiet --prefix=$DEPS_INSTALL_RUNTIME_DIR/libtool-install
+make install --quiet --jobs $(nproc)
+rm -rf $PACKAGES_DIR/libtool-2.4.6.tar.gz
+
+###########
+# openssl #
+###########
+
+cd $PACKAGES_DIR
+wget --no-verbose --no-clobber https://www.openssl.org/source/openssl-1.1.1h.tar.gz
+tar -xf openssl-1.1.1h.tar.gz
+cd openssl-1.1.1h
+./config \
+  --prefix=$DEPS_INSTALL_RUNTIME_DIR/openssl-install \
+  --openssldir=/etc/ssl
+make install --quiet # must run as single core job
+rm -f $PACKAGES_DIR/openssl-1.1.1h.tar.gz
+
+############
+# libmagic #
+############
+
+cd $PACKAGES_DIR
+wget --no-verbose --no-clobber https://github.com/threatstack/libmagic/archive/5.18.tar.gz
+tar -xf 5.18.tar.gz
+cd libmagic-5.18/
+
+./configure --quiet --prefix=$DEPS_INSTALL_RUNTIME_DIR/libmagic-install
+make install --quiet --jobs $(nproc)
+rm -f $PACKAGES_DIR/libmagic-5.18.tar.gz
+
+###########
+# libcutl #
+###########
+# note: needed for ODB 2.4.0
+
+cd $PACKAGES_DIR
+wget --no-verbose --no-clobber https://www.codesynthesis.com/download/libcutl/1.10/libcutl-1.10.0.tar.gz
+tar -xf libcutl-1.10.0.tar.gz
+cd libcutl-1.10.0
+
+./configure --quiet --prefix=$DEPS_INSTALL_BUILD_DIR/libcutl-install
+make install --quiet --jobs $(nproc)
+rm -f $PACKAGES_DIR/libcutl-1.10.0.tar.gz
+
+##############
+# PostgreSQL #
+##############
+
+cd $PACKAGES_DIR
+wget --no-verbose --no-clobber https://ftp.postgresql.org/pub/source/v10.4/postgresql-10.4.tar.gz
+tar -xf postgresql-10.4.tar.gz
+cd postgresql-10.4
+
+./configure \
+  --quiet \
+  --prefix=$DEPS_INSTALL_RUNTIME_DIR/postgresql-install \
+  --without-readline \
+  --without-zlib
+
+make install --quiet --jobs $(nproc)
+rm -f $PACKAGES_DIR/postgresql-10.4.tar.gz
+
+###############
+# odb, libodb #
+###############
+
+if [ ! -f $DEPS_INSTALL_RUNTIME_DIR/odb-install/bin/odb ]; then
+  if [[ $ODB_VERSION == "2.5.0" ]]; then
+    # build2
+    cd $PACKAGES_DIR
+    wget --no-verbose --no-clobber https://download.build2.org/0.13.0/build2-install-0.13.0.sh
+    sh build2-install-0.13.0.sh --yes --trust yes --jobs $(nproc) $PACKAGES_DIR/build2-install
+    export PATH=$PACKAGES_DIR/build2-install/bin:$PATH
+
+    # odb, libodb
+    cd $PACKAGES_DIR
+    mkdir odb-build
+    cd odb-build
+    bpkg create --quiet --jobs $(nproc) cc \
+      config.cxx=g++ \
+      config.cc.coptions=-O3 \
+      config.bin.rpath_link=$DEPS_INSTALL_RUNTIME_DIR/odb-install/lib \
+      config.install.root=$DEPS_INSTALL_RUNTIME_DIR/odb-install
+
+    bpkg add https://pkg.cppget.org/1/beta --trust-yes
+    bpkg fetch --trust-yes
+
+    bpkg build odb --yes --quiet --jobs $(nproc)
+    bpkg build libodb --yes --quiet --jobs $(nproc)
+    bpkg build libodb-sqlite --yes --quiet --jobs $(nproc)
+    bpkg build libodb-pgsql --yes --quiet --jobs $(nproc)
+    bpkg install --all --recursive --quiet --jobs $(nproc)
+
+    rm -f $PACKAGES_DIR/build2-toolchain-0.13.0.tar.xz
+  elif [[ $ODB_VERSION == "2.4.0" ]]; then
+    # odb
+    cd $PACKAGES_DIR
+    wget --no-verbose --no-clobber https://www.codesynthesis.com/download/odb/2.4/odb-2.4.0.tar.gz
+
+    tar -xf odb-2.4.0.tar.gz
+    cd odb-2.4.0
+
+    ./configure --quiet \
+      --prefix=$DEPS_INSTALL_RUNTIME_DIR/odb-install \
+      --with-libcutl=$PACKAGES_DIR/libcutl-1.10.0 # build dir
+    make install --quiet --jobs $(nproc)
+    rm -f $PACKAGES_DIR/odb-2.4.0.tar.gz
+
+
+    # libodb
+    cd $PACKAGES_DIR
+    wget --no-verbose --no-clobber https://www.codesynthesis.com/download/odb/2.4/libodb-2.4.0.tar.gz
+
+    tar -xf libodb-2.4.0.tar.gz
+    cd libodb-2.4.0
+
+    ./configure --quiet \
+      --prefix=$DEPS_INSTALL_RUNTIME_DIR/odb-install
+    make install --quiet --jobs $(nproc)
+    rm -f $PACKAGES_DIR/libodb-2.4.0.tar.gz
+
+
+    # libodb-pgsql
+    cd $PACKAGES_DIR
+    wget --no-verbose --no-clobber https://www.codesynthesis.com/download/odb/2.4/libodb-pgsql-2.4.0.tar.gz
+
+    tar -xf libodb-pgsql-2.4.0.tar.gz
+    cd libodb-pgsql-2.4.0
+
+    CXXFLAGS="$CXXFLAGS -I$DEPS_INSTALL_RUNTIME_DIR/postgresql-install/include" \
+    LDFLAGS="$LDFLAGS -L$DEPS_INSTALL_RUNTIME_DIR/postgresql-install/lib" \
+    ./configure \
+      --prefix=$DEPS_INSTALL_RUNTIME_DIR/odb-install \
+      --with-libodb=$PACKAGES_DIR/libodb-2.4.0 # build dir
+    make install --quiet --jobs $(nproc)
+    rm -f $PACKAGES_DIR/libodb-pgsql-2.4.0.tar.gz
+  else
+    echo "ERROR: Not support ODB version."
+    exit 1
+  fi
+else
+  echo "Found ODB in cache."
+fi
+
+############
+# GraphViz #
+############
+
+cd $PACKAGES_DIR
+wget --no-verbose --no-clobber https://graphviz.gitlab.io/pub/graphviz/stable/SOURCES/graphviz.tar.gz
+tar -xf graphviz.tar.gz
+cd graphviz-2.40.1
+
+./configure --quiet --prefix=$DEPS_INSTALL_RUNTIME_DIR/graphviz-install
+make install --quiet --jobs $(nproc)
+rm -f $PACKAGES_DIR/graphviz.tar.gz
+
+##########
+# Python #
+##########
+
+cd $PACKAGES_DIR
+wget --no-verbose --no-clobber https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tar.xz
+tar -xf Python-3.9.0.tar.xz
+cd Python-3.9.0
+
+# needed for Python compile AND run
+export LD_LIBRARY_PATH=$DEPS_INSTALL_RUNTIME_DIR/openssl-install/lib:$LD_LIBRARY_PATH
+
+./configure \
+  --quiet \
+  --prefix=$DEPS_INSTALL_RUNTIME_DIR/python-install \
+  --with-openssl=$DEPS_INSTALL_RUNTIME_DIR/openssl-install \
+  --enable-optimizations
+make install --quiet --jobs $(nproc)
+rm -f $PACKAGES_DIR/Python-3.9.0.tar.xz
+
+export PATH=$DEPS_INSTALL_RUNTIME_DIR/python-install/bin:$PATH
+
+##############
+# LLVM/Clang #
+##############
+
+if [ ! -f $DEPS_INSTALL_RUNTIME_DIR/llvm-install/bin/clang ]; then
+  cd $PACKAGES_DIR
+  wget --no-verbose --no-clobber https://github.com/llvm/llvm-project/archive/llvmorg-10.0.1.tar.gz
+  tar -xf llvmorg-10.0.1.tar.gz
+  mv llvm-project-llvmorg-10.0.1 llvm-project
+  mkdir llvm-project/build
+  cd llvm-project/build
+
+  cmake ../llvm \
+    -G "Unix Makefiles" \
+    -DLLVM_ENABLE_PROJECTS=clang \
+    -DCMAKE_INSTALL_PREFIX=$DEPS_INSTALL_RUNTIME_DIR/llvm-install \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DLLVM_ENABLE_RTTI=ON
+
+  make install --quiet --jobs $(nproc)
+  rm -f $PACKAGES_DIR/llvmorg-10.0.1.tar.gz
+else
+  echo "Found LLVM/Clang in cache."
+fi
+
+###########
+# libgit2 #
+###########
+
+cd $PACKAGES_DIR
+wget --no-verbose --no-clobber https://github.com/libgit2/libgit2/releases/download/v1.1.0/libgit2-1.1.0.tar.gz
+tar -xf libgit2-1.1.0.tar.gz
+mkdir libgit2-1.1.0/build
+cd libgit2-1.1.0/build
+
+cmake .. \
+  -DCMAKE_INSTALL_PREFIX=$DEPS_INSTALL_RUNTIME_DIR/libgit2-install \
+  -DOPENSSL_ROOT_DIR=$DEPS_INSTALL_RUNTIME_DIR/openssl-install
+make install --quiet --jobs $(nproc)
+rm -f $PACKAGES_DIR/libgit2-1.1.0.tar.gz
+
+#########
+# ctags #
+#########
+
+cd $PACKAGES_DIR
+wget --no-verbose --no-clobber http://prdownloads.sourceforge.net/ctags/ctags-5.8.tar.gz
+tar -xf ctags-5.8.tar.gz
+cd ctags-5.8
+./configure --quiet --prefix=$DEPS_INSTALL_RUNTIME_DIR/ctags-install
+make install --quiet --jobs $(nproc)
+rm -f $PACKAGES_DIR/ctags-5.8.tar.gz
+
+#########
+# Boost #
+#########
+
+if [ ! -f $DEPS_INSTALL_RUNTIME_DIR/boost-install/lib/libboost_program_options.so ]; then
+  cd $PACKAGES_DIR
+  wget --no-verbose --no-clobber https://dl.bintray.com/boostorg/release/1.74.0/source/boost_1_74_0.tar.gz
+  tar -xf boost_1_74_0.tar.gz
+  cd boost_1_74_0
+
+  ./bootstrap.sh \
+    --prefix=$DEPS_INSTALL_RUNTIME_DIR/boost-install \
+    --with-python=$DEPS_INSTALL_RUNTIME_DIR/python-install/bin/python
+  ./b2 -j $(nproc) install
+
+  rm -f $PACKAGES_DIR/boost_1_74_0.tar.gz
+else
+  echo "Found Boost in cache."
+fi
+
+##########
+# Thrift #
+##########
+
+cd $PACKAGES_DIR
+wget --no-verbose --no-clobber http://xenia.sote.hu/ftp/mirrors/www.apache.org/thrift/0.13.0/thrift-0.13.0.tar.gz
+tar -xf thrift-0.13.0.tar.gz
+cd thrift-0.13.0
+
+CXXFLAGS="$CXXFLAGS -I$DEPS_INSTALL_RUNTIME_DIR/boost-install/include" \
+LDFLAGS="$LDFLAGS -Wl,-rpath-link,$DEPS_INSTALL_RUNTIME_DIR/openssl-install/lib" \
+./configure \
+  --quiet \
+  --prefix=$DEPS_INSTALL_RUNTIME_DIR/thrift-install \
+  --with-boost=$DEPS_INSTALL_RUNTIME_DIR/boost-install \
+  --with-openssl=$DEPS_INSTALL_RUNTIME_DIR/openssl-install \
+  --without-python
+
+make install --quiet --jobs $(nproc)
+rm -f $PACKAGES_DIR/thrift-0.13.0.tar.gz
+
+########
+# Java #
+########
+
+cd $PACKAGES_DIR
+wget --no-verbose --no-clobber https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_linux-x64_bin.tar.gz
+tar -xf openjdk-15.0.1_linux-x64_bin.tar.gz -C $DEPS_INSTALL_RUNTIME_DIR
+rm -f openjdk-15.0.1_linux-x64_bin.tar.gz
+
+cd $DEPS_INSTALL_RUNTIME_DIR
+mv jdk-15.0.1 jdk-install
+
+export PATH=$DEPS_INSTALL_RUNTIME_DIR/jdk-install/bin:$PATH
+export JAVA_HOME=$DEPS_INSTALL_RUNTIME_DIR/jdk-install
+
+###############
+# Google Test #
+###############
+
+cd $PACKAGES_DIR
+wget --no-verbose --no-clobber https://github.com/google/googletest/archive/release-1.10.0.tar.gz
+tar -xf release-1.10.0.tar.gz
+mkdir gtest-build
+cd gtest-build
+cmake ../googletest-release-1.10.0 -DCMAKE_INSTALL_PREFIX=$DEPS_INSTALL_BUILD_DIR/gtest-install
+make install --quiet --jobs $(nproc)
+rm -f $PACKAGES_DIR/release-1.10.0.tar.gz
+
+#######
+# npm #
+#######
+
+cd $PACKAGES_DIR
+wget --no-verbose --no-clobber https://nodejs.org/dist/v14.15.0/node-v14.15.0-linux-x64.tar.xz
+tar -xf node-v14.15.0-linux-x64.tar.xz -C $DEPS_INSTALL_RUNTIME_DIR
+rm -f node-v14.15.0-linux-x64.tar.xz
+
+cd $DEPS_INSTALL_RUNTIME_DIR
+mv node-v14.15.0-linux-x64 node-install
+export PATH=$DEPS_INSTALL_RUNTIME_DIR/node-install/bin:$PATH
+
+#######
+# pip #
+#######
+
+cd $PACKAGES_DIR
+wget --no-verbose --no-clobber https://bootstrap.pypa.io/get-pip.py
+python3 get-pip.py
+rm -f get-pip.py
+
+#############
+# ccdb-tool #
+#############
+
+cd $PACKAGES_DIR
+wget --no-verbose --no-clobber https://github.com/gamesh411/ccdb-tool/archive/master.zip -O ccdb-tool.zip
+unzip -q ccdb-tool.zip -d $BUILD_DIR
+rm -f ccdb-tool.zip
+
+cd $BUILD_DIR
+mv ccdb-tool-master ccdb-tool

--- a/.gitlab/cc-env.sh
+++ b/.gitlab/cc-env.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# SOURCE THIS FILE!
+
+PS1_ORIG=$PS1
+
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd -P)"
+DEPS_INSTALL_DIR=$ROOT_DIR/deps-runtime
+CC_INSTALL_DIR=$ROOT_DIR/cc-install
+
+export LD_LIBRARY_PATH=$DEPS_INSTALL_DIR/libgit2-install/lib64\
+:$DEPS_INSTALL_DIR/openssl-install/lib\
+:$DEPS_INSTALL_DIR/graphviz-install/lib\
+:$DEPS_INSTALL_DIR/libmagic-install/lib\
+:$DEPS_INSTALL_DIR/boost-install/lib\
+:$DEPS_INSTALL_DIR/odb-install/lib\
+:$DEPS_INSTALL_DIR/thrift-install/lib\
+:$DEPS_INSTALL_DIR/llvm-install/lib\
+:$DEPS_INSTALL_DIR/libtool-install/lib\
+:$DEPS_INSTALL_DIR/postgresql-install/lib\
+:$LD_LIBRARY_PATH
+
+export PATH=$DEPS_INSTALL_DIR/jdk-install/bin\
+:$DEPS_INSTALL_DIR/ctags-install/bin\
+:$DEPS_INSTALL_DIR/python-install/bin\
+:$DEPS_INSTALL_DIR/node-install/bin\
+:$CC_INSTALL_DIR/bin\
+:$PATH
+
+export MAGIC=$DEPS_INSTALL_DIR/libmagic-install/share/misc/magic.mgc
+export JAVA_HOME=$DEPS_INSTALL_DIR/jdk-install
+
+if [ -f $ROOT_DIR/ccdb-tool/venv/bin/activate ]; then
+  source $ROOT_DIR/ccdb-tool/venv/bin/activate
+else
+  pushd $ROOT_DIR/ccdb-tool
+  # install venv
+  python3 -m pip install virtualenv
+  # create venv
+  make venv
+  source venv/bin/activate
+  # build ccdb-tool
+  make package
+  popd
+fi
+
+export PS1="(cc-env) $PS1_ORIG"

--- a/.gitlab/ci.yml
+++ b/.gitlab/ci.yml
@@ -107,6 +107,8 @@ tarball ubuntu-16.04:
         - apt-get install -yqq curl wget bzip2 unzip ca-certificates
         # build tools for CodeCompass
         - apt-get install -yqq build-essential libgmp-dev zlib1g-dev
+        # build tools for ctags
+        - apt-get install -yqq dh-autoreconf pkg-config
         # build tools for ccdb-tools
         - apt-get install -yqq libffi-dev
         # show GLIBC verison

--- a/.gitlab/ci.yml
+++ b/.gitlab/ci.yml
@@ -1,0 +1,148 @@
+stages:
+    - prepare
+    - package
+    - deploy
+
+variables:
+    BUILD_DIR: $CI_PROJECT_DIR/build
+    PACKAGES_DIR: $CI_PROJECT_DIR/build/packages
+    DEPS_INSTALL_BUILD_DIR: $CI_PROJECT_DIR/build/deps-build
+    DEPS_INSTALL_RUNTIME_DIR: $CI_PROJECT_DIR/build/deps-runtime
+    CC_SRC_DIR: $CI_PROJECT_DIR
+    CC_BUILD_DIR: $CI_PROJECT_DIR/build/cc-build
+    CC_INSTALL_DIR: $CI_PROJECT_DIR/build/cc-install
+
+.tarball:
+    stage: package
+    when: manual
+    allow_failure: false
+    timeout: 12h
+    tags: ["long-running"]
+    script:
+        - cd .gitlab
+        - chmod +x build-deps.sh build-codecompass.sh
+        - ./build-deps.sh
+        - ./build-codecompass.sh
+        - cd $BUILD_DIR
+        - cp $CI_PROJECT_DIR/.gitlab/cc-env.sh .
+        - cp $CI_PROJECT_DIR/.gitlab/README.md .
+        - tar -czf codecompass.tar.gz --transform "s|^\.|codecompass|" ./deps-runtime ./cc-install ./ccdb-tool ./cc-env.sh ./README.md
+        - "echo Tarball size: $(du -m codecompass.tar.gz | cut -f1) MB"
+    artifacts:
+        paths:
+            - build/codecompass.tar.gz
+        expire_in: 1 week
+    cache:
+        paths:
+            - $DEPS_INSTALL_BUILD_DIR/gcc-install/
+            - $DEPS_INSTALL_RUNTIME_DIR/odb-install/
+            - $DEPS_INSTALL_RUNTIME_DIR/llvm-install/
+            - $DEPS_INSTALL_RUNTIME_DIR/boost-install/
+
+.show-glibc-version: &show-glibc-version
+  - |
+    if ! GLIBC_VERSION=$(ldd --version | grep -Po "(?<=GLIBC )[0-9.]+"); then
+      GLIBC_VERSION=$(ldd --version | grep -Po "[0-9.]+[0-9]$")
+    fi
+    if LIBSTDC_PATH=$(ldconfig -p | grep -m1 "stdc++" | grep -Po "(?<=\=\> ).*"); then
+      GLIBCXX_VERSIONS=$(strings $LIBSTDC_PATH | grep -Po "(?<=GLIBCXX_)[0-9.]+")
+      GLIBCXX_VERSIONS="${GLIBCXX_VERSIONS//$'\n'/ }" # replace newlines with spaces
+    fi
+    echo "GLIBC version: $GLIBC_VERSION"
+    echo "GLIBCXX versions: $GLIBCXX_VERSIONS"
+
+tarball suse-15:
+    extends: .tarball
+    image: opensuse/leap:15
+    cache:
+        key: "leap"
+    variables:
+        GCC_VERSION: 7.5.0
+        ODB_VERSION: 2.5.0
+    before_script:
+        - zypper refresh
+        - zypper update -y
+        # download tools
+        - zypper install -y curl wget bzip2 unzip ca-certificates
+        # build tools for CodeCompass
+        - zypper install -y -t pattern devel_basis
+        - zypper install -y binutils gcc-c++ gmp-devel
+        # build tools for ccdb-tools
+        - zypper install -y libffi-devel
+        # show GLIBC verison
+        - *show-glibc-version
+
+tarball suse-42.1:
+    extends: .tarball
+    image: opensuse/archive:42.1
+    cache:
+        key: "malachite"
+    variables:
+        GCC_VERSION: 5.5.0
+        ODB_VERSION: 2.4.0
+    before_script:
+        - zypper refresh
+        - zypper update -y
+        # download tools
+        - zypper install -y curl wget bzip2 unzip ca-certificates
+        # build tools for CodeCompass
+        - zypper install -y -t pattern devel_basis
+        - zypper install -y binutils gcc-c++ gmp-devel
+        # build tools for ccdb-tools
+        - zypper install -y libffi-devel
+        # show GLIBC verison
+        - *show-glibc-version
+
+tarball ubuntu-16.04:
+    extends: .tarball
+    image: ubuntu:16.04
+    cache:
+        key: "xenial"
+    variables:
+        GCC_VERSION: 5.5.0
+        ODB_VERSION: 2.4.0
+    before_script:
+        - apt-get update -yqq
+        # download tools
+        - apt-get install -yqq curl wget bzip2 unzip ca-certificates
+        # build tools for CodeCompass
+        - apt-get install -yqq build-essential libgmp-dev zlib1g-dev
+        # build tools for ccdb-tools
+        - apt-get install -yqq libffi-dev
+        # show GLIBC verison
+        - *show-glibc-version
+
+.upload:
+    stage: deploy
+    image: ubuntu:20.04
+    when: manual
+    allow_failure: false
+    variables:
+        FILENAME: codecompass.tar.gz
+    before_script:
+        - 'which ssh-agent || ( apt-get update -y && apt-get install openssh-client -y )'
+        - mkdir -p ~/.ssh
+        - eval $(ssh-agent -s)
+        - '[[ -f /.dockerenv ]] && echo -e "Host *\n\tStrictHostKeyChecking no\n\n" > ~/.ssh/config'
+    script:
+        - ssh-add <(echo "$CD_PRIVATE_KEY")
+        - scp -P22 build/codecompass.tar.gz gitlab-deployer@codecompass.net:/var/www/codecompass/$FILENAME
+        - ssh -p22 gitlab-deployer@codecompass.net "mv -f /var/www/codecompass/$FILENAME /var/www/codecompass/live/wwwroot/tarball/$FILENAME"
+
+upload suse-15:
+    extends: .upload
+    variables:
+        FILENAME: codecompass-suse-15.tar.gz
+    needs: ["tarball suse-15"]
+
+upload suse-42.1:
+    extends: .upload
+    variables:
+        FILENAME: codecompass-suse-42.1.tar.gz
+    needs: ["tarball suse-42.1"]
+
+upload ubuntu-16.04:
+    extends: .upload
+    variables:
+        FILENAME: codecompass-ubuntu-16.04.tar.gz
+    needs: ["tarball ubuntu-16.04"]


### PR DESCRIPTION
This PR adds a Bash script to build all dependencies of CodeCompass from source and CodeCompass itself.  
The created tarball can be extracted and used on a fresh system with high compatibility. (Only minimal assumptions are made, which are typically installed together with the operating system.)

The PR also adds a configuration to execute the creation of the tarballs in GitLab CI. The tarball is created in 3 operating systems:
 - OpenSUSE 42.1 (tested to be compatible with SUSE SLES 12 SP2 on Ericsson servers);
 - OpenSUSE Leap 15;
 - Ubuntu 16.04.

The tarballs are uploaded here:  
https://codecompass.net/tarball/