### PR TITLE
Trigger GitLab CI automatically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      
+
       - name: Update apt-get
         run: sudo apt-get update
 
@@ -389,3 +389,18 @@ jobs:
           make -j $(nproc)
           cd ${{github.workspace}}/install/bin
           ./CodeCompass_parser -d "sqlite:database=$HOME/xerces.sqlite" -w $HOME/ws_pgsql/ -n "Xerces-C" -i $HOME/xerces-c -i $HOME/build_xerces-c/compile_commands.json -j $(nproc)
+
+  tarball:
+    needs: parse
+    if: ${{ github.repository == 'Ericsson/CodeCompass' && github.ref == 'refs/heads/master' }}
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Update apt-get
+        run: sudo apt-get update
+
+      - name: Install curl
+        run: sudo apt-get install curl
+
+      - name: Trigget GitLab CI
+        run: curl -X POST -F token=${{ secrets.GITLAB_TRIGGER_TOKEN }} -F ref=master https://gitlab.inf.elte.hu/api/v4/projects/85/trigger/pipeline

--- a/.gitlab/ci.yml
+++ b/.gitlab/ci.yml
@@ -1,3 +1,11 @@
+workflow:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "trigger"'
+      when: always
+    - if: '$CI_PIPELINE_SOURCE == "web"'
+      when: always
+    - when: never
+
 stages:
     - prepare
     - package
@@ -14,7 +22,6 @@ variables:
 
 .tarball:
     stage: package
-    when: manual
     allow_failure: false
     timeout: 12h
     tags: ["long-running"]
@@ -117,7 +124,6 @@ tarball ubuntu-16.04:
 .upload:
     stage: deploy
     image: ubuntu:20.04
-    when: manual
     allow_failure: false
     variables:
         FILENAME: codecompass-$CI_COMMIT_BRANCH.tar.gz


### PR DESCRIPTION
Currently the tarball building and publishing pipeline must be manually triggered in GitLab CI.
With this PR the pipeline is automatically triggered for the *master* branch if the tests in GitHub Action succeeded.

Manual triggering remains still possible.