### PR TITLE
Parsing test projects in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Build project
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 env:
   BUILD_TYPE: Release
@@ -64,8 +64,16 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-18.04' && matrix.db == 'sqlite3' }}
         run: sudo apt-get install libsqlite3-dev
 
-      - name: Install Thrift
+      - name: Cache Thrift Ubuntu 18
+        id: thrift-cache
         if: ${{ matrix.os == 'ubuntu-18.04' }}
+        uses: actions/cache@v2
+        with:
+          path: ~/thrift_install
+          key: ${{ matrix.db }}-thrift-v2
+
+      - name: Install Thrift
+        if: ${{ matrix.os == 'ubuntu-18.04' && steps.thrift-cache.outputs.cache-hit != 'true' }}
         run: |
           cd $HOME
           wget -O thrift-0.13.0.tar.gz "http://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=thrift/0.13.0/thrift-0.13.0.tar.gz"
@@ -73,11 +81,17 @@ jobs:
           cd thrift-0.13.0
           ./configure --prefix=$HOME/thrift_install --without-python --enable-libtool-lock --enable-tutorial=no --enable-tests=no --with-libevent --with-zlib --without-nodejs --without-lua --without-ruby --without-csharp --without-erlang --without-perl --without-php --without-php_extension --without-dart --without-haskell --without-go --without-rs --without-haxe --without-dotnetcore --without-d --without-qt4 --without-qt5 --without-java --without-swift
           make install -j $(nproc)
-          echo "CMAKE_PREFIX_PATH=$HOME/thrift_install:$CMAKE_PREFIX_PATH" >> $GITHUB_ENV
-          echo "PATH=$HOME/thrift_install/bin:$PATH" >> $GITHUB_ENV
+
+      - name: Cache ODB Ubuntu 18
+        id: odb-cache
+        if: ${{ matrix.os == 'ubuntu-18.04' }}
+        uses: actions/cache@v2
+        with:
+          path: ~/odb_install
+          key: ${{ matrix.db }}-odb-v2
 
       - name: Install ODB
-        if: ${{ matrix.os == 'ubuntu-18.04' }}
+        if: ${{ matrix.os == 'ubuntu-18.04' && steps.odb-cache.outputs.cache-hit != 'true' }}
         run: |
           cd $HOME
           mkdir /tmp/build2src
@@ -95,8 +109,14 @@ jobs:
           bpkg build libodb-sqlite --yes
           bpkg build libodb-pgsql --yes
           bpkg install --all --recursive
-          echo "CMAKE_PREFIX_PATH=$HOME/odb_install:$CMAKE_PREFIX_PATH" >> $GITHUB_ENV
-          echo "PATH=$HOME/odb_install/bin:$PATH" >> $GITHUB_ENV
+
+      - name: Export environment variables Ubuntu 18
+        if: ${{ matrix.os == 'ubuntu-18.04' }}
+        run: |
+          ls $HOME/odb_install/bin
+          ls $HOME/thrift_install/bin
+          echo "CMAKE_PREFIX_PATH=$HOME/thrift_install:$HOME/odb_install:$CMAKE_PREFIX_PATH" >> $GITHUB_ENV
+          echo "PATH=$HOME/thrift_install/bin:$HOME/odb_install/bin:$PATH" >> $GITHUB_ENV
 
       - name: Install GoogleTest
         run: |
@@ -138,5 +158,3 @@ jobs:
       - name: Run tests
         working-directory: ${{github.workspace}}/build
         run: make test ARGS=-V
-
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,37 +192,26 @@ jobs:
         working-directory: ${{github.workspace}}/build
         run: make test ARGS=-V
 
-      - name: Parse CodeCompass Postgresql
-        if: ${{ matrix.db == 'postgresql' }}
-        run: >
-          mkdir $HOME/ws_pgsql
-
-          ${{github.workspace}}/${{ matrix.os }}/${{ matrix.db }}/install/bin/CodeCompass_parser
-          -d "pgsql:host=localhost;port=5432;user=postgres;password=postgres;database=codecompass"
-          -w $HOME/ws_pgsql/
-          -n "CodeCompass"
-          -i ${{github.workspace}}
-          -i ${{github.workspace}}/build/compile_commands.json
-          -j $(nproc)
-
-      - name: Parse CodeCompass SQLite3
-        if: ${{ matrix.db == 'sqlite3' }}
-        run: >
-          mkdir $HOME/ws_pgsql
-
-          ${{github.workspace}}/${{ matrix.os }}/${{ matrix.db }}/install/bin/CodeCompass_parser
-          -d "sqlite:database=$HOME/codecompass.sqlite"
-          -w $HOME/ws_pgsql/
-          -n "CodeCompass"
-          -i ${{github.workspace}}
-          -i ${{github.workspace}}/build/compile_commands.json
-          -j $(nproc)
-
       - name: Archive CodeCompass binaries
         uses: actions/upload-artifact@v2
         with:
           name: codecompass-${{ matrix.os }}-${{ matrix.db }}-bin
           path: ${{github.workspace}}/${{ matrix.os }}/${{ matrix.db }}/install
+
+      - name: Archive CodeCompass compile-time source files
+        uses: actions/upload-artifact@v2
+        with:
+          name: codecompass-${{ matrix.os }}-${{ matrix.db }}-compiletime
+          path: |
+            ${{github.workspace}}/build/**/*.c
+            ${{github.workspace}}/build/**/*.h
+            ${{github.workspace}}/build/**/*.cpp
+            ${{github.workspace}}/build/**/*.hpp
+            ${{github.workspace}}/build/**/*.cxx
+            ${{github.workspace}}/build/**/*.hxx
+            ${{github.workspace}}/build/**/*.ixx
+            ${{github.workspace}}/build/**/*.js
+            ${{github.workspace}}/build/**/compile_commands.json
 
   parse:
     needs: build
@@ -255,13 +244,16 @@ jobs:
           - 5432:5432
 
     steps:
+      - uses: actions/checkout@v2
+
       # Ubuntu 18.04 commands
       - name: Install required packages Ubuntu 18
         if: ${{ matrix.os == 'ubuntu-18.04' }}
         run: >
-          sudo apt-get install -y git cmake make g++ gcc-7-plugin-dev libboost-all-dev
-          llvm-10-dev clang-10 libclang-10-dev default-jdk libssl1.0-dev
-          libmagic-dev libgit2-dev ctags
+          sudo apt-get install -y git cmake make g++ gcc-7-plugin-dev libgraphviz-dev
+          libboost-filesystem-dev libboost-log-dev libboost-program-options-dev
+          llvm-10-dev clang-10 libclang-10-dev default-jre libssl1.0-dev libmagic-dev
+          libgit2-dev ctags libgtest-dev
 
       - name: Install Postgresql Ubuntu 18
         if: ${{ matrix.os == 'ubuntu-18.04' && matrix.db == 'postgresql' }}
@@ -297,9 +289,10 @@ jobs:
       - name: Install required packages Ubuntu 20
         if: ${{ matrix.os == 'ubuntu-20.04' }}
         run: >
-          sudo apt-get install -y git cmake make g++ libboost-all-dev llvm-10-dev
-          clang-10 libclang-10-dev odb libodb-dev libthrift-dev default-jdk
-          libssl-dev libmagic-dev libgit2-dev ctags
+          sudo apt-get install -y git cmake make g++ libboost-filesystem-dev
+          libboost-log-dev libboost-program-options-dev llvm-10-dev clang-10
+          libclang-10-dev libgraphviz-dev libgtest-dev odb libodb-dev
+          libthrift-dev default-jre libssl1.1 libmagic-dev libgit2-dev ctags
 
       - name: Install Postgresql Ubuntu 20
         if: ${{ matrix.os == 'ubuntu-20.04' && matrix.db == 'postgresql' }}
@@ -314,9 +307,17 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: codecompass-${{ matrix.os }}-${{ matrix.db }}-bin
+          path: ${{github.workspace}}/install
 
-      - name: Add execute right to parser
-        run: chmod +x ${{github.workspace}}/bin/CodeCompass_parser
+      - name: Download CodeCompass compile-time source files
+        uses: actions/download-artifact@v2
+        with:
+          name: codecompass-${{ matrix.os }}-${{ matrix.db }}-compiletime
+          path: ${{github.workspace}}/build
+
+      - name: Add execute right to parser and move source files
+        run: |
+          chmod +x ${{github.workspace}}/install/bin/CodeCompass_parser
 
       # Parsing with Postgresql
       - name: Parse TinyXML Postgresql
@@ -327,8 +328,19 @@ jobs:
           mkdir build_tinyxml2 && cd build_tinyxml2
           cmake $HOME/tinyxml2 -DCMAKE_EXPORT_COMPILE_COMMANDS=1
           make -j $(nproc)
-          cd ${{github.workspace}}/bin
+          cd ${{github.workspace}}/install/bin
           ./CodeCompass_parser  -d "pgsql:host=localhost;port=5432;user=postgres;password=postgres;database=tinyxml2" -w $HOME/ws_pgsql/ -n TinyXML2 -i $HOME/tinyxml2 -i $HOME/build_tinyxml2/compile_commands.json -j $(nproc)
+
+      - name: Parse CodeCompass Postgresql
+        if: ${{ matrix.db == 'postgresql' }}
+        run: >
+          ${{github.workspace}}/install/bin/CodeCompass_parser
+          -d "pgsql:host=localhost;port=5432;user=postgres;password=postgres;database=codecompass"
+          -w $HOME/ws_pgsql/
+          -n "CodeCompass"
+          -i ${{github.workspace}}
+          -i ${{github.workspace}}/build/compile_commands.json
+          -j $(nproc)
 
       - name: Parse Xerces-C Postgresql
         if: ${{ matrix.db == 'postgresql' }}
@@ -338,7 +350,7 @@ jobs:
           mkdir build_xerces-c && cd build_xerces-c
           cmake $HOME/xerces-c -DCMAKE_EXPORT_COMPILE_COMMANDS=1
           make -j $(nproc)
-          cd ${{github.workspace}}/bin
+          cd ${{github.workspace}}/install/bin
           ./CodeCompass_parser -d "pgsql:host=localhost;port=5432;user=postgres;password=postgres;database=xerces_c" -w $HOME/ws_pgsql/ -n "Xerces-C" -i $HOME/xerces-c -i $HOME/build_xerces-c/compile_commands.json -j $(nproc)
 
       # Parsing with SQLite3
@@ -350,8 +362,19 @@ jobs:
           mkdir build_tinyxml2 && cd build_tinyxml2
           cmake $HOME/tinyxml2 -DCMAKE_EXPORT_COMPILE_COMMANDS=1
           make -j $(nproc)
-          cd ${{github.workspace}}/bin
+          cd ${{github.workspace}}/install/bin
           ./CodeCompass_parser  -d "sqlite:database=$HOME/tinyxml2.sqlite" -w $HOME/ws_pgsql/ -n TinyXML2 -i $HOME/tinyxml2 -i $HOME/build_tinyxml2/compile_commands.json -j $(nproc)
+
+      - name: Parse CodeCompass SQLite3
+        if: ${{ matrix.db == 'sqlite3' }}
+        run: >
+          ${{github.workspace}}/install/bin/CodeCompass_parser
+          -d "sqlite:database=$HOME/codecompass.sqlite"
+          -w $HOME/ws_pgsql/
+          -n "CodeCompass"
+          -i ${{github.workspace}}
+          -i ${{github.workspace}}/build/compile_commands.json
+          -j $(nproc)
 
       - name: Parse Xerces-C SQLite3
         if: ${{ matrix.db == 'sqlite3' }}
@@ -361,5 +384,5 @@ jobs:
           mkdir build_xerces-c && cd build_xerces-c
           cmake $HOME/xerces-c -DCMAKE_EXPORT_COMPILE_COMMANDS=1
           make -j $(nproc)
-          cd ${{github.workspace}}/bin
+          cd ${{github.workspace}}/install/bin
           ./CodeCompass_parser -d "sqlite:database=$HOME/xerces.sqlite" -w $HOME/ws_pgsql/ -n "Xerces-C" -i $HOME/xerces-c -i $HOME/build_xerces-c/compile_commands.json -j $(nproc)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,28 +37,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Update apt-get
-        run: sudo apt-get update
+      #- name: Update apt-get
+      #  run: sudo apt-get update
 
-      - name: Install required packages Ubuntu 20
-        if: ${{ matrix.os == 'ubuntu-20.04' }}
-        run: sudo apt-get install -y git cmake make g++ libboost-all-dev llvm-10-dev clang-10 libclang-10-dev odb libodb-dev thrift-compiler libthrift-dev default-jdk libssl-dev libgraphviz-dev libmagic-dev libgit2-dev ctags libgtest-dev npm
-
+      # Ubuntu 18.04 commands
       - name: Install required packages Ubuntu 18
         if: ${{ matrix.os == 'ubuntu-18.04' }}
-        run: sudo apt-get install -y git cmake make g++ gcc-7-plugin-dev libboost-all-dev llvm-10-dev clang-10 libclang-10-dev default-jdk libssl1.0-dev libgraphviz-dev libmagic-dev libgit2-dev ctags libgtest-dev npm
-
-      - name: Install Postgresql Ubuntu 20
-        if: ${{ matrix.os == 'ubuntu-20.04' && matrix.db == 'postgresql' }}
-        run: sudo apt-get install libodb-pgsql-dev postgresql-server-dev-12
+        run: >
+          sudo apt-get install -y git cmake make g++ gcc-7-plugin-dev libboost-all-dev
+          llvm-10-dev clang-10 libclang-10-dev default-jdk libssl1.0-dev libgraphviz-dev
+          libmagic-dev libgit2-dev ctags libgtest-dev npm
 
       - name: Install Postgresql Ubuntu 18
         if: ${{ matrix.os == 'ubuntu-18.04' && matrix.db == 'postgresql' }}
         run: sudo apt-get install postgresql-server-dev-10
-
-      - name: Install SQLite3 Ubuntu 20
-        if: ${{ matrix.os == 'ubuntu-20.04' && matrix.db == 'sqlite3' }}
-        run: sudo apt-get install libodb-sqlite-dev libsqlite3-dev
 
       - name: Install SQLite3 Ubuntu 18
         if: ${{ matrix.os == 'ubuntu-18.04' && matrix.db == 'sqlite3' }}
@@ -74,12 +66,23 @@ jobs:
 
       - name: Install Thrift
         if: ${{ matrix.os == 'ubuntu-18.04' && steps.thrift-cache.outputs.cache-hit != 'true' }}
-        run: |
+        run: >
           cd $HOME
-          wget -O thrift-0.13.0.tar.gz "http://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=thrift/0.13.0/thrift-0.13.0.tar.gz"
+
+          wget -O thrift-0.13.0.tar.gz
+          "http://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=thrift/0.13.0/thrift-0.13.0.tar.gz"
+
           tar -xvf ./thrift-0.13.0.tar.gz
+
           cd thrift-0.13.0
-          ./configure --prefix=$HOME/thrift_install --without-python --enable-libtool-lock --enable-tutorial=no --enable-tests=no --with-libevent --with-zlib --without-nodejs --without-lua --without-ruby --without-csharp --without-erlang --without-perl --without-php --without-php_extension --without-dart --without-haskell --without-go --without-rs --without-haxe --without-dotnetcore --without-d --without-qt4 --without-qt5 --without-java --without-swift
+
+          ./configure --prefix=$HOME/thrift_install --without-python --enable-libtool-lock
+          --enable-tutorial=no --enable-tests=no --with-libevent --with-zlib --without-nodejs
+          --without-lua --without-ruby --without-csharp --without-erlang --without-perl
+          --without-php --without-php_extension --without-dart --without-haskell --without-go
+          --without-rs --without-haxe --without-dotnetcore --without-d --without-qt4 --without-qt5
+          --without-java --without-swift
+
           make install -j $(nproc)
 
       - name: Cache ODB Ubuntu 18
@@ -118,6 +121,23 @@ jobs:
           echo "CMAKE_PREFIX_PATH=$HOME/thrift_install:$HOME/odb_install:$CMAKE_PREFIX_PATH" >> $GITHUB_ENV
           echo "PATH=$HOME/thrift_install/bin:$HOME/odb_install/bin:$PATH" >> $GITHUB_ENV
 
+      # Ubuntu 20.04 commands
+      - name: Install required packages Ubuntu 20
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
+        run: >
+          sudo apt-get install -y git cmake make g++ libboost-all-dev llvm-10-dev clang-10
+          libclang-10-dev odb libodb-dev thrift-compiler libthrift-dev default-jdk libssl-dev
+          libgraphviz-dev libmagic-dev libgit2-dev ctags libgtest-dev npm
+
+      - name: Install Postgresql Ubuntu 20
+        if: ${{ matrix.os == 'ubuntu-20.04' && matrix.db == 'postgresql' }}
+        run: sudo apt-get install libodb-pgsql-dev postgresql-server-dev-12
+
+      - name: Install SQLite3 Ubuntu 20
+        if: ${{ matrix.os == 'ubuntu-20.04' && matrix.db == 'sqlite3' }}
+        run: sudo apt-get install libodb-sqlite-dev libsqlite3-dev
+
+      # Common commands
       - name: Install GoogleTest
         run: |
           echo $PATH
@@ -140,12 +160,25 @@ jobs:
       - name: Run CMake (Postgresql)
         if: ${{ matrix.db == 'postgresql' }}
         working-directory: ${{github.workspace}}/build
-        run: cmake .. -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/install -DDATABASE=pgsql -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DLLVM_DIR=/usr/lib/llvm-10/cmake -DClang_DIR=/usr/lib/cmake/clang-10 -DTEST_DB="pgsql:host=localhost;username=postgres;password=postgres;port=5432;database=cc_test"
+        run: >
+          cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=1
+          -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/${{ matrix.os }}/${{ matrix.db }}/install
+          -DDATABASE=pgsql
+          -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+          -DLLVM_DIR=/usr/lib/llvm-10/cmake
+          -DClang_DIR=/usr/lib/cmake/clang-10
+          -DTEST_DB="pgsql:host=localhost;username=postgres;password=postgres;port=5432;database=cc_test"
 
       - name: Run CMake (SQLite3)
         if: ${{ matrix.db == 'sqlite3' }}
         working-directory: ${{github.workspace}}/build
-        run: cmake .. -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/install -DDATABASE=sqlite -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DLLVM_DIR=/usr/lib/llvm-10/cmake -DClang_DIR=/usr/lib/cmake/clang-10 -DTEST_DB="sqlite:database=$HOME/mydatabase.sqlite"
+        run: >
+          cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=1
+          -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/${{ matrix.os }}/${{ matrix.db }}/install
+          -DDATABASE=sqlite -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+          -DLLVM_DIR=/usr/lib/llvm-10/cmake
+          -DClang_DIR=/usr/lib/cmake/clang-10
+          -DTEST_DB="sqlite:database=$HOME/mydatabase.sqlite"
 
       - name: Build
         working-directory: ${{github.workspace}}/build
@@ -158,3 +191,175 @@ jobs:
       - name: Run tests
         working-directory: ${{github.workspace}}/build
         run: make test ARGS=-V
+
+      - name: Parse CodeCompass Postgresql
+        if: ${{ matrix.db == 'postgresql' }}
+        run: >
+          mkdir $HOME/ws_pgsql
+
+          ${{github.workspace}}/${{ matrix.os }}/${{ matrix.db }}/install/bin/CodeCompass_parser
+          -d "pgsql:host=localhost;port=5432;user=postgres;password=postgres;database=codecompass"
+          -w $HOME/ws_pgsql/
+          -n "CodeCompass"
+          -i ${{github.workspace}}
+          -i ${{github.workspace}}/build/compile_commands.json
+          -j $(nproc)
+
+      - name: Parse CodeCompass SQLite3
+        if: ${{ matrix.db == 'sqlite3' }}
+        run: >
+          mkdir $HOME/ws_pgsql
+
+          ${{github.workspace}}/${{ matrix.os }}/${{ matrix.db }}/install/bin/CodeCompass_parser
+          -d "sqlite:database=$HOME/codecompass.sqlite"
+          -w $HOME/ws_pgsql/
+          -n "CodeCompass"
+          -i ${{github.workspace}}
+          -i ${{github.workspace}}/build/compile_commands.json
+          -j $(nproc)
+
+      - name: Archive CodeCompass binaries
+        uses: actions/upload-artifact@v2
+        with:
+          name: codecompass-${{ matrix.os }}-${{ matrix.db }}-bin
+          path: ${{github.workspace}}/${{ matrix.os }}/${{ matrix.db }}/install
+
+  parse:
+    needs: build
+    strategy:
+      matrix:
+        db: [ postgresql, sqlite3 ]
+        os: [ ubuntu-20.04, ubuntu-18.04 ]
+      fail-fast: false
+
+    runs-on: ${{ matrix.os }}
+
+    # Service containers to run with `runner-job`
+    services:
+      # Label used to access the service container
+      postgres:
+        # Docker Hub image
+        image: postgres
+        # Provide the password for postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
+
+    steps:
+      # Ubuntu 18.04 commands
+      - name: Install required packages Ubuntu 18
+        if: ${{ matrix.os == 'ubuntu-18.04' }}
+        run: >
+          sudo apt-get install -y git cmake make g++ gcc-7-plugin-dev libboost-all-dev
+          llvm-10-dev clang-10 libclang-10-dev default-jdk libssl1.0-dev
+          libmagic-dev libgit2-dev ctags
+
+      - name: Install Postgresql Ubuntu 18
+        if: ${{ matrix.os == 'ubuntu-18.04' && matrix.db == 'postgresql' }}
+        run: sudo apt-get install postgresql-server-dev-10
+
+      - name: Install SQLite3 Ubuntu 18
+        if: ${{ matrix.os == 'ubuntu-18.04' && matrix.db == 'sqlite3' }}
+        run: sudo apt-get install libsqlite3-dev
+
+      - name: Cache ODB Ubuntu 18
+        id: odb-cache
+        if: ${{ matrix.os == 'ubuntu-18.04' }}
+        uses: actions/cache@v2
+        with:
+          path: ~/odb_install
+          key: ${{ matrix.db }}-odb-v2
+
+      - name: Cache Thrift Ubuntu 18
+        id: thrift-cache
+        if: ${{ matrix.os == 'ubuntu-18.04' }}
+        uses: actions/cache@v2
+        with:
+          path: ~/thrift_install
+          key: ${{ matrix.db }}-thrift-v2
+
+      - name: Export environment variables Ubuntu 18
+        if: ${{ matrix.os == 'ubuntu-18.04' }}
+        run: |
+          echo "LD_LIBRARY_PATH=$HOME/thrift_install/lib:$HOME/odb_install/lib:$CMAKE_PREFIX_PATH" >> $GITHUB_ENV
+          echo "PATH=$HOME/thrift_install/bin:$HOME/odb_install/bin:$PATH" >> $GITHUB_ENV
+
+      # Ubuntu 20.04 commands
+      - name: Install required packages Ubuntu 20
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
+        run: >
+          sudo apt-get install -y git cmake make g++ libboost-all-dev llvm-10-dev
+          clang-10 libclang-10-dev odb libodb-dev libthrift-dev default-jdk
+          libssl-dev libmagic-dev libgit2-dev ctags
+
+      - name: Install Postgresql Ubuntu 20
+        if: ${{ matrix.os == 'ubuntu-20.04' && matrix.db == 'postgresql' }}
+        run: sudo apt-get install libodb-pgsql-dev postgresql-server-dev-12
+
+      - name: Install SQLite3 Ubuntu 20
+        if: ${{ matrix.os == 'ubuntu-20.04' && matrix.db == 'sqlite3' }}
+        run: sudo apt-get install libodb-sqlite-dev libsqlite3-dev
+
+      # Common commands
+      - name: Download CodeCompass binaries
+        uses: actions/download-artifact@v2
+        with:
+          name: codecompass-${{ matrix.os }}-${{ matrix.db }}-bin
+
+      - name: Add execute right to parser
+        run: chmod +x ${{github.workspace}}/bin/CodeCompass_parser
+
+      # Parsing with Postgresql
+      - name: Parse TinyXML Postgresql
+        if: ${{ matrix.db == 'postgresql' }}
+        run: |
+          cd $HOME
+          git clone https://github.com/leethomason/tinyxml2
+          mkdir build_tinyxml2 && cd build_tinyxml2
+          cmake $HOME/tinyxml2 -DCMAKE_EXPORT_COMPILE_COMMANDS=1
+          make -j $(nproc)
+          cd ${{github.workspace}}/bin
+          ./CodeCompass_parser  -d "pgsql:host=localhost;port=5432;user=postgres;password=postgres;database=tinyxml2" -w $HOME/ws_pgsql/ -n TinyXML2 -i $HOME/tinyxml2 -i $HOME/build_tinyxml2/compile_commands.json -j $(nproc)
+
+      - name: Parse Xerces-C Postgresql
+        if: ${{ matrix.db == 'postgresql' }}
+        run: |
+          cd $HOME
+          git clone https://github.com/apache/xerces-c/
+          mkdir build_xerces-c && cd build_xerces-c
+          cmake $HOME/xerces-c -DCMAKE_EXPORT_COMPILE_COMMANDS=1
+          make -j $(nproc)
+          cd ${{github.workspace}}/bin
+          ./CodeCompass_parser -d "pgsql:host=localhost;port=5432;user=postgres;password=postgres;database=xerces_c" -w $HOME/ws_pgsql/ -n "Xerces-C" -i $HOME/xerces-c -i $HOME/build_xerces-c/compile_commands.json -j $(nproc)
+
+      # Parsing with SQLite3
+      - name: Parse TinyXML Sqlite3
+        if: ${{ matrix.db == 'sqlite3' }}
+        run: |
+          cd $HOME
+          git clone https://github.com/leethomason/tinyxml2
+          mkdir build_tinyxml2 && cd build_tinyxml2
+          cmake $HOME/tinyxml2 -DCMAKE_EXPORT_COMPILE_COMMANDS=1
+          make -j $(nproc)
+          cd ${{github.workspace}}/bin
+          ./CodeCompass_parser  -d "sqlite:database=$HOME/tinyxml2.sqlite" -w $HOME/ws_pgsql/ -n TinyXML2 -i $HOME/tinyxml2 -i $HOME/build_tinyxml2/compile_commands.json -j $(nproc)
+
+      - name: Parse Xerces-C SQLite3
+        if: ${{ matrix.db == 'sqlite3' }}
+        run: |
+          cd $HOME
+          git clone https://github.com/apache/xerces-c/
+          mkdir build_xerces-c && cd build_xerces-c
+          cmake $HOME/xerces-c -DCMAKE_EXPORT_COMPILE_COMMANDS=1
+          make -j $(nproc)
+          cd ${{github.workspace}}/bin
+          ./CodeCompass_parser -d "sqlite:database=$HOME/xerces.sqlite" -w $HOME/ws_pgsql/ -n "Xerces-C" -i $HOME/xerces-c -i $HOME/build_xerces-c/compile_commands.json -j $(nproc)


### PR DESCRIPTION
I continued Github Actions CI migration with parsing Xerces-C and TinyXML on both Ubuntu 18.04 and 20.04, with Postgresql and SQLite3 as well. Also complemented building CodeCompass with caching ODB and Thrift on 18.04. I reorganized CI commands to group by OS.