### PR TITLE
Updating docker image building in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,54 @@ env:
   BUILD_TYPE: Debug
 
 jobs:
+  dockertest:
+    #needs: parse
+    if: ${{ github.repository == 'mcserep/CodeCompass' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release') == true) }}
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build images for current master
+        if: ${{ github.ref == 'refs/heads/master' }}
+        id: docker_build
+        run: |
+          docker build -t codecompass:dev     -t modelcpp/codecompass:dev            --file docker/dev/Dockerfile .
+          docker build -t codecompass:runtime -t modelcpp/codecompass:runtime-sqlite --file docker/runtime/Dockerfile --no-cache --build-arg CC_DATABASE=sqlite .
+          docker build -t codecompass:web     -t modelcpp/codecompass:web-sqlite     --file docker/web/Dockerfile --no-cache .
+          docker build -t codecompass:runtime -t modelcpp/codecompass:runtime-pgsql  --file docker/runtime/Dockerfile --no-cache --build-arg CC_DATABASE=pgsql .
+          docker build -t codecompass:web     -t modelcpp/codecompass:web-pgsql      --file docker/web/Dockerfile --no-cache .
+          docker tag modelcpp/codecompass:runtime-pgsql modelcpp/codecompass:latest
+
+      - name: Build images for Flash
+        if: ${{ github.ref == 'refs/heads/release/Flash' }}
+        id: docker_build
+        run: |
+          docker build -t codecompass:dev-flash     -t modelcpp/codecompass:dev-flash            --file docker/dev/Dockerfile .
+          docker build -t codecompass:runtime-flash -t modelcpp/codecompass:runtime-sqlite-flash --file docker/runtime/Dockerfile --no-cache --build-arg CC_DATABASE=sqlite .
+          docker build -t codecompass:web-flash     -t modelcpp/codecompass:web-sqlite-flash     --file docker/web/Dockerfile --no-cache .
+          docker build -t codecompass:runtime-flash -t modelcpp/codecompass:runtime-pgsql-flash  --file docker/runtime/Dockerfile --no-cache --build-arg CC_DATABASE=pgsql .
+          docker build -t codecompass:web-flash     -t modelcpp/codecompass:web-pgsql-flash      --file docker/web/Dockerfile --no-cache .
+          docker tag modelcpp/codecompass:runtime-pgsql-flash modelcpp/codecompass:flash
+
+  tarballtest:
+    #needs: parse
+    if: ${{ github.repository == 'mcserep/CodeCompass' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release') == true) }}
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Update apt-get
+        run: sudo apt-get update
+
+      - name: Install curl
+        run: sudo apt-get install curl
+
+      - name: Trigget GitLab CI
+        run: curl -X POST -F token=${{ secrets.GITLAB_TRIGGER_TOKEN }} -F ref=master https://gitlab.inf.elte.hu/api/v4/projects/85/trigger/pipeline
+
+
+
   build:
     strategy:
       matrix:
@@ -401,14 +449,15 @@ jobs:
 
   docker:
     needs: parse
-    if: ${{ github.repository == 'Ericsson/CodeCompass' && github.ref == 'refs/heads/master' }}
+    if: ${{ github.repository == 'Ericsson/CodeCompass' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release') == true) }}
     runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Build images
+      - name: Build images for current master
+        if: ${{ github.ref == 'refs/heads/master' }}
         id: docker_build
         run: |
           docker build -t codecompass:dev     -t modelcpp/codecompass:dev            --file docker/dev/Dockerfile .
@@ -418,6 +467,17 @@ jobs:
           docker build -t codecompass:web     -t modelcpp/codecompass:web-pgsql      --file docker/web/Dockerfile --no-cache .
           docker tag modelcpp/codecompass:runtime-pgsql modelcpp/codecompass:latest
 
+      - name: Build images for Flash
+        if: ${{ github.ref == 'refs/heads/release/Flash' }}
+        id: docker_build
+        run: |
+          docker build -t codecompass:dev-flash     -t modelcpp/codecompass:dev-flash            --file docker/dev/Dockerfile .
+          docker build -t codecompass:runtime-flash -t modelcpp/codecompass:runtime-sqlite-flash --file docker/runtime/Dockerfile --no-cache --build-arg CC_DATABASE=sqlite .
+          docker build -t codecompass:web-flash     -t modelcpp/codecompass:web-sqlite-flash     --file docker/web/Dockerfile --no-cache .
+          docker build -t codecompass:runtime-flash -t modelcpp/codecompass:runtime-pgsql-flash  --file docker/runtime/Dockerfile --no-cache --build-arg CC_DATABASE=pgsql .
+          docker build -t codecompass:web-flash     -t modelcpp/codecompass:web-pgsql-flash      --file docker/web/Dockerfile --no-cache .
+          docker tag modelcpp/codecompass:runtime-pgsql-flash modelcpp/codecompass:flash
+
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
@@ -425,6 +485,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Push images
+        if: ${{ github.ref == 'refs/heads/master' }}
         run: |
           docker push modelcpp/codecompass:dev
           docker push modelcpp/codecompass:runtime-sqlite
@@ -433,9 +494,19 @@ jobs:
           docker push modelcpp/codecompass:web-pgsql
           docker push modelcpp/codecompass:latest
 
+      - name: Push images
+        if: ${{ github.ref == 'refs/heads/release/Flash' }}
+        run: |
+          docker push modelcpp/codecompass:dev-flash
+          docker push modelcpp/codecompass:runtime-sqlite-flash
+          docker push modelcpp/codecompass:runtime-pgsql-flash
+          docker push modelcpp/codecompass:web-sqlite-flash
+          docker push modelcpp/codecompass:web-pgsql-flash
+          docker push modelcpp/codecompass:flash
+
   tarball:
     needs: parse
-    if: ${{ github.repository == 'Ericsson/CodeCompass' && github.ref == 'refs/heads/master' }}
+    if: ${{ github.repository == 'Ericsson/CodeCompass' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release') == true) }}
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,49 +8,37 @@ env:
 jobs:
   dockertest:
     #needs: parse
-    if: ${{ github.repository == 'mcserep/CodeCompass' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release') == true) }}
+    if: ${{ github.repository == 'Ericsson/CodeCompass' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release') == true) }}
     runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Branch name slug
+        uses: rlespinasse/github-slug-action@v4
+
+      - name: Branch name substring
+        uses: bhowell2/github-substring-action
+        id: branch_substring_test
+        with:
+          value: ${{ env.GITHUB_REPOSITORY_SLUG }}"
+          index_of_str: "release"
+          fail_if_not_found: false
+          default_return_value: ""
+
       - name: Build images for current master
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref_name == 'master' || startsWith(github.ref_name, 'release') == true) }}
         id: docker_build_test
         run: |
-          docker build -t codecompass:dev     -t modelcpp/codecompass:dev            --file docker/dev/Dockerfile .
+          export BRANCH=steps.branch_substring.outputs.substring
+          echo $BRANCH
+          docker build -t codecompass:dev$BRANCH     -t modelcpp/codecompass:dev$BRANCH            --file docker/dev/Dockerfile .
           docker build -t codecompass:runtime -t modelcpp/codecompass:runtime-sqlite --file docker/runtime/Dockerfile --no-cache --build-arg CC_DATABASE=sqlite .
           docker build -t codecompass:web     -t modelcpp/codecompass:web-sqlite     --file docker/web/Dockerfile --no-cache .
           docker build -t codecompass:runtime -t modelcpp/codecompass:runtime-pgsql  --file docker/runtime/Dockerfile --no-cache --build-arg CC_DATABASE=pgsql .
           docker build -t codecompass:web     -t modelcpp/codecompass:web-pgsql      --file docker/web/Dockerfile --no-cache .
           docker tag modelcpp/codecompass:runtime-pgsql modelcpp/codecompass:latest
-
-      - name: Build images for Flash
-        if: ${{ github.ref == 'refs/heads/release/Flash' }}
-        id: docker_build_flash_test
-        run: |
-          docker build -t codecompass:dev-flash     -t modelcpp/codecompass:dev-flash            --file docker/dev/Dockerfile .
-          docker build -t codecompass:runtime-flash -t modelcpp/codecompass:runtime-sqlite-flash --file docker/runtime/Dockerfile --no-cache --build-arg CC_DATABASE=sqlite .
-          docker build -t codecompass:web-flash     -t modelcpp/codecompass:web-sqlite-flash     --file docker/web/Dockerfile --no-cache .
-          docker build -t codecompass:runtime-flash -t modelcpp/codecompass:runtime-pgsql-flash  --file docker/runtime/Dockerfile --no-cache --build-arg CC_DATABASE=pgsql .
-          docker build -t codecompass:web-flash     -t modelcpp/codecompass:web-pgsql-flash      --file docker/web/Dockerfile --no-cache .
-          docker tag modelcpp/codecompass:runtime-pgsql-flash modelcpp/codecompass:flash
-
-  tarballtest:
-    #needs: parse
-    if: ${{ github.repository == 'mcserep/CodeCompass' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release') == true) }}
-    runs-on: ubuntu-20.04
-
-    steps:
-      - name: Update apt-get
-        run: sudo apt-get update
-
-      - name: Install curl
-        run: sudo apt-get install curl
-
-      - name: Trigget GitLab CI
-        run: curl -X POST -F token=${{ secrets.GITLAB_TRIGGER_TOKEN }} -F ref=master https://gitlab.inf.elte.hu/api/v4/projects/85/trigger/pipeline
 
 
 
@@ -456,27 +444,30 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Branch name slug
+        uses: rlespinasse/github-slug-action@v4
+
+      - name: Branch name substring
+        uses: bhowell2/github-substring-action
+        id: branch_substring
+        with:
+          value: ${{ env.GITHUB_REPOSITORY_SLUG }}"
+          index_of_str: "release"
+          fail_if_not_found: false
+          default_return_value: ""
+
       - name: Build images for current master
-        if: ${{ github.ref == 'refs/heads/master' }}
-        id: docker_build_master
+        if: ${{ github.ref_name == 'master' || startsWith(github.ref_name, 'release') == true) }}
+        id: docker_build
         run: |
-          docker build -t codecompass:dev     -t modelcpp/codecompass:dev            --file docker/dev/Dockerfile .
+          export BRANCH=steps.branch_substring.outputs.substring
+          echo $BRANCH
+          docker build -t codecompass:dev$BRANCH     -t modelcpp/codecompass:dev$BRANCH            --file docker/dev/Dockerfile .
           docker build -t codecompass:runtime -t modelcpp/codecompass:runtime-sqlite --file docker/runtime/Dockerfile --no-cache --build-arg CC_DATABASE=sqlite .
           docker build -t codecompass:web     -t modelcpp/codecompass:web-sqlite     --file docker/web/Dockerfile --no-cache .
           docker build -t codecompass:runtime -t modelcpp/codecompass:runtime-pgsql  --file docker/runtime/Dockerfile --no-cache --build-arg CC_DATABASE=pgsql .
           docker build -t codecompass:web     -t modelcpp/codecompass:web-pgsql      --file docker/web/Dockerfile --no-cache .
           docker tag modelcpp/codecompass:runtime-pgsql modelcpp/codecompass:latest
-
-      - name: Build images for Flash
-        if: ${{ github.ref == 'refs/heads/release/Flash' }}
-        id: docker_build_flash
-        run: |
-          docker build -t codecompass:dev-flash     -t modelcpp/codecompass:dev-flash            --file docker/dev/Dockerfile .
-          docker build -t codecompass:runtime-flash -t modelcpp/codecompass:runtime-sqlite-flash --file docker/runtime/Dockerfile --no-cache --build-arg CC_DATABASE=sqlite .
-          docker build -t codecompass:web-flash     -t modelcpp/codecompass:web-sqlite-flash     --file docker/web/Dockerfile --no-cache .
-          docker build -t codecompass:runtime-flash -t modelcpp/codecompass:runtime-pgsql-flash  --file docker/runtime/Dockerfile --no-cache --build-arg CC_DATABASE=pgsql .
-          docker build -t codecompass:web-flash     -t modelcpp/codecompass:web-pgsql-flash      --file docker/web/Dockerfile --no-cache .
-          docker tag modelcpp/codecompass:runtime-pgsql-flash modelcpp/codecompass:flash
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
@@ -516,5 +507,5 @@ jobs:
       - name: Install curl
         run: sudo apt-get install curl
 
-      - name: Trigget GitLab CI
+      - name: Trigger GitLab CI
         run: curl -X POST -F token=${{ secrets.GITLAB_TRIGGER_TOKEN }} -F ref=master https://gitlab.inf.elte.hu/api/v4/projects/85/trigger/pipeline

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Build images for current master
         if: ${{ github.ref == 'refs/heads/master' }}
-        id: docker_build
+        id: docker_build_test
         run: |
           docker build -t codecompass:dev     -t modelcpp/codecompass:dev            --file docker/dev/Dockerfile .
           docker build -t codecompass:runtime -t modelcpp/codecompass:runtime-sqlite --file docker/runtime/Dockerfile --no-cache --build-arg CC_DATABASE=sqlite .
@@ -28,7 +28,7 @@ jobs:
 
       - name: Build images for Flash
         if: ${{ github.ref == 'refs/heads/release/Flash' }}
-        id: docker_build
+        id: docker_build_flash_test
         run: |
           docker build -t codecompass:dev-flash     -t modelcpp/codecompass:dev-flash            --file docker/dev/Dockerfile .
           docker build -t codecompass:runtime-flash -t modelcpp/codecompass:runtime-sqlite-flash --file docker/runtime/Dockerfile --no-cache --build-arg CC_DATABASE=sqlite .
@@ -458,7 +458,7 @@ jobs:
 
       - name: Build images for current master
         if: ${{ github.ref == 'refs/heads/master' }}
-        id: docker_build
+        id: docker_build_master
         run: |
           docker build -t codecompass:dev     -t modelcpp/codecompass:dev            --file docker/dev/Dockerfile .
           docker build -t codecompass:runtime -t modelcpp/codecompass:runtime-sqlite --file docker/runtime/Dockerfile --no-cache --build-arg CC_DATABASE=sqlite .
@@ -469,7 +469,7 @@ jobs:
 
       - name: Build images for Flash
         if: ${{ github.ref == 'refs/heads/release/Flash' }}
-        id: docker_build
+        id: docker_build_flash
         run: |
           docker build -t codecompass:dev-flash     -t modelcpp/codecompass:dev-flash            --file docker/dev/Dockerfile .
           docker build -t codecompass:runtime-flash -t modelcpp/codecompass:runtime-sqlite-flash --file docker/runtime/Dockerfile --no-cache --build-arg CC_DATABASE=sqlite .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
 jobs:
   dockertest:
     #needs: parse
-    if: ${{ github.repository == 'Ericsson/CodeCompass' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release') == true) }}
+    if: ${{ github.repository == 'mcserep/CodeCompass' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release') == true) }}
     runs-on: ubuntu-20.04
 
     steps:
@@ -19,7 +19,7 @@ jobs:
         uses: rlespinasse/github-slug-action@v4
 
       - name: Branch name substring
-        uses: bhowell2/github-substring-action
+        uses: bhowell2/github-substring-action@v1.0.0
         id: branch_substring_test
         with:
           value: ${{ env.GITHUB_REPOSITORY_SLUG }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,43 +6,6 @@ env:
   BUILD_TYPE: Debug
 
 jobs:
-  dockertest:
-    #needs: parse
-    if: ${{ github.repository == 'mcserep/CodeCompass' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release') == true) }}
-    runs-on: ubuntu-20.04
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Branch name slug
-        uses: rlespinasse/github-slug-action@v4
-
-      - name: Branch name substring
-        uses: bhowell2/github-substring-action@v1.0.0
-        id: branch_substring_test
-        with:
-          value: ${{ env.GITHUB_REF_SLUG }}
-          index_of_str: "release"
-          fail_if_not_found: false
-          default_return_value: ""
-
-      - name: Build images for current master
-        if: ${{ github.ref_name == 'master' || startsWith(github.ref_name, 'release') == true }}
-        id: docker_build_test
-        run: |
-          echo ${{ steps.branch_substring_test.outputs.substring }}
-          export BRANCH=${{ steps.branch_substring_test.outputs.substring }}
-          echo $BRANCH
-          docker build -t codecompass:dev$BRANCH     -t modelcpp/codecompass:dev$BRANCH            --file docker/dev/Dockerfile .
-          docker build -t codecompass:runtime -t modelcpp/codecompass:runtime-sqlite --file docker/runtime/Dockerfile --no-cache --build-arg CC_DATABASE=sqlite .
-          docker build -t codecompass:web     -t modelcpp/codecompass:web-sqlite     --file docker/web/Dockerfile --no-cache .
-          docker build -t codecompass:runtime -t modelcpp/codecompass:runtime-pgsql  --file docker/runtime/Dockerfile --no-cache --build-arg CC_DATABASE=pgsql .
-          docker build -t codecompass:web     -t modelcpp/codecompass:web-pgsql      --file docker/web/Dockerfile --no-cache .
-          docker tag modelcpp/codecompass:runtime-pgsql modelcpp/codecompass:latest
-
-
-
   build:
     strategy:
       matrix:
@@ -438,7 +401,7 @@ jobs:
 
   docker:
     needs: parse
-    if: ${{ github.repository == 'Ericsson/CodeCompass' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release') == true) }}
+    if: ${{ github.repository == 'Ericsson/CodeCompass' && (github.ref_name == 'master' || startsWith(github.ref_name, 'release') == true) }}
     runs-on: ubuntu-20.04
 
     steps:
@@ -452,26 +415,21 @@ jobs:
         uses: bhowell2/github-substring-action@v1.0.0
         id: branch_substring
         with:
-          value: ${{ env.GITHUB_REPOSITORY_SLUG }}"
+          value: ${{ env.GITHUB_REF_SLUG }}
           index_of_str: "release"
           fail_if_not_found: false
           default_return_value: ""
 
       - name: Build images for current master
         if: ${{ github.ref_name == 'master' || startsWith(github.ref_name, 'release') == true }}
-        id: docker_build
         run: |
-          echo steps.branch_substring.outputs.substring
-          echo $(echo steps.branch_substring.outputs.substring)
-          echo ${echo steps.branch_substring.outputs.substring}
-          export BRANCH=$(steps.branch_substring.outputs.substring)
-          echo $BRANCH
-          docker build -t codecompass:dev$BRANCH     -t modelcpp/codecompass:dev$BRANCH            --file docker/dev/Dockerfile .
-          docker build -t codecompass:runtime -t modelcpp/codecompass:runtime-sqlite --file docker/runtime/Dockerfile --no-cache --build-arg CC_DATABASE=sqlite .
-          docker build -t codecompass:web     -t modelcpp/codecompass:web-sqlite     --file docker/web/Dockerfile --no-cache .
-          docker build -t codecompass:runtime -t modelcpp/codecompass:runtime-pgsql  --file docker/runtime/Dockerfile --no-cache --build-arg CC_DATABASE=pgsql .
-          docker build -t codecompass:web     -t modelcpp/codecompass:web-pgsql      --file docker/web/Dockerfile --no-cache .
-          docker tag modelcpp/codecompass:runtime-pgsql modelcpp/codecompass:latest
+          export BRANCH=${{ steps.branch_substring.outputs.substring }}
+          docker build -t codecompass$BRANCH:dev     -t modelcpp/codecompass$BRANCH:dev            --file docker/dev/Dockerfile .
+          docker build -t codecompass$BRANCH:runtime -t modelcpp/codecompass$BRANCH:runtime-sqlite --file docker/runtime/Dockerfile --no-cache --build-arg CC_DATABASE=sqlite .
+          docker build -t codecompass$BRANCH:web     -t modelcpp/codecompass$BRANCH:web-sqlite     --file docker/web/Dockerfile --no-cache .
+          docker build -t codecompass$BRANCH:runtime -t modelcpp/codecompass$BRANCH:runtime-pgsql  --file docker/runtime/Dockerfile --no-cache --build-arg CC_DATABASE=pgsql .
+          docker build -t codecompass$BRANCH:web     -t modelcpp/codecompass$BRANCH:web-pgsql      --file docker/web/Dockerfile --no-cache .
+          docker tag modelcpp/codecompass$BRANCH:runtime-pgsql modelcpp/codecompass$BRANCH:latest
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
@@ -480,28 +438,19 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Push images
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref_name == 'master' || startsWith(github.ref_name, 'release') == true }}
         run: |
-          docker push modelcpp/codecompass:dev
-          docker push modelcpp/codecompass:runtime-sqlite
-          docker push modelcpp/codecompass:runtime-pgsql
-          docker push modelcpp/codecompass:web-sqlite
-          docker push modelcpp/codecompass:web-pgsql
-          docker push modelcpp/codecompass:latest
-
-      - name: Push images
-        if: ${{ github.ref == 'refs/heads/release/Flash' }}
-        run: |
-          docker push modelcpp/codecompass:dev-flash
-          docker push modelcpp/codecompass:runtime-sqlite-flash
-          docker push modelcpp/codecompass:runtime-pgsql-flash
-          docker push modelcpp/codecompass:web-sqlite-flash
-          docker push modelcpp/codecompass:web-pgsql-flash
-          docker push modelcpp/codecompass:flash
+          export BRANCH=${{ steps.branch_substring.outputs.substring }}
+          docker push modelcpp/codecompass$BRANCH:dev
+          docker push modelcpp/codecompass$BRANCH:runtime-sqlite
+          docker push modelcpp/codecompass$BRANCH:runtime-pgsql
+          docker push modelcpp/codecompass$BRANCH:web-sqlite
+          docker push modelcpp/codecompass$BRANCH:web-pgsql
+          docker push modelcpp/codecompass$BRANCH:latest
 
   tarball:
     needs: parse
-    if: ${{ github.repository == 'Ericsson/CodeCompass' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release') == true) }}
+    if: ${{ github.repository == 'Ericsson/CodeCompass' && github.ref_name == 'master' }}
     runs-on: ubuntu-20.04
 
     steps:
@@ -512,4 +461,4 @@ jobs:
         run: sudo apt-get install curl
 
       - name: Trigger GitLab CI
-        run: curl -X POST -F token=${{ secrets.GITLAB_TRIGGER_TOKEN }} -F ref=master https://gitlab.inf.elte.hu/api/v4/projects/85/trigger/pipeline
+        run: curl -X POST -F token=${{ secrets.GITLAB_TRIGGER_TOKEN }} -F ref=${{ github.ref_name }} https://gitlab.inf.elte.hu/api/v4/projects/85/trigger/pipeline

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,16 +22,17 @@ jobs:
         uses: bhowell2/github-substring-action@v1.0.0
         id: branch_substring_test
         with:
-          value: ${{ env.GITHUB_REPOSITORY_SLUG }}"
+          value: ${{ env.GITHUB_REF_SLUG }}
           index_of_str: "release"
           fail_if_not_found: false
           default_return_value: ""
 
       - name: Build images for current master
-        if: ${{ github.ref_name == 'master' || startsWith(github.ref_name, 'release') == true) }}
+        if: ${{ github.ref_name == 'master' || startsWith(github.ref_name, 'release') == true }}
         id: docker_build_test
         run: |
-          export BRANCH=steps.branch_substring.outputs.substring
+          echo ${{ steps.branch_substring_test.outputs.substring }}
+          export BRANCH=${{ steps.branch_substring_test.outputs.substring }}
           echo $BRANCH
           docker build -t codecompass:dev$BRANCH     -t modelcpp/codecompass:dev$BRANCH            --file docker/dev/Dockerfile .
           docker build -t codecompass:runtime -t modelcpp/codecompass:runtime-sqlite --file docker/runtime/Dockerfile --no-cache --build-arg CC_DATABASE=sqlite .
@@ -448,7 +449,7 @@ jobs:
         uses: rlespinasse/github-slug-action@v4
 
       - name: Branch name substring
-        uses: bhowell2/github-substring-action
+        uses: bhowell2/github-substring-action@v1.0.0
         id: branch_substring
         with:
           value: ${{ env.GITHUB_REPOSITORY_SLUG }}"
@@ -457,10 +458,13 @@ jobs:
           default_return_value: ""
 
       - name: Build images for current master
-        if: ${{ github.ref_name == 'master' || startsWith(github.ref_name, 'release') == true) }}
+        if: ${{ github.ref_name == 'master' || startsWith(github.ref_name, 'release') == true }}
         id: docker_build
         run: |
-          export BRANCH=steps.branch_substring.outputs.substring
+          echo steps.branch_substring.outputs.substring
+          echo $(echo steps.branch_substring.outputs.substring)
+          echo ${echo steps.branch_substring.outputs.substring}
+          export BRANCH=$(steps.branch_substring.outputs.substring)
           echo $BRANCH
           docker build -t codecompass:dev$BRANCH     -t modelcpp/codecompass:dev$BRANCH            --file docker/dev/Dockerfile .
           docker build -t codecompass:runtime -t modelcpp/codecompass:runtime-sqlite --file docker/runtime/Dockerfile --no-cache --build-arg CC_DATABASE=sqlite .


### PR DESCRIPTION
I updated the Docker image building in the GitHub Actions workflow to build images based on major releases besides master. This results in build docker images if a commit comes in to any branch named `release/something`, e.g. `release/Flash`.