### PR TITLE
Disable git blame menu when blame is not available.

### DIFF
--- a/plugins/git/service/git.thrift
+++ b/plugins/git/service/git.thrift
@@ -209,5 +209,11 @@ service GitService
     1:string repoId_,
     2:string hexOid_,
     3:string path_,
-    4:string localModificationsFileId_)
+    4:string localModificationsFileId_),
+
+   /**
+   * Check whether there is at least one repository
+   * in the workspace directory.
+   */
+    bool isEnabled()
 }

--- a/plugins/git/service/git.thrift
+++ b/plugins/git/service/git.thrift
@@ -215,5 +215,5 @@ service GitService
    * Check whether there is at least one repository
    * in the workspace directory.
    */
-    bool isEnabled()
+    bool isRepositoryAvailable()
 }

--- a/plugins/git/service/include/service/gitservice.h
+++ b/plugins/git/service/include/service/gitservice.h
@@ -116,6 +116,8 @@ public:
     const GitDiffOptions& options_,
     const bool isCompact_ = false) override;
 
+  virtual bool isEnabled() override;
+
 private:
   /**
    * Returns the absolute path of the repository identified by repository id.

--- a/plugins/git/service/include/service/gitservice.h
+++ b/plugins/git/service/include/service/gitservice.h
@@ -116,7 +116,7 @@ public:
     const GitDiffOptions& options_,
     const bool isCompact_ = false) override;
 
-  virtual bool isEnabled() override;
+  virtual bool isRepositoryAvailable() override;
 
 private:
   /**

--- a/plugins/git/service/src/gitservice.cpp
+++ b/plugins/git/service/src/gitservice.cpp
@@ -132,6 +132,13 @@ std::string GitServiceHandler::getRepoPath(const std::string& repoId_) const
   return *_datadir + "/version/" + repoId_;
 }
 
+bool GitServiceHandler::isEnabled()
+{
+  namespace fs = ::boost::filesystem;
+  return fs::exists(*_datadir + "/version") ||
+    fs::is_empty(*_datadir + "/version");
+}
+
 void GitServiceHandler::getRepositoryList(std::vector<GitRepository>& return_)
 {
   namespace fs = ::boost::filesystem;

--- a/plugins/git/service/src/gitservice.cpp
+++ b/plugins/git/service/src/gitservice.cpp
@@ -135,8 +135,8 @@ std::string GitServiceHandler::getRepoPath(const std::string& repoId_) const
 bool GitServiceHandler::isRepositoryAvailable()
 {
   namespace fs = ::boost::filesystem;
-  return fs::exists(*_datadir + "/version") ||
-    fs::is_empty(*_datadir + "/version");
+  return fs::exists(*_datadir + "/version") &&
+    !fs::is_empty(*_datadir + "/version");
 }
 
 void GitServiceHandler::getRepositoryList(std::vector<GitRepository>& return_)

--- a/plugins/git/service/src/gitservice.cpp
+++ b/plugins/git/service/src/gitservice.cpp
@@ -132,7 +132,7 @@ std::string GitServiceHandler::getRepoPath(const std::string& repoId_) const
   return *_datadir + "/version/" + repoId_;
 }
 
-bool GitServiceHandler::isEnabled()
+bool GitServiceHandler::isRepositoryAvailable()
 {
   namespace fs = ::boost::filesystem;
   return fs::exists(*_datadir + "/version") ||

--- a/plugins/git/webgui/js/gitMenu.js
+++ b/plugins/git/webgui/js/gitMenu.js
@@ -9,9 +9,16 @@ function (topic, Menu, MenuItem, PopupMenuItem, model, viewHandler) {
 
   model.addService('gitservice', 'GitService', GitServiceClient);
 
+  if (!model.gitservice.isEnabled())
+    return;
+
   var nodeMenu = {
     id : 'git-text-team-node',
     render : function (nodeInfo, fileInfo) {
+      var res = model.gitservice.getRepositoryByProjectPath(fileInfo.path);
+      if (!res.isInRepository)
+        return;
+
       var submenu = new Menu();
 
       submenu.addChild(new MenuItem({
@@ -40,6 +47,10 @@ function (topic, Menu, MenuItem, PopupMenuItem, model, viewHandler) {
     id : 'git-text-team-file',
     render : function (fileInfo) {
       if (fileInfo.type === "Dir")
+        return;
+
+      var res = model.gitservice.getRepositoryByProjectPath(fileInfo.path);
+      if (!res.isInRepository)
         return;
 
       var submenu = new Menu();

--- a/plugins/git/webgui/js/gitMenu.js
+++ b/plugins/git/webgui/js/gitMenu.js
@@ -9,7 +9,7 @@ function (topic, Menu, MenuItem, PopupMenuItem, model, viewHandler) {
 
   model.addService('gitservice', 'GitService', GitServiceClient);
 
-  if (!model.gitservice.isEnabled())
+  if (!model.gitservice.isRepositoryAvailable())
     return;
 
   var nodeMenu = {


### PR DESCRIPTION
Git blame menu (Team --> Blame) does not appear in the right-click menu on clicking a node or a file if:
- There are no repositories available in the workspace directory.
- The file in question is unversioned.
Closes #232.