### PR TITLE
Skip circular symlinks

### DIFF
--- a/util/src/parserutil.cpp
+++ b/util/src/parserutil.cpp
@@ -50,17 +50,17 @@ bool iterateDirectoryRecursive(
 
   fs::path p(path_);
 
-  try
+  boost::system::error_code ec;
+  auto target = fs::canonical(p, ec);
+  if (ec)
   {
-    if (!fs::exists(p))
-    {
-      LOG(warning) << "Not found: " << p;
-      return true;
-    }
+    LOG(warning) << p << ": " << ec.message();
+    return true;
   }
-  catch (const std::exception& ex_)
+
+  if (!fs::exists(p))
   {
-    LOG(warning) << "Parser threw an exception: " << ex_.what();
+    LOG(warning) << "Not found: " << p;
     return true;
   }
 

--- a/util/src/parserutil.cpp
+++ b/util/src/parserutil.cpp
@@ -50,9 +50,17 @@ bool iterateDirectoryRecursive(
 
   fs::path p(path_);
 
-  if (!fs::exists(p))
+  try
   {
-    LOG(warning) << "Not found: " << p;
+    if (!fs::exists(p))
+    {
+      LOG(warning) << "Not found: " << p;
+      return true;
+    }
+  }
+  catch (const std::exception& ex_)
+  {
+    LOG(warning) << "Parser threw an exception: " << ex_.what();
     return true;
   }
 


### PR DESCRIPTION
Circular symlinks cause every parser to throw an exception and fail. I complemented `parserutil.cpp` with local exception handling to skip the problematic file and avoid failure of the entire parser.