### PR TITLE
Improve initialization of git blame view

### DIFF
--- a/plugins/git/webgui/js/gitBlame.js
+++ b/plugins/git/webgui/js/gitBlame.js
@@ -204,7 +204,6 @@ function (on, topic, declare, Color, dom, Tooltip, Text, model, viewHandler,
      * @param {Integer} fileId
      */
     loadBlameView : function (path, fileId) {
-      this.set('selection', [1,1,1,1]);
       var res = model.gitservice.getRepositoryByProjectPath(path);
 
       if (!res.isInRepository)
@@ -250,14 +249,26 @@ function (on, topic, declare, Color, dom, Tooltip, Text, model, viewHandler,
         if (!fileInfo)
           return;
 
+        var selection = message.nodeInfo
+          ? [
+              message.nodeInfo.range.range.startpos.line,
+              message.nodeInfo.range.range.startpos.column,
+              message.nodeInfo.range.range.endpos.line,
+              message.nodeInfo.range.range.endpos.column]
+          : [1, 1, 1, 1];
+
         commitCache = {};
         that.loadFile(fileInfo.id);
+        that.set('selection', selection);
+        that.jumpToPos(selection[0], selection[1]);
+
         that.loadBlameView(fileInfo.path, fileInfo.id);
 
         topic.publish('codecompass/setCenterModule', that.id);
 
         urlHandler.setStateValue({
-          center : that.id
+          center : that.id,
+          select : selection.join('|')
         });
       });
     }

--- a/plugins/git/webgui/js/gitBlame.js
+++ b/plugins/git/webgui/js/gitBlame.js
@@ -268,7 +268,8 @@ function (on, topic, declare, Color, dom, Tooltip, Text, model, viewHandler,
 
         urlHandler.setStateValue({
           center : that.id,
-          select : selection.join('|')
+          select : selection.join('|'),
+          fid    : fileInfo.id
         });
       });
     }


### PR DESCRIPTION
This PR fixes two things about the initialization of the git blame view:
1. Jump to the currently selected node when opening git blame view. Fixes #218.
2. Set `fid`. Fixes an issue where if a file's blame view is opened before opening any code views, the info tree won't work.