### PR TITLE
CallExpr can be applied to a function pointer

### DIFF
--- a/plugins/cpp/parser/src/clangastvisitor.h
+++ b/plugins/cpp/parser/src/clangastvisitor.h
@@ -1061,7 +1061,10 @@ public:
       : namedCallee->getNameAsString();
     astNode->location = getFileLoc(ce_->getBeginLoc(), ce_->getEndLoc());
     astNode->entityHash = util::fnvHash(usr);
-    astNode->symbolType = model::CppAstNode::SymbolType::Function;
+    astNode->symbolType
+      = funcCallee
+      ? model::CppAstNode::SymbolType::Function
+      : model::CppAstNode::SymbolType::FunctionPtr;
     astNode->astType
       = isVirtualCall(ce_)
       ? model::CppAstNode::AstType::VirtualCall

--- a/plugins/cpp/service/src/cppservice.cpp
+++ b/plugins/cpp/service/src/cppservice.cpp
@@ -958,6 +958,8 @@ void CppServiceHandler::getReferences(
         break;
     }
 
+    // In the InfoTree we'd like to see AST nodes in alphabetical order except
+    // for function parameters and enum constants where the order is important.
     if (referenceId_ != PARAMETER &&
         referenceId_ != ENUM_CONSTANTS)
       std::sort(nodes.begin(), nodes.end(), compareByValue);
@@ -1523,17 +1525,14 @@ CppServiceHandler::getTags(const std::vector<model::CppAstNode>& nodes_)
             tags[node.id].push_back(visibility);
         }
 
-        if (defNode.symbolType == model::CppAstNode::SymbolType::Function)
-        {
-          //--- Virtual Tag ---//
+        //--- Virtual Tag ---//
 
-          FuncResult funcNodes = _db->query<cc::model::CppFunction>(
-            FuncQuery::entityHash == defNode.entityHash);
-          const model::CppFunction& funcNode = *funcNodes.begin();
+        FuncResult funcNodes = _db->query<cc::model::CppFunction>(
+          FuncQuery::entityHash == defNode.entityHash);
+        const model::CppFunction& funcNode = *funcNodes.begin();
 
-          for (const model::Tag& tag : funcNode.tags)
-            tags[node.id].push_back(model::tagToString(tag));
-        }
+        for (const model::Tag& tag : funcNode.tags)
+          tags[node.id].push_back(model::tagToString(tag));
 
         break;
       }


### PR DESCRIPTION
In an earlier commit (a8a1502ac68c1349281e34e2729cdc3988ccf6af) there was a
bugfix which related to fetching "is virtual" tag of a function pointer. Of
course function pointers can't have this flag. This previous commit fixed this
issue on server-side, however, it was the parser's fault that the symbol type
in a call expression was set to function even if it was a function pointer.