### PR TITLE
Reducing the number of db connections at runtime

### DIFF
--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories(
 include_directories(SYSTEM
   ${ODB_INCLUDE_DIRS})
 
-add_library(util STATIC
+add_library(util SHARED
   src/dbutil.cpp
   src/dynamiclibrary.cpp
   src/filesystem.cpp
@@ -17,9 +17,8 @@ add_library(util STATIC
   src/pipedprocess.cpp
   src/util.cpp)
 
-target_compile_options(util PUBLIC -fPIC)
-
 target_link_libraries(util
+  gvc
   ${Boost_LIBRARIES})
 
 string(TOLOWER "${DATABASE}" _database)
@@ -27,3 +26,5 @@ if (${_database} STREQUAL "sqlite")
   target_link_libraries(util
     sqlite3)
 endif()
+
+install(TARGETS util DESTINATION ${INSTALL_LIB_DIR})


### PR DESCRIPTION
In this PR I made the `util` library shared instead of static. This way each parsed project shall open one connection to the database at webserver runtime instead of each plugin opening its own connection per project.

@mcserep thank you for your help with this.

Fixes #485.