### PR TITLE
Track file browsing with Google Analytics

### DIFF
--- a/webgui/scripts/codecompass/view/component/Text.js
+++ b/webgui/scripts/codecompass/view/component/Text.js
@@ -342,6 +342,14 @@ function (declare, domClass, dom, style, query, topic, ContentPane, Dialog,
       this.set('header', this._fileInfo);
 
       this._getSyntaxHighlight(this._fileInfo);
+
+      if (gtag) {
+        gtag('event', 'page_view', {
+          page_location: window.location.href,
+          page_path: window.location.pathname + window.location.hash,
+          page_title: urlFileInfo.path
+        });
+      }
     },
 
     /**

--- a/webgui/scripts/ga.js
+++ b/webgui/scripts/ga.js
@@ -1,3 +1,4 @@
+var gtag = null;
 $(document).ready(function() {
     $.ajax({
         url: 'ga.txt',
@@ -8,7 +9,7 @@ $(document).ready(function() {
 
             window.dataLayer = window.dataLayer || [];
 
-            function gtag() {
+            gtag = function() {
                 dataLayer.push(arguments);
             }
 


### PR DESCRIPTION
Currently only a single page view event is sent to *Google Analytics* (**if enabled**) when opening a new project in the web browser. Since browsing in the File Manager and opening files are done asynchronously in the background, they do not trigger a page reload. Only selecting a new project in the web browser triggers a page reload.

The aim of this PR is to send a `page_view` event to Google Analytics when the content of a new file is loaded.
That way we could get much more precise diagnostic about which project and files are visited most on a CodeCompass instance (e.g. http://codecompass.net/demo/)