### PR TITLE
Fix PostgreSql version conflict issue in GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,10 @@ jobs:
           llvm-10-dev clang-10 libclang-10-dev default-jdk libssl1.0-dev libgraphviz-dev
           libmagic-dev libgit2-dev ctags libgtest-dev npm libldap2-dev
 
+      - name: Remove default Postgresql Ubuntu 18
+        if: ${{ matrix.os == 'ubuntu-18.04' && matrix.db == 'postgresql' }}
+        run: sudo apt-get remove libpq5
+
       - name: Install Postgresql Ubuntu 18
         if: ${{ matrix.os == 'ubuntu-18.04' && matrix.db == 'postgresql' }}
         run: sudo apt-get install postgresql-server-dev-10
@@ -257,6 +261,10 @@ jobs:
           libboost-filesystem-dev libboost-log-dev libboost-program-options-dev
           llvm-10-dev clang-10 libclang-10-dev default-jre libssl1.0-dev libmagic-dev
           libgit2-dev ctags libgtest-dev libldap-2.4-2
+
+      - name: Remove default Postgresql Ubuntu 18
+        if: ${{ matrix.os == 'ubuntu-18.04' && matrix.db == 'postgresql' }}
+        run: sudo apt-get remove libpq5
 
       - name: Install Postgresql Ubuntu 18
         if: ${{ matrix.os == 'ubuntu-18.04' && matrix.db == 'postgresql' }}


### PR DESCRIPTION
The virtual environments of GitHub Actions are not clean OS installments, but contain many preinstalled software, even from PPAs.  
Recently the [Ubuntu 18.04 image](https://github.com/actions/virtual-environments/blob/ubuntu18/20211219.1/images/linux/Ubuntu1804-README.md) contains PostgreSQL 14, which is incompatible with version 10 installed by the CI script of CodeCompass.

As a resolution, the default Postgresql version for Ubuntu 18 in GitHub Actions is removed.  
*(Using PostgreSQL 14 would also work, but in that case the virtual environment would differ from the documentation, possibly hiding potential failures in the future.)*