### PR TITLE
Change working directory of C++ parser

### DIFF
--- a/parser/include/parser/sourcemanager.h
+++ b/parser/include/parser/sourcemanager.h
@@ -51,8 +51,8 @@ public:
    * based on the given path_. The object is read from a cache. If the file is
    * not in the cache yet then a model::File entry is created, persisted in the
    * database and placed in the cache. If the file doesn't exist then it returns
-   * nullptr.
-   * @param path_ The file path to look up.
+   * a file with no contents.
+   * @param path_ The absolute file path to look up.
    */
   model::FilePtr getFile(const std::string& path_);
 

--- a/parser/src/sourcemanager.cpp
+++ b/parser/src/sourcemanager.cpp
@@ -166,7 +166,7 @@ model::FilePtr SourceManager::getFile(const std::string& path_)
   boost::filesystem::path canonicalPath
     = boost::filesystem::canonical(path_, ec);
 
-  //--- If the file can't be found on disk then return nullptr ---//
+  //--- If the file can't be found on disk then return a blank file ---//
 
   bool fileExists = true;
   if (ec)

--- a/plugins/cpp/parser/include/cppparser/filelocutil.h
+++ b/plugins/cpp/parser/include/cppparser/filelocutil.h
@@ -79,23 +79,31 @@ public:
   }
 
   /**
-   * This function returns the file path in which loc_ location takes place. The
-   * location is meant to be the expanded location (in case of macro expansion).
-   * If the file can't be determined then empty string returns.
+   * This function returns the absolute path of the file in which loc_ location
+   * takes place. The location is meant to be the expanded location (in case of
+   * macro expansion).
+   * If the file can't be determined then an empty string is returned.
    */
   std::string getFilePath(const clang::SourceLocation& loc_)
   {
-    clang::SourceLocation expLoc = _clangSrcMan.getExpansionLoc(loc_);
-    clang::FileID fid = _clangSrcMan.getFileID(expLoc);
+    return getFilePath(
+      _clangSrcMan.getFileID(_clangSrcMan.getExpansionLoc(loc_)));
+  }
 
-    if (fid.isInvalid())
+  /**
+   * This function returns the absolute path of the file identified by fid_.
+   * If the file can't be determined then an empty string is returned.
+   */
+  std::string getFilePath(const clang::FileID& fid_)
+  {
+    if (fid_.isInvalid())
       return std::string();
 
-    const clang::FileEntry* fileEntry = _clangSrcMan.getFileEntryForID(fid);
+    const clang::FileEntry* fileEntry = _clangSrcMan.getFileEntryForID(fid_);
     if (!fileEntry)
       return std::string();
 
-    return fileEntry->getName();
+    return fileEntry->tryGetRealPathName();
   }
 
 private:

--- a/plugins/cpp/parser/src/cppparser.cpp
+++ b/plugins/cpp/parser/src/cppparser.cpp
@@ -325,15 +325,11 @@ int CppParser::parseWorker(const clang::tooling::CompileCommand& command_)
 
   //--- Start the tool ---//
 
-  fs::path sourceFullPath(command_.Filename);
-  if (!sourceFullPath.is_absolute())
-    sourceFullPath = fs::path(command_.Directory) / command_.Filename;
-
   VisitorActionFactory factory(_ctx);
 
   // Use a PhysicalFileSystem as it's thread-safe
 
-  clang::tooling::ClangTool tool(*compilationDb, sourceFullPath.string(),
+  clang::tooling::ClangTool tool(*compilationDb, command_.Filename,
     std::make_shared<clang::PCHContainerOperations>(),
     llvm::vfs::createPhysicalFileSystem().release());
 

--- a/plugins/cpp/parser/src/ppincludecallback.cpp
+++ b/plugins/cpp/parser/src/ppincludecallback.cpp
@@ -58,10 +58,10 @@ model::CppAstNodePtr PPIncludeCallback::createFileAstNode(
 void PPIncludeCallback::InclusionDirective(
   clang::SourceLocation hashLoc_,
   const clang::Token&,
-  clang::StringRef fileName_,
+  clang::StringRef,
   bool,
   clang::CharSourceRange filenameRange_,
-  const clang::FileEntry*,
+  const clang::FileEntry* file_,
   clang::StringRef searchPath_,
   clang::StringRef,
   const clang::Module*,
@@ -75,8 +75,8 @@ void PPIncludeCallback::InclusionDirective(
 
   //--- Included file ---//
 
-  std::string includedPath = searchPath_.str() + '/' + fileName_.str();
-  model::FilePtr included = _ctx.srcMgr.getFile(includedPath);
+  model::FilePtr included = _ctx.srcMgr.getFile(
+    file_->tryGetRealPathName().str());
   included->parseStatus = model::File::PSFullyParsed;
   if (included->type != model::File::DIRECTORY_TYPE &&
       included->type != _cppSourceType)
@@ -87,8 +87,8 @@ void PPIncludeCallback::InclusionDirective(
 
   //--- Includer file ---//
 
-  std::string includerPath = presLoc.getFilename();
-  model::FilePtr includer = _ctx.srcMgr.getFile(includerPath);
+  model::FilePtr includer = _ctx.srcMgr.getFile(
+    _fileLocUtil.getFilePath(presLoc.getFileID()));
   includer->parseStatus = model::File::PSFullyParsed;
   if (includer->type != model::File::DIRECTORY_TYPE &&
       includer->type != _cppSourceType)

--- a/plugins/cpp/parser/src/ppmacrocallback.cpp
+++ b/plugins/cpp/parser/src/ppmacrocallback.cpp
@@ -253,11 +253,13 @@ std::string PPMacroCallback::getUSR(const clang::MacroInfo* mi_)
   std::string locStr
      = std::to_string(presLoc.getLine())   + ":" +
        std::to_string(presLoc.getColumn()) + ":";
+       
+  std::string filePath = _fileLocUtil.getFilePath(presLoc.getFileID());
 
   return locStr
     + (isBuiltInMacro(mi_)
-    ? presLoc.getFilename()
-    : std::to_string(_ctx.srcMgr.getFile(presLoc.getFilename())->id));
+    ? filePath
+    : std::to_string(_ctx.srcMgr.getFile(filePath)->id));
 }
 
 } // parser


### PR DESCRIPTION
This PR makes Clang tool invocations use the working directories of each compilation command. This fixes relative paths in arguments not being handled properly (#571), as previously the tool ran in the default working directory of `.`.

Callers of `SourceManager::getFile` in `cppparser` were changed to provide an absolute path.

Additionally, inaccurate comments in `SourceManager::getFile` were corrected.