### PR TITLE
Local testing containers

### DIFF
--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -1,0 +1,45 @@
+ARG UBUNTU_VERSION=20.04
+
+FROM ubuntu:${UBUNTU_VERSION}
+
+ARG UBUNTU_VERSION
+
+# tzdata package is installed implicitly in the following command. This package
+# sets timezone interactively during the installation process. This environment
+# variable prevents this interaction.
+ARG DEBIAN_FRONTEND=noninteractive
+
+
+#Setting user and group properties
+ARG CC_GID=960
+ARG CC_UID=960
+
+ENV CC_GID ${CC_GID}
+ENV CC_UID ${CC_UID}
+
+RUN groupadd --system codecompass --gid ${CC_GID} && \
+    useradd --system --no-log-init --no-create-home --uid ${CC_UID} --gid codecompass codecompass
+
+
+COPY docker/test/install_dependencies.sh /tmp/install_dependencies.sh
+RUN chmod +x /tmp/install_dependencies.sh && \
+    /tmp/install_dependencies.sh ${UBUNTU_VERSION} && \
+    rm /tmp/install_dependencies.sh
+    
+COPY docker/dev/codecompass-build.sh /usr/local/bin
+
+# Setting the environment.
+ENV DATABASE=sqlite \
+    BUILD_TYPE=Release \
+    BUILD_DIR=/CodeCompass/build \
+    LLVM_DIR=/usr/lib/llvm-10/cmake \
+    Clang_DIR=/usr/lib/cmake/clang-10 \
+    INSTALL_DIR=/CodeCompass/install \
+    SOURCE_DIR=/CodeCompass/CodeCompass \
+    TEST_WORKSPACE=/CodeCompass/test_workspace \
+    TEST_DB="sqlite:database=$TEST_WORKSPACE/cc_test.sqlite"
+    
+ENV PATH=/opt/odb/bin:/opt/thrift/bin:$INSTALL_DIR/bin:$PATH
+
+ENV GTEST_ROOT=/opt/gtest \
+    CMAKE_PREFIX_PATH=/opt/thrift:/opt/odb:$CMAKE_PREFIX_PATH \

--- a/docker/test/README.md
+++ b/docker/test/README.md
@@ -1,0 +1,29 @@
+# Test images
+
+[![Docker](../../doc/images/docker.jpg)](https://www.docker.com/)
+
+This Dockerfile and the `install_dependencies.sh` script serves the purpose of local multi-OS testing.
+## Build
+To build the testing image navigate to the root of the CodeCompass source and the command below. By default the user and group properties inside and outside the container do not match. If one would prefer them to match, for convenience reasons, they can add 
+`--build-arg CC_UID=$(id -u) --build-arg CC_GUI=$(id -g)` to the command below.
+
+```bash
+developer@computer:CodeCompass$ docker build --tag cc-test:<version> \
+--build-arg UBUNTU_VERSION=<version> --file docker/test/Dockerfile .
+```
+Version can be 18.04 or 20.04 since these are the supported Ubuntu versions. Naturally the name of the image does not matter, one can change it however they like.
+
+## How to test with the images
+These images, just like the `codecompass:dev` image, are shipped with the `codecompass-build.sh` convenience script inside.
+To test one's code it has to be mounted to the container at startup.
+```bash
+developer@computer:~$ docker run --tty --interactive --rm \
+--volume <path_to_source>:/CodeCompass/CodeCompass \
+cc-test:<version> /bin/bash
+```
+The inside the container one can build and test their source by running the following commands in order:
+```bash
+developer@container:/$ codecompass-build.sh -j $(nproc)
+developer@container:/$ codecompass-build.sh install
+developer@container:/$ codecompass-build.sh test
+```

--- a/docker/test/install_dependencies.sh
+++ b/docker/test/install_dependencies.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+#This script is intended to run inside the testing container.
+#DO NOT use it on it's own.
+
+set -euxo pipefail
+
+function install_fossa {
+apt-get update 
+apt-get --yes install --no-install-recommends \
+    cmake make \
+    default-jdk \
+    ctags \
+    gcc-9 gcc-9-plugin-dev g++-9 \
+    libboost-filesystem-dev \
+    libboost-log-dev \
+    libboost-program-options-dev \
+    libboost-regex-dev \
+    libgit2-dev \
+    libgraphviz-dev \
+    libgtest-dev \
+    libmagic-dev \
+    libsqlite3-dev \
+    libssl-dev \
+    llvm-10 clang-10 llvm-10-dev libclang-10-dev \
+    npm \
+    thrift-compiler libthrift-dev \
+    odb libodb-sqlite-dev libodb-pgsql-dev && \
+    ln -s /usr/bin/gcc-9 /usr/bin/gcc && \
+    ln -s /usr/bin/g++-9 /usr/bin/g++
+
+# Build GTest.
+cd /usr/src/googletest && \
+mkdir build && \
+cd build && \
+cmake .. && \
+make install && \
+cd / && \
+rm -rf /usr/src/googletest/build
+
+}
+
+function install_beaver {
+apt-get update 
+apt-get --yes install --no-install-recommends \
+  git cmake make g++ gcc-7-plugin-dev libboost-all-dev \
+  llvm-10-dev clang-10 libclang-10-dev \
+  default-jdk libssl1.0-dev libgraphviz-dev libmagic-dev libgit2-dev ctags \
+  libgtest-dev npm libsqlite3-dev wget curl
+
+#Install odb
+wget https://download.build2.org/0.13.0/build2-install-0.13.0.sh
+sh build2-install-0.13.0.sh --yes --trust yes "/opt/build2"
+export PATH="/opt/build2/bin:$PATH" 
+mkdir /tmp/odb_build
+cd /tmp/odb_build
+bpkg create --quiet --jobs $(nproc) cc \
+  config.cxx=g++ \
+  config.cc.coptions=-O3 \
+  config.bin.rpath=/opt/odb/lib \
+  config.install.root=/opt/odb
+
+bpkg add https://pkg.cppget.org/1/beta --trust-yes
+bpkg fetch --trust-yes
+
+# Building odb
+bpkg build odb --yes
+bpkg build libodb --yes
+bpkg build libodb-sqlite --yes
+#bpkg build libodb-pgsql --yes
+bpkg install --all --recursive
+
+#Build thrift
+wget "http://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=thrift/0.13.0/thrift-0.13.0.tar.gz" \
+  -O thrift-0.13.0.tar.gz
+tar -xvf ./thrift-0.13.0.tar.gz
+cd thrift-0.13.0
+
+./configure --prefix=/opt/thrift --silent --without-python          \
+  --enable-libtool-lock --enable-tutorial=no --enable-tests=no      \
+  --with-libevent --with-zlib --without-nodejs --without-lua        \
+  --without-ruby --without-csharp --without-erlang --without-perl   \
+  --without-php --without-php_extension --without-dart              \
+  --without-haskell --without-go --without-rs --without-haxe        \
+  --without-dotnetcore --without-d --without-qt4 --without-qt5      \
+  --without-java
+
+make install -j $(nproc)
+
+
+#build gtest
+mkdir /tmp/gtest -p
+cp -R /usr/src/googletest/* /tmp/gtest
+
+cd /tmp/gtest
+mkdir build
+cd build
+
+cmake .. -DCMAKE_INSTALL_PREFIX=/opt/gtest
+make install -j $(nproc)
+
+rm -rf build
+}
+
+if [[ $1 == *"20.04"* ]]; then
+    install_fossa    
+elif [[ $1 == *"18.04"* ]]; then
+    install_beaver
+else
+    exit
+fi


### PR DESCRIPTION
I made this, because I felt like we lack the ability to test locally properly, since every build has to be tested for multiple Ubuntu versions and our current `codecompass:dev` container only work for 20.04. This image can be built with multiple Ubuntu  versions, allowing us to test our build in both environments locally. Also it opens up the possibility to develop CodeCompass to any linux operating system later.