### PR TITLE
Filter C/C++ compile commands

### DIFF
--- a/plugins/cpp/parser/src/cppparser.cpp
+++ b/plugins/cpp/parser/src/cppparser.cpp
@@ -748,20 +748,16 @@ bool CppParser::parseByJson(
 
   //--- Read the compilation commands compile database ---//
 
-  std::vector<clang::tooling::CompileCommand> tempCompileCommands =
+  std::vector<clang::tooling::CompileCommand> compileCommands =
     compDb->getAllCompileCommands();
-  std::vector<clang::tooling::CompileCommand> compileCommands;
 
-  const std::vector<std::string> cppExts{
-    ".c", ".cc", ".cpp", ".cxx", ".o", ".so", ".a"};
-
-  std::copy_if(tempCompileCommands.begin(), tempCompileCommands.end(),
-    std::back_inserter(compileCommands), [&](clang::tooling::CompileCommand c)
-    {
-      auto iter = std::find(cppExts.begin(), cppExts.end(),
-                  fs::extension(c.Filename));
-      return iter != cppExts.end();
-    });
+  compileCommands.erase(
+    std::remove_if(compileCommands.begin(), compileCommands.end(),
+      [&](const clang::tooling::CompileCommand& c)
+      {
+        return !isSourceFile(c.Filename);
+      }),
+    compileCommands.end());
 
   std::size_t numCompileCommands = compileCommands.size();
 

--- a/plugins/cpp/parser/src/cppparser.cpp
+++ b/plugins/cpp/parser/src/cppparser.cpp
@@ -748,8 +748,21 @@ bool CppParser::parseByJson(
 
   //--- Read the compilation commands compile database ---//
 
-  std::vector<clang::tooling::CompileCommand> compileCommands =
+  std::vector<clang::tooling::CompileCommand> tempCompileCommands =
     compDb->getAllCompileCommands();
+  std::vector<clang::tooling::CompileCommand> compileCommands;
+
+  const std::vector<std::string> cppExts{
+    ".c", ".cc", ".cpp", ".cxx", ".o", ".so", ".a"};
+
+  std::copy_if(tempCompileCommands.begin(), tempCompileCommands.end(),
+    std::back_inserter(compileCommands), [&](clang::tooling::CompileCommand c)
+    {
+      auto iter = std::find(cppExts.begin(), cppExts.end(),
+                  fs::extension(c.Filename));
+      return iter != cppExts.end();
+    });
+
   std::size_t numCompileCommands = compileCommands.size();
 
   //--- Create a thread pool for the current commands ---//


### PR DESCRIPTION
Filter compile commands from `compile_commands.json` so C++ plugin won't try to parse everything in case of a multi-language project. 