### PR TITLE
Updating selection in URL on every click on a word

### DIFF
--- a/webgui/scripts/codecompass/view/component/Text.js
+++ b/webgui/scripts/codecompass/view/component/Text.js
@@ -453,6 +453,22 @@ function (declare, domClass, dom, style, query, topic, ContentPane, Dialog,
         elementInfo : astNodeInfo
       });
 
+      //--- Update URL ---//
+
+      if (astNodeInfo)
+      {
+        var range = astNodeInfo.range.range;
+        var selection = [
+          range.startpos.line,
+          range.startpos.column,
+          range.endpos.line,
+          range.endpos.column];
+
+        urlHandler.setStateValue({
+          select : selection.join('|')
+        });
+      }
+
       //--- Highlighting the same occurrence of the selected entity ---//
 
       this._markUsages(pos, this._fileInfo);


### PR DESCRIPTION
Selection in URL is always `1|1|1|1` (except when a search result is selected). This PR fixes this by updating the selection on every click on a word in a file.
Fixes #382 and #543. 