### PR TITLE
docs: add missing postgresql dependency and use apt everywhere

### DIFF
--- a/doc/deps.md
+++ b/doc/deps.md
@@ -81,7 +81,7 @@ package manager.
 sudo apt install libsqlite3-dev
 
 # For PostgreSQL database systems:
-sudo apt install postgresql postgresql-server-dev-<version>
+sudo apt install postgresql-server-dev-<version>
 ```
 
 ##### Ubuntu 20.04 ("Focal Fossa") LTS
@@ -91,7 +91,7 @@ sudo apt install postgresql postgresql-server-dev-<version>
 sudo apt install libodb-sqlite-dev libsqlite3-dev
 
 # For PostgreSQL database systems:
-sudo apt install postgresql libodb-pgsql-dev postgresql-server-dev-<version>
+sudo apt install libodb-pgsql-dev postgresql-server-dev-<version>
 ```
 
 

--- a/doc/deps.md
+++ b/doc/deps.md
@@ -81,17 +81,17 @@ package manager.
 sudo apt install libsqlite3-dev
 
 # For PostgreSQL database systems:
-sudo apt install postgresql-server-dev-<version>
+sudo apt install postgresql postgresql-server-dev-<version>
 ```
 
 ##### Ubuntu 20.04 ("Focal Fossa") LTS
 
 ```bash
 # For SQLite database systems:
-sudo apt-get install libodb-sqlite-dev libsqlite3-dev
+sudo apt install libodb-sqlite-dev libsqlite3-dev
 
 # For PostgreSQL database systems:
-sudo apt-get install libodb-pgsql-dev postgresql-server-dev-<version>
+sudo apt install postgresql libodb-pgsql-dev postgresql-server-dev-<version>
 ```
 
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -15,9 +15,15 @@ creating and using the database file.
 
 ### Using *PostgreSQL* from package manager
 
-PostgreSQL can be installed from the package manager, using
-`sudo apt install postgresql-<version>` (e.g. `postgresql-9.5`). This will
-set up an automatically starting local server on the default port `5432`.
+PostgreSQL can be installed from the package manager:
+
+```bash
+sudo apt install postgresql-<version>
+# (e.g. postgresql-12)
+```
+
+This will set up an automatically starting local server on the default port
+`5432`.
 
 This server, by default, is only accessible for an automatically created system
 user named `postgres`. However, CodeCompass's database layer only supports

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -16,7 +16,7 @@ creating and using the database file.
 ### Using *PostgreSQL* from package manager
 
 PostgreSQL can be installed from the package manager, using
-`sudo apt-get install postgresql-<version>` (e.g. `postgresql-9.5`). This will
+`sudo apt install postgresql-<version>` (e.g. `postgresql-9.5`). This will
 set up an automatically starting local server on the default port `5432`.
 
 This server, by default, is only accessible for an automatically created system


### PR DESCRIPTION
Following the instructions in the docs to set up PostgreSQL on Lubuntu 20.04, I got an error when running `psql`, saying a server wasn't running. It was not until I installed the `postgresql` package that the instructions worked. This package isn't installed by default on [Ubuntu 20.04](http://releases.ubuntu.com/focal/ubuntu-20.04.4-desktop-amd64.manifest) or [18.04](http://releases.ubuntu.com/bionic/ubuntu-18.04.6-desktop-amd64.manifest) desktop either.

I also changed leftover occurrences of `apt-get` to `apt` while I was at it.