### PR TITLE
fix(build): (NFC) Fix some compiler warnings emitted when compiling with Clang 13.0

### DIFF
--- a/plugins/cpp/parser/include/cppparser/cppparser.h
+++ b/plugins/cpp/parser/include/cppparser/cppparser.h
@@ -105,16 +105,16 @@ private:
   bool isNonSourceFlag(const std::string& arg_) const;
   bool parseByJson(const std::string& jsonFile_, std::size_t threadNum_);
   int parseWorker(const clang::tooling::CompileCommand& command_);
-  
+
   void initBuildActions();
-  void markByInclusion(model::FilePtr file_);
+  void markByInclusion(const model::FilePtr& file_);
   std::vector<std::vector<std::string>> createCleanupOrder();
   bool cleanupWorker(const std::string& path_);
 
   std::unordered_set<std::uint64_t> _parsedCommandHashes;
 
 };
-  
+
 } // parser
 } // cc
 

--- a/plugins/cpp/parser/src/cppparser.cpp
+++ b/plugins/cpp/parser/src/cppparser.cpp
@@ -469,7 +469,7 @@ void CppParser::markModifiedFiles()
   // Detect changed files through C++ header inclusions.
   util::OdbTransaction {_ctx.db} ([&]
   {
-    for (const model::FilePtr file : filePtrs)
+    for (const model::FilePtr& file : filePtrs)
     {
       if(file)
       {
@@ -711,7 +711,7 @@ void CppParser::initBuildActions()
   });
 }
 
-void CppParser::markByInclusion(model::FilePtr file_)
+void CppParser::markByInclusion(const model::FilePtr& file_)
 {
   auto inclusions = _ctx.db->query<model::CppHeaderInclusion>(
     odb::query<model::CppHeaderInclusion>::included == file_->id);

--- a/plugins/cpp/test/src/cppparsertest.cpp
+++ b/plugins/cpp/test/src/cppparsertest.cpp
@@ -361,9 +361,10 @@ TEST_F(CppParserTest, Record)
     {
       EXPECT_EQ(n.symbolType, model::CppAstNode::SymbolType::Type);
 
+      using LineType = decltype(n.location.range.start.line);
       switch (n.location.range.start.line)
       {
-        case -1: 
+        case static_cast<LineType>(-1):
           EXPECT_TRUE(
             // TODO: investigate the type of this. It is possibly the parameter
             // of a compiler generated copy constructor or assignment operator.
@@ -653,10 +654,13 @@ TEST_F(CppParserTest, Variable)
     astNodes = _db->query<model::CppAstNode>(
       QCppAstNode::entityHash == memberVariable.entityHash);
 
+    using LineType =
+        decltype(std::declval<model::CppAstNode>().location.range.start.line);
     for (const model::CppAstNode& n : astNodes)
       switch (n.location.range.start.line)
       {
-        case -1: // Access by compiler generated constructors.
+        case static_cast<LineType>(-1):
+          // Access by compiler generated constructors.
         case 44: // Simple access for read.
           EXPECT_EQ(n.astType, model::CppAstNode::AstType::Read);
           break;

--- a/webserver/src/mainrequesthandler.h
+++ b/webserver/src/mainrequesthandler.h
@@ -12,7 +12,7 @@ namespace webserver
 class Session;
 class SessionManager;
 
-struct MainRequestHandler
+class MainRequestHandler
 {
 public:
   SessionManager* sessionManager;
@@ -30,7 +30,7 @@ private:
   template <typename F>
   auto executeWithSessionContext(cc::webserver::Session* sess_, F func);
 };
-  
+
 } // webserver
 } // cc
 


### PR DESCRIPTION
When trying to compile CodeCompass with LibTooling built on top of Clang 13.0, some warnings were emitted that broke the build. This patch fixes these.

 - `-Wc++11-narrowing`
 - `-Wmismatched-tags`
 - `-Wrange-loop-construct`