### PR TITLE
Fix server-side syntax highlighting

### DIFF
--- a/plugins/cpp/service/src/cppservice.cpp
+++ b/plugins/cpp/service/src/cppservice.cpp
@@ -1226,7 +1226,9 @@ void CppServiceHandler::getSyntaxHighlight(
         continue;
 
       // Regular expression to find element position
-      std::string reg = "\\b" + node.astValue + "\\b";
+      const std::regex specialChars { R"([-[\]{}()*+?.,\^$|#\s])" };
+      std::string sanitizedAstValue = std::regex_replace(node.astValue, specialChars, R"(\$&)");
+      std::string reg = "\\b" + sanitizedAstValue + "\\b";
 
       for (std::size_t i = node.location.range.start.line - 1;
            i < node.location.range.end.line && i < content.size();


### PR DESCRIPTION
Closes #500.

`AstValue` can contain special characters, especially since #425 they can contain curly braces sometimes.
The `AstValue` is used in regular expressions during server-side syntax highlighting, however these special characters were not escaped (until now). This resulted in invalid regular match expressions and the `getSyntaxHighlight` Thrift call ultimately failed.