### PR TITLE
Fix recursive caller nodes

### DIFF
--- a/plugins/cpp/webgui/js/cppInfoTree.js
+++ b/plugins/cpp/webgui/js/cppInfoTree.js
@@ -31,7 +31,11 @@ function (model, viewHandler, util) {
   }
 
   function createReferenceCountLabel(label, count) {
-    return label + '<span class="reference-count">(' + count + ')</span>';
+    var parsedLabel = $('<div>').append($.parseHTML(label));
+    parsedLabel.children('span.reference-count').remove();
+    parsedLabel.append('<span class="reference-count">(' + count + ')</span>');
+
+    return parsedLabel.html();
   }
 
   function createLabel(astNodeInfo) {

--- a/plugins/cpp/webgui/js/cppInfoTree.js
+++ b/plugins/cpp/webgui/js/cppInfoTree.js
@@ -185,7 +185,9 @@ function (model, viewHandler, util) {
                         refType     : parentNode.refType,
                         cssClass    : parentNode.cssClass,
                         hasChildren : true,
-                        getChildren : parentNode.getChildren
+                        getChildren : function () {
+                          return loadReferenceNodes(this, reference, refTypes);
+                        }
                       });
 
                     //--- Call ---//


### PR DESCRIPTION
Fixes #544, which was caused by the children of the child caller nodes being set incorrectly. Recursions in the tree are also avoided now.

There is one issue remaining that I need some feedback on. When the child caller nodes are created, the reference count after their name is appended to instead of replaced, which means reference counts keep piling up as we go deeper in the tree. See "Caller(4)(8)(1)" in this screenshot.
![](https://user-images.githubusercontent.com/100377984/157374426-fc685057-b257-4436-bdb8-bbc2c489e2e9.png)
This is not intentional, is it? In that case I can fix it too.
