### PR TITLE
Reduce INFO level log output

### DIFF
--- a/plugins/metrics/parser/include/metricsparser/metricsparser.h
+++ b/plugins/metrics/parser/include/metricsparser/metricsparser.h
@@ -1,6 +1,8 @@
 #ifndef CC_PARSER_METRICS_PARSER_H
 #define CC_PARSER_METRICS_PARSER_H
 
+#include <atomic>
+
 #include <parser/abstractparser.h>
 #include <parser/parsercontext.h>
 
@@ -50,6 +52,7 @@ private:
 
   std::unordered_set<model::FileId> _fileIdCache;
   std::unique_ptr<util::JobQueueThreadPool<std::string>> _pool;
+  std::atomic<int> _visitedFileCount;
 };
 
 } // namespace parser

--- a/plugins/metrics/parser/src/metricsparser.cpp
+++ b/plugins/metrics/parser/src/metricsparser.cpp
@@ -39,9 +39,12 @@ MetricsParser::MetricsParser(ParserContext& ctx_): AbstractParser(ctx_)
       if (file)
       {
         if (_fileIdCache.find(file->id) == _fileIdCache.end())
+        {
           this->persistLoc(getLocFromFile(file), file->id);
+          ++this->_visitedFileCount;
+        }
         else
-          LOG(info) << "Metrics already counted for file: " << file->path;
+          LOG(debug) << "Metrics already counted for file: " << file->path;
       }
     });
 }
@@ -82,6 +85,8 @@ bool MetricsParser::cleanupDatabase()
 
 bool MetricsParser::parse()
 {
+  this->_visitedFileCount = 0;
+
   for(std::string path : _ctx.options["input"].as<std::vector<std::string>>())
   {
     LOG(info) << "Metrics parse path: " << path;
@@ -111,6 +116,7 @@ bool MetricsParser::parse()
   }
 
   _pool->wait();
+  LOG(info) << "Processed files: " << this->_visitedFileCount;
 
   return true;
 }
@@ -132,7 +138,7 @@ MetricsParser::Loc MetricsParser::getLocFromFile(model::FilePtr file_) const
 {
   Loc result;
 
-  LOG(info) << "Count metrics for " << file_->path;
+  LOG(debug) << "Count metrics for " << file_->path;
 
   //--- Get source code ---//
 

--- a/plugins/search/parser/src/searchparser.cpp
+++ b/plugins/search/parser/src/searchparser.cpp
@@ -128,7 +128,7 @@ util::DirIterCallback SearchParser::getParserCallback(const std::string& path_)
       if (std::find(_skipDirectories.begin(), _skipDirectories.end(),
             canonicalPath) != _skipDirectories.end())
       {
-        LOG(info) << "Skipping " << currPath_ << " because it was listed in "
+        LOG(trace) << "Skipping " << currPath_ << " because it was listed in "
           "the skipping directory flag of the search parser.";
         return false;
       }
@@ -184,7 +184,7 @@ bool SearchParser::shouldHandle(const std::string& path_)
     if (normPath.length() >= sufflen &&
         normPath.compare(normPath.length() - sufflen, sufflen, suff) == 0)
     {
-      LOG(info) << "Skipping " << path_;
+      LOG(trace) << "Skipping " << path_;
       return false;
     }
   }
@@ -202,7 +202,7 @@ bool SearchParser::shouldHandle(const std::string& path_)
 
   if (!_ctx.srcMgr.isPlainText(path_))
   {
-    LOG(info) << "Skipping " << path_ << " because it is not plain text.";
+    LOG(trace) << "Skipping " << path_ << " because it is not plain text.";
     return false;
   }
 


### PR DESCRIPTION
*metricsparser* and *searchparser* have very verbose log output on INFO level, which makes it hard to locate important messages. This PR reduces it:
 - Messages from *metricsparser* regarding each file being processed should be DEBUG level. Instead only a final count of processed files is printed.
 - Messages from *searchparser* regarding **skipped** files should be only TRACE level. The number of indexed files are already printed.