### PR TITLE
Upgrading to build2 0.15.0.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,8 +103,8 @@ jobs:
           cd $HOME
           mkdir /tmp/build2src
           cd /tmp/build2src
-          curl -sSfO https://download.build2.org/0.14.0/build2-install-0.14.0.sh
-          sh build2-install-0.14.0.sh --yes --trust yes "$HOME/build2_install/"
+          curl -sSfO https://download.build2.org/0.15.0/build2-install-0.15.0.sh
+          sh build2-install-0.15.0.sh --yes --trust yes "$HOME/build2_install/"
           export PATH=$PATH:$HOME/build2_install/bin/
           mkdir /tmp/odb_build
           cd /tmp/odb_build

--- a/.gitlab/build-deps.sh
+++ b/.gitlab/build-deps.sh
@@ -137,8 +137,8 @@ if [ ! -f $DEPS_INSTALL_RUNTIME_DIR/odb-install/bin/odb ]; then
   if [[ $ODB_VERSION == "2.5.0" ]]; then
     # build2
     cd $PACKAGES_DIR
-    wget --no-verbose --no-clobber https://download.build2.org/0.14.0/build2-install-0.14.0.sh
-    sh build2-install-0.14.0.sh --yes --trust yes --jobs $(nproc) $PACKAGES_DIR/build2-install
+    wget --no-verbose --no-clobber https://download.build2.org/0.15.0/build2-install-0.15.0.sh
+    sh build2-install-0.15.0.sh --yes --trust yes --jobs $(nproc) $PACKAGES_DIR/build2-install
     export PATH=$PACKAGES_DIR/build2-install/bin:$PATH
 
     # odb, libodb
@@ -160,7 +160,7 @@ if [ ! -f $DEPS_INSTALL_RUNTIME_DIR/odb-install/bin/odb ]; then
     bpkg build libodb-pgsql --yes --quiet --jobs $(nproc)
     bpkg install --all --recursive --quiet --jobs $(nproc)
 
-    rm -f $PACKAGES_DIR/build2-toolchain-0.14.0.tar.xz
+    rm -f $PACKAGES_DIR/build2-toolchain-0.15.0.tar.xz
   elif [[ $ODB_VERSION == "2.4.0" ]]; then
     # odb
     cd $PACKAGES_DIR

--- a/doc/deps.md
+++ b/doc/deps.md
@@ -116,8 +116,8 @@ The ODB installation uses the build2 build system. (Build2 is not needed for
 CodeCompass so you may delete it right after the installation of ODB.)
 
 ```bash
-wget https://download.build2.org/0.14.0/build2-install-0.14.0.sh
-sh build2-install-0.14.0.sh --yes --trust yes "<build2_install_dir>"
+wget https://download.build2.org/0.15.0/build2-install-0.15.0.sh
+sh build2-install-0.15.0.sh --yes --trust yes "<build2_install_dir>"
 ```
 
 Now, utilizing the *Build2* toolchain, we can build the *ODB* compiler and


### PR DESCRIPTION
Build2 v0.14.0 is no longer working in the GitHub workflow ("invalid version error"), so the build actions fail on Ubuntu 18.04. I upgraded it to 0.15.0.