### PR TITLE
Fixes for CppParserTest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Build project
 on: [push, pull_request, workflow_dispatch]
 
 env:
-  BUILD_TYPE: Release
+  BUILD_TYPE: Debug
 
 jobs:
   build:

--- a/plugins/cpp/test/src/cppparsertest.cpp
+++ b/plugins/cpp/test/src/cppparsertest.cpp
@@ -142,7 +142,7 @@ TEST_F(CppParserTest, FunctionWithMultipleDeclarations)
   _transaction([&, this]() {
     RCppFunction callees = _db->query<model::CppFunction>(
       QCppFunction::name == "multiFunction");
-    EXPECT_GT(callees.size(), 0);
+    EXPECT_FALSE(callees.empty());
 
     RCppAstNode multiFuncAstNode = _db->query<model::CppAstNode>(
       QCppAstNode::entityHash == callees.begin()->entityHash);
@@ -307,7 +307,7 @@ TEST_F(CppParserTest, Typedef)
       QCppTypedef::name == "Integer");
     RCppAstNode astNodes = _db->query<model::CppAstNode>(
       QCppAstNode::entityHash == integer.entityHash);
-    EXPECT_GT(astNodes.size(), 0);
+    EXPECT_FALSE(astNodes.empty());
 
     for (const model::CppAstNode& n : astNodes)
     {
@@ -461,11 +461,11 @@ TEST_F(CppParserTest, Enum)
   {
     RCppEnum enumerations = _db->query<model::CppEnum>(
       QCppEnum::name == "Enumeration");
-    EXPECT_GT(enumerations.size(), 0);
+    EXPECT_FALSE(enumerations.empty());
 
     RCppAstNode astNodes = _db->query<model::CppAstNode>(
       QCppAstNode::entityHash == enumerations.begin()->entityHash);
-    EXPECT_GT(astNodes.size(), 0);
+    EXPECT_FALSE(astNodes.empty());
 
     for (const model::CppAstNode& n : astNodes)
     {


### PR DESCRIPTION
Closes #439.

This PR fixes the strange issue that the unit tests failed when CodeCompass was compiled in *Debug* mode.
It turned out that these tests were really failing (for a long time actually), but when compiled *Release* mode, some ODB functions just fail silently and assertions are only done in *Debug* mode.

In most cases, the root of these issues was the `query_value()` function, which returns the selected record from the database *as a value*. The number of resulted records *must be precisely one*, otherwise assertion failure is done in debug mode. In release mode no error is raised at all: when multiple results are available, the first one is returned and in case of zero results, a default constructed object is returned (or even memory garbage, I haven't checked it).

As the [ODB Manual](https://www.codesynthesis.com/products/odb/doc/manual.xhtml#4.3) states:
> If the query executed using `query_one()` or `query_value()` returns more than one element, then these functions fail with an assertion. Additionally, `query_value()` also fails with an assertion if the query returned no elements.

These misbehaviours went unnoticed in release mode, because when multiple results were available, simply the first was returned; and when no results were available, all `EQ_*` assertions were inside a loop, which was executed 0 times.

In this PR I have addressed these issues and fixed them. In all cases I am confident that the unit tests were incorrect and CodeCompass worked correctly. There is only a single case where I am uncertain (related to function pointers), but I will mark that case for discussion explicitly soon.

I have also modified that the CI shall build CodeCompass in *Debug* mode for testing in the future, to avoid any such issue like this in the future. (Docker images and tarballs are still built in *Release* mode of course.)