### PR TITLE
Displaying build log messages when clicking on the parse status label.

### DIFF
--- a/webgui/scripts/codecompass/view/component/Text.js
+++ b/webgui/scripts/codecompass/view/component/Text.js
@@ -22,6 +22,7 @@ function (declare, domClass, dom, style, query, topic, ContentPane, Dialog,
     postCreate : function () {
       this.inherited(arguments);
 
+      this.set('title', 'Build logs');
       this._table = dom.create('table', { class : 'buildlogtable' });
 
       this._addHeader();
@@ -228,7 +229,26 @@ function (declare, domClass, dom, style, query, topic, ContentPane, Dialog,
 
       this._header = {
         header      : dom.create('div',  { class : 'header'      }),
-        parsestatus : dom.create('span', { class : 'parsestatus' }),
+        parsestatus : dom.create('span', {
+          class     : 'parsestatus',
+          onclick   : function () {
+            var dialog = new BuildDialog();
+            var file = urlHandler.getFileInfo();
+            var buildLogs = model.project.getBuildLog(file.id);
+
+            if (buildLogs.length === 0)
+            {
+              new Dialog({
+                title   : 'Build logs',
+                content : '<b>No build logs for this file.</b>'
+              }).show();
+              return;
+            }
+
+            dialog.addBuildLogs(buildLogs);
+            dialog.show();
+          }
+        }),
         filename    : dom.create('span', { class : 'filename'    }),
         path        : dom.create('span', { class : 'path'        }),
         colons      : dom.toDom('<span class="colons">::</span>')

--- a/webgui/scripts/codecompass/view/component/Text.js
+++ b/webgui/scripts/codecompass/view/component/Text.js
@@ -43,10 +43,12 @@ function (declare, domClass, dom, style, query, topic, ContentPane, Dialog,
           if (!that.textmodule)
             console.error("Editor object must be given in constructor");
 
-          that.textmodule.set('selection', {
-            from : buildLog.range.startpos,
-            to   : buildLog.range.endpos
-          });
+          that.textmodule.set('selection', [
+            buildLog.range.startpos.line,
+            buildLog.range.startpos.column,
+            buildLog.range.endpos.line,
+            buildLog.range.endpos.column
+          ]);
 
           that.textmodule.jumpToPos(
             buildLog.range.startpos.line,
@@ -108,7 +110,7 @@ function (declare, domClass, dom, style, query, topic, ContentPane, Dialog,
      */
     clearBuildLogs : function () {
       dom.empty(this._table);
-      _addHeader();
+      this._addHeader();
     },
 
     /**
@@ -232,7 +234,9 @@ function (declare, domClass, dom, style, query, topic, ContentPane, Dialog,
         parsestatus : dom.create('span', {
           class     : 'parsestatus',
           onclick   : function () {
-            var dialog = new BuildDialog();
+            var dialog = that._buildDialog;
+            dialog.clearBuildLogs();
+
             var file = urlHandler.getFileInfo();
             var buildLogs = model.project.getBuildLog(file.id);
 


### PR DESCRIPTION
We talked some time ago about not being able to see build logs from the webservice. In this PR, I connected the endpoint that queries build logs of a file with the onclick event of the parse status label in the header of an open file.