### PR TITLE
fix: (NFC) Remove stale self-referential `#include`

### DIFF
--- a/parser/include/parser/pluginhandler.h
+++ b/parser/include/parser/pluginhandler.h
@@ -6,7 +6,6 @@
 #include <map>
 #include <vector>
 
-#include <parser/pluginhandler.h>
 #include <parser/abstractparser.h>
 #include <util/dynamiclibrary.h>
 


### PR DESCRIPTION
While not inherently a problem when it comes to compiling with standard C++ tools, when executing a research effort to create C++20 Modules out of CodeCompass, a tool I've hand-crafted ran into an issue by detecting the self-loop via this include.