### PR TITLE
Fixing tarball creation to contain LDAP authentication

### DIFF
--- a/.gitlab/build-codecompass.sh
+++ b/.gitlab/build-codecompass.sh
@@ -21,14 +21,16 @@ export CPLUS_INCLUDE_PATH=$DEPS_INSTALL_BUILD_DIR/gtest-install/include\
 :$DEPS_INSTALL_RUNTIME_DIR/libmagic-install/include\
 :$DEPS_INSTALL_RUNTIME_DIR/graphviz-install/include\
 :$DEPS_INSTALL_RUNTIME_DIR/boost-install/include\
-:$DEPS_INSTALL_RUNTIME_DIR/openssl-install/include
+:$DEPS_INSTALL_RUNTIME_DIR/openssl-install/include\
+:$DEPS_INSTALL_RUNTIME_DIR/openldap-install/include
 
 export C_INCLUDE_PATH=$DEPS_INSTALL_BUILD_DIR/gtest-install/include\
 :$DEPS_INSTALL_RUNTIME_DIR/libgit2-install/include\
 :$DEPS_INSTALL_RUNTIME_DIR/libmagic-install/include\
 :$DEPS_INSTALL_RUNTIME_DIR/graphviz-install/include\
 :$DEPS_INSTALL_RUNTIME_DIR/boost-install/include\
-:$DEPS_INSTALL_RUNTIME_DIR/openssl-install/include
+:$DEPS_INSTALL_RUNTIME_DIR/openssl-install/include\
+:$DEPS_INSTALL_RUNTIME_DIR/openldap-install/include
 
 export LIBRARY_PATH=$DEPS_INSTALL_RUNTIME_DIR/graphviz-install/lib\
 :$DEPS_INSTALL_RUNTIME_DIR/libmagic-install/lib\
@@ -47,7 +49,8 @@ export CMAKE_PREFIX_PATH=$DEPS_INSTALL_RUNTIME_DIR/libgit2-install\
 :$DEPS_INSTALL_RUNTIME_DIR/odb-install\
 :$DEPS_INSTALL_RUNTIME_DIR/thrift-install\
 :$DEPS_INSTALL_RUNTIME_DIR/boost-install\
-:$DEPS_INSTALL_RUNTIME_DIR/llvm-install
+:$DEPS_INSTALL_RUNTIME_DIR/llvm-install\
+:$DEPS_INSTALL_RUNTIME_DIR/openldap-install
 
 export GTEST_ROOT=$DEPS_INSTALL_BUILD_DIR/gtest-install
 
@@ -61,5 +64,6 @@ cmake $CC_SRC_DIR \
   -DDATABASE=pgsql \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DLLVM_DIR=$DEPS_INSTALL_RUNTIME_DIR/llvm/lib/cmake/llvm/ \
-  -DClang_DIR=$DEPS_INSTALL_RUNTIME_DIR/llvm/lib/cmake/clang/
+  -DClang_DIR=$DEPS_INSTALL_RUNTIME_DIR/llvm/lib/cmake/clang \
+  -DWITH_AUTH="plain;ldap"
 make install --quiet --jobs $(nproc)

--- a/.gitlab/build-codecompass.sh
+++ b/.gitlab/build-codecompass.sh
@@ -63,7 +63,7 @@ cmake $CC_SRC_DIR \
   -DCMAKE_INSTALL_PREFIX=$CC_INSTALL_DIR \
   -DDATABASE=pgsql \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DWITH_AUTH="plain;ldap" \
   -DLLVM_DIR=$DEPS_INSTALL_RUNTIME_DIR/llvm/lib/cmake/llvm/ \
-  -DClang_DIR=$DEPS_INSTALL_RUNTIME_DIR/llvm/lib/cmake/clang \
-  -DWITH_AUTH="plain;ldap"
+  -DClang_DIR=$DEPS_INSTALL_RUNTIME_DIR/llvm/lib/cmake/clang/
 make install --quiet --jobs $(nproc)

--- a/.gitlab/build-deps.sh
+++ b/.gitlab/build-deps.sh
@@ -398,7 +398,6 @@ make
 make install
 
 rm -f $PACKAGES_DIR/openldap-2.5.6.tgz
-export PATH=$DEPS_INSTALL_RUNTIME_DIR/openldap-install/bin:$PATH
 
 #######
 # pip #

--- a/.gitlab/build-deps.sh
+++ b/.gitlab/build-deps.sh
@@ -383,6 +383,23 @@ cd $DEPS_INSTALL_RUNTIME_DIR
 mv node-v14.15.0-linux-x64 node-install
 export PATH=$DEPS_INSTALL_RUNTIME_DIR/node-install/bin:$PATH
 
+############
+# OpenLDAP #
+############
+
+cd $PACKAGES_DIR
+wget --no-verbose --no-clobber http://mirror.eu.oneandone.net/software/openldap/openldap-release/openldap-2.5.6.tgz
+tar -xf openldap-2.5.6.tgz
+
+cd openldap-2.5.6
+./configure --quiet --prefix=$DEPS_INSTALL_BUILD_DIR/openldap-install
+make depend
+make
+make install
+
+rm -f $PACKAGES_DIR/openldap-2.5.6.tgz
+export PATH=$DEPS_INSTALL_RUNTIME_DIR/openldap-install/bin:$PATH
+
 #######
 # pip #
 #######

--- a/.gitlab/cc-env.sh
+++ b/.gitlab/cc-env.sh
@@ -17,6 +17,7 @@ export LD_LIBRARY_PATH=$DEPS_INSTALL_DIR/libgit2-install/lib64\
 :$DEPS_INSTALL_DIR/llvm-install/lib\
 :$DEPS_INSTALL_DIR/libtool-install/lib\
 :$DEPS_INSTALL_DIR/postgresql-install/lib\
+:$DEPS_INSTALL_DIR/openldap-install/lib\
 :$LD_LIBRARY_PATH
 
 export PATH=$DEPS_INSTALL_DIR/jdk-install/bin\

--- a/.gitlab/ci.yml
+++ b/.gitlab/ci.yml
@@ -74,7 +74,8 @@ tarball suse-15:
         # build tools for CodeCompass
         - zypper install -y -t pattern devel_basis
         - zypper install -y binutils gcc-c++ gmp-devel
-        - zypper install -y groff groff-full
+        # build tools for OpenLDAP
+        - zypper install -y groff
         # build tools for ccdb-tools
         - zypper install -y libffi-devel
         # show GLIBC verison
@@ -97,7 +98,7 @@ tarball suse-42.1:
         - zypper install -y -t pattern devel_basis
         - zypper install -y binutils gcc-c++ gmp-devel
         # build tools for OpenLDAP
-        - zypper install -y groff groff-full
+        - zypper install -y groff
         # build tools for ccdb-tools
         - zypper install -y libffi-devel
         # show GLIBC verison
@@ -120,7 +121,7 @@ tarball ubuntu-16.04:
         # build tools for ctags
         - apt-get install -yqq dh-autoreconf pkg-config
         # build tools for OpenLDAP
-        - apt install -yqq groff groff-base
+        - apt install -yqq groff-base
         # build tools for ccdb-tools
         - apt-get install -yqq libffi-dev
         # show GLIBC verison

--- a/.gitlab/ci.yml
+++ b/.gitlab/ci.yml
@@ -74,6 +74,7 @@ tarball suse-15:
         # build tools for CodeCompass
         - zypper install -y -t pattern devel_basis
         - zypper install -y binutils gcc-c++ gmp-devel
+        - zypper install -y groff groff-full
         # build tools for ccdb-tools
         - zypper install -y libffi-devel
         # show GLIBC verison
@@ -95,6 +96,8 @@ tarball suse-42.1:
         # build tools for CodeCompass
         - zypper install -y -t pattern devel_basis
         - zypper install -y binutils gcc-c++ gmp-devel
+        # build tools for OpenLDAP
+        - zypper install -y groff groff-full
         # build tools for ccdb-tools
         - zypper install -y libffi-devel
         # show GLIBC verison
@@ -116,6 +119,8 @@ tarball ubuntu-16.04:
         - apt-get install -yqq build-essential libgmp-dev zlib1g-dev
         # build tools for ctags
         - apt-get install -yqq dh-autoreconf pkg-config
+        # build tools for OpenLDAP
+        - apt install -yqq groff groff-base
         # build tools for ccdb-tools
         - apt-get install -yqq libffi-dev
         # show GLIBC verison

--- a/doc/deps.md
+++ b/doc/deps.md
@@ -51,7 +51,7 @@ known issues.
 sudo apt install git cmake make g++ gcc-7-plugin-dev libboost-all-dev \
   llvm-10-dev clang-10 libclang-10-dev \
   default-jdk libssl1.0-dev libgraphviz-dev libmagic-dev libgit2-dev ctags \
-  libgtest-dev npm
+  libldap2-dev libgtest-dev npm
 ```
 
 #### Ubuntu 20.04 ("Focal Fossa") LTS
@@ -61,7 +61,7 @@ sudo apt install git cmake make g++ libboost-all-dev \
   llvm-10-dev clang-10 libclang-10-dev \
   odb libodb-dev thrift-compiler libthrift-dev \
   default-jdk libssl-dev libgraphviz-dev libmagic-dev libgit2-dev ctags \
-  libgtest-dev npm
+  libldap2-dev libgtest-dev npm
 ```
 
 #### Database engine support


### PR DESCRIPTION
The scripts that support tarball creation did not contain the dependencies for LDAP authentication. I complemented the scripts accordingly.