### PR TITLE
Google Analytics event tracking

### DIFF
--- a/plugins/cpp/webgui/js/cppMenu.js
+++ b/plugins/cpp/webgui/js/cppMenu.js
@@ -5,8 +5,9 @@ require([
   'dijit/PopupMenuItem',
   'codecompass/astHelper',
   'codecompass/model',
+  'codecompass/urlHandler',
   'codecompass/viewHandler'],
-function (topic, Menu, MenuItem, PopupMenuItem, astHelper, model, viewHandler) {
+function (topic, Menu, MenuItem, PopupMenuItem, astHelper, model, urlHandler, viewHandler) {
 
   model.addService('cppservice', 'CppService', LanguageServiceClient);
 
@@ -65,6 +66,15 @@ function (topic, Menu, MenuItem, PopupMenuItem, astHelper, model, viewHandler) {
             fileType    : fileInfo.type,
             elementInfo : nodeInfo
           });
+
+          if (gtag) {
+            gtag ('event', 'documentation', {
+              'event_category' : urlHandler.getState('wsid'),
+              'event_label' : urlHandler.getFileInfo().name
+                            + ': '
+                            + nodeInfo.astNodeValue
+            });
+          }
         }
       });
     }

--- a/plugins/cpp_reparse/webgui/js/cppReparseFileAST.js
+++ b/plugins/cpp_reparse/webgui/js/cppReparseFileAST.js
@@ -60,6 +60,13 @@ function (on, topic, declare, Color, Deferred, dom, ContentPane, Tooltip,
           that.set('content', astHtml);
         }
       );
+
+      if (gtag) {
+        gtag ('event', 'cpp_reparse_file', {
+          'event_category' : urlHandler.getState('wsid'),
+          'event_label' : urlHandler.getFileInfo().name
+        });
+      }
     },
 
     loadASTForNode : function (nodeInfo) {
@@ -72,6 +79,15 @@ function (on, topic, declare, Color, Deferred, dom, ContentPane, Tooltip,
           that.set('content', astHtml);
         }
       );
+
+      if (gtag) {
+        gtag ('event', 'cpp_reparse_node', {
+          'event_category' : urlHandler.getState('wsid'),
+          'event_label' : urlHandler.getFileInfo().name
+              + ': '
+              + nodeInfo.astNodeValue
+        });
+      }
     },
 
     _subscribeTopics : function () {

--- a/plugins/git/webgui/js/gitBlame.js
+++ b/plugins/git/webgui/js/gitBlame.js
@@ -101,7 +101,7 @@ function (on, topic, declare, Color, dom, Tooltip, Text, model, viewHandler,
    * @return The function returns an array of objects which have the following
    * properties: text, commitId, color.
    */
-  function caclulateAnnotations(repoId, commitId, path, maybeModifiedFileId) {
+  function calculateAnnotations(repoId, commitId, path, maybeModifiedFileId) {
 
     var blameInfo = model.gitservice.getBlameInfo(
       repoId, commitId, path, maybeModifiedFileId);
@@ -136,6 +136,13 @@ function (on, topic, declare, Color, dom, Tooltip, Text, model, viewHandler,
       for (var i = 0; i < blame.linesInHunk; ++i)
         blameForLines.push(blameForLine);
     });
+
+    if (gtag) {
+      gtag ('event', 'git_blame', {
+        'event_category' : urlHandler.getState('wsid'),
+        'event_label' : urlHandler.getFileInfo().name
+      });
+    }
 
     return blameForLines;
   }
@@ -203,7 +210,7 @@ function (on, topic, declare, Color, dom, Tooltip, Text, model, viewHandler,
       if (!res.isInRepository)
         return;
 
-      var annotations = caclulateAnnotations(
+      var annotations = calculateAnnotations(
         res.repoId, res.commitId, res.repoPath, fileId);
 
       for (var i = 0; i < this._codeMirror.lineCount(); ++i) {

--- a/plugins/metrics/webgui/js/metrics.js
+++ b/plugins/metrics/webgui/js/metrics.js
@@ -535,6 +535,13 @@ function (declare, dom, topic, style, MenuItem, Button, CheckBox, Select,
         }
       });
       });
+
+      if (gtag) {
+        gtag ('event', 'metrics', {
+          'event_category' : urlHandler.getState('wsid'),
+          'event_label' : urlHandler.getFileInfo().name
+        });
+      }
     }
   });
 

--- a/plugins/search/webgui/js/searchResult.js
+++ b/plugins/search/webgui/js/searchResult.js
@@ -71,8 +71,8 @@ function (ObjectStoreModel, BorderContainer, declare, Memory, Observable, topic,
           if (that._currentQueryData) {
             that._pagerChanged = true;
             topic.publish(
-                'codecompass/search',
-                that._currentQueryData);
+              'codecompass/search',
+              that._currentQueryData);
           }
         }
       });
@@ -128,14 +128,14 @@ function (ObjectStoreModel, BorderContainer, declare, Memory, Observable, topic,
             that._store.remove(item.id);
 
             that._moreMap[item.parent].splice(0, moreSize).forEach(
-                function (lineMatch) {
-                  that._store.add({
-                    name: lineMatch.text,
-                    parent: item.parent,
-                    fileRange: lineMatch.range,
-                    fileName: item.fileName
-                  });
+              function (lineMatch) {
+                that._store.add({
+                  name: lineMatch.text,
+                  parent: item.parent,
+                  fileRange: lineMatch.range,
+                  fileName: item.fileName
                 });
+              });
 
             if (that._moreMap[item.parent].length !== 0)
               that._store.add(item);
@@ -272,15 +272,15 @@ function (ObjectStoreModel, BorderContainer, declare, Memory, Observable, topic,
 
       try {
         var searchResult
-            = data.searchType === SearchOptions.SearchForFileName
-            ? model.searchservice.searchFile(params)
-            : model.searchservice.search(params);
+          = data.searchType === SearchOptions.SearchForFileName
+          ? model.searchservice.searchFile(params)
+          : model.searchservice.search(params);
       } catch (ex) {
         topic.publish('codecompass/searchError', {exception: ex});
       }
 
       this._pager.set(
-          'total', searchResult ? searchResult.totalFiles : 0);
+        'total', searchResult ? searchResult.totalFiles : 0);
 
       if (!searchResult || searchResult.totalFiles === 0) {
         this._store.add({
@@ -299,14 +299,14 @@ function (ObjectStoreModel, BorderContainer, declare, Memory, Observable, topic,
           var fileNode = that._createDirsByFInfo(searchResultEntry.finfo);
 
           searchResultEntry.matchingLines.splice(0, moreSize).forEach(
-              function (lineMatch) {
-                that._store.add({
-                  name: util.escapeTags(lineMatch.text),
-                  parent: searchResultEntry.finfo.path,
-                  fileRange: lineMatch.range,
-                  fileName: searchResultEntry.finfo.name
-                });
+            function (lineMatch) {
+              that._store.add({
+                name: util.escapeTags(lineMatch.text),
+                parent: searchResultEntry.finfo.path,
+                fileRange: lineMatch.range,
+                fileName: searchResultEntry.finfo.name
               });
+            });
 
           if (searchResultEntry.matchingLines.length !== 0)
             that._store.add({

--- a/plugins/search/webgui/js/searchResult.js
+++ b/plugins/search/webgui/js/searchResult.js
@@ -34,7 +34,6 @@ function (ObjectStoreModel, BorderContainer, declare, Memory, Observable, topic,
   });
 
   var SearchResult = declare(BorderContainer, {
-    searchTypes : model.searchservice.getSearchTypes(),
     constructor: function () {
       var that = this;
 
@@ -52,6 +51,8 @@ function (ObjectStoreModel, BorderContainer, declare, Memory, Observable, topic,
           dirFilter: message.dirFilter,
           searchType: message.searchType
         };
+
+        that._searchTypes = model.searchservice.getSearchTypes();
 
         that._loadResults();
 
@@ -259,7 +260,7 @@ function (ObjectStoreModel, BorderContainer, declare, Memory, Observable, topic,
       params.filter = filter;
 
       if (gtag) {
-        var type = this.searchTypes.find(t => t.id === data.searchType);
+        var type = this._searchTypes.find(t => t.id === data.searchType);
         gtag('event', 'search: ' + type.name, {
           'event_category': urlHandler.getState('wsid'),
           'event_label': params.query

--- a/plugins/search/webgui/js/searchResult.js
+++ b/plugins/search/webgui/js/searchResult.js
@@ -7,13 +7,14 @@ require([
   'dojo/topic',
   'dojo/mouse',
   'codecompass/model',
+  'codecompass/urlHandler',
   'codecompass/util',
   'codecompass/view/component/HtmlTree',
   'codecompass/view/component/Pager',
   'codecompass/view/component/TooltipTreeMixin',
   'codecompass/viewHandler'],
 function (ObjectStoreModel, BorderContainer, declare, Memory, Observable, topic,
-  mouse, model, util, HtmlTree, Pager, TooltipTreeMixin, viewHandler) {
+  mouse, model, urlHandler, util, HtmlTree, Pager, TooltipTreeMixin, viewHandler) {
 
   var moreSize = 5;
   var moreText = 'More ...';
@@ -251,11 +252,18 @@ function (ObjectStoreModel, BorderContainer, declare, Memory, Observable, topic,
       params.query   = data.text;
       params.range   = range;
       params.filter  = filter;
+
+      if (gtag) {
+        gtag ('event', 'search: ' + data.searchType.toString(), {
+          'event_category' : urlHandler.getState('wsid'),
+          'event_label' : params.query
+        });
+      }
   
       //--- Build new tree ---//
   
       this._moreMap = {};
-  
+
       try {
         var searchResult
           = data.searchType === SearchOptions.SearchForFileName

--- a/webgui/scripts/codecompass/view/codeBites.js
+++ b/webgui/scripts/codecompass/view/codeBites.js
@@ -129,7 +129,16 @@ function (declare, array, dom, style, topic, on, ContentPane, ResizeHandle,
           cssClass : 'cb-label cb-label-' + colorIdx
         }]]
       });
-    
+
+    if (gtag) {
+      gtag ('event', 'code_bites', {
+        'event_category' : urlHandler.getState('wsid'),
+        'event_label' : urlHandler.getFileInfo().name
+                      + ': '
+                      + astNodeInfo.astNodeValue.toString()
+      });
+    }
+
     return newElement;
   }
 

--- a/webgui/scripts/codecompass/view/component/Text.js
+++ b/webgui/scripts/codecompass/view/component/Text.js
@@ -468,6 +468,15 @@ function (declare, domClass, dom, style, query, topic, ContentPane, Dialog,
         var service = model.getLanguageService(this._fileInfo.type);
         astHelper.jumpToDef(astNodeInfo.id, service);
       }
+
+      if (gtag) {
+        gtag('event', 'click_on_word', {
+          'event_category' : urlHandler.getState('wsid'),
+          'event_label' : urlHandler.getFileInfo().name
+                        + ': '
+                        + this._getWordAt(pos).string
+        });
+      }
     },
 
     /**

--- a/webgui/scripts/codecompass/view/diagram.js
+++ b/webgui/scripts/codecompass/view/diagram.js
@@ -71,6 +71,13 @@ function (declare, attr, dom, query, topic, BorderContainer, ContentPane,
       this._handlerId = handlerId;
       this._diagramType = diagramType;
 
+      if (gtag) {
+        gtag ('event', 'load_diagram: ' + diagramType.toString(), {
+          'event_category' : urlHandler.getState('wsid'),
+          'event_label' : urlHandler.getFileInfo().name
+        });
+      }
+
       try {
         this._diagCont.set('content', dom.create('span', {
           class : 'diagram-loading'


### PR DESCRIPTION
I added a couple more event trackers to collect data about the main functionalities and send them to Google Analytics, if it is enabled. The following requests are recorded:

- diagrams
- showing AST
- documentation
- git blame
- clicking on node
- type and query of search
- code bites

The type of request, the name of the project, file and/or node are recorded by the event trackers.