### PR TITLE
Finding CodeCompass binary path

### DIFF
--- a/util/include/util/filesystem.h
+++ b/util/include/util/filesystem.h
@@ -16,6 +16,12 @@ namespace util
  */
 std::string binaryPathToInstallDir(const char* path);
 
+/**
+ * @brief Find the directory where a CodeCompass binary is being run from.
+ * @return The absolute path of the directory where the binary is located.
+ */
+std::string findCurrentExecutableDir();
+
 } // namespace util
 } // namespace cc
 

--- a/util/src/filesystem.cpp
+++ b/util/src/filesystem.cpp
@@ -1,4 +1,6 @@
 #include <cstdlib>
+#include <climits>
+#include <unistd.h>
 
 #include <boost/filesystem.hpp>
 
@@ -48,6 +50,18 @@ std::string binaryPathToInstallDir(const char* path)
   }
 
   throw std::runtime_error(std::string("Could not find ") + path + std::string("."));
+}
+
+std::string findCurrentExecutableDir()
+{
+  char exePath[PATH_MAX];
+  ssize_t len = ::readlink("/proc/self/exe", exePath, sizeof(exePath));
+
+  if (len == -1 || len == sizeof(exePath))
+    len = 0;
+
+  exePath[len] = '\0';
+  return fs::path(exePath).parent_path().string();
 }
 
 } // namespace util


### PR DESCRIPTION
Multiple plugins need to know the absolute path of the CodeCompass binary that is being run, in places where they don't reach `argv[0]`.