### PR TITLE
Update PostgreSQL user permission in Usage Guide

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -38,7 +38,7 @@ psql
 In the PostgreSQL command-line shell, type:
 
 ```sql
-CREATE USER compass WITH SUPERUSER LOGIN PASSWORD '<mypassword>';
+CREATE USER compass WITH CREATEDB LOGIN PASSWORD '<mypassword>';
 ```
 
 You can exit this shell by typing `\q` and pressing the `ENTER` key. A user
@@ -47,9 +47,9 @@ with the given name and credentials is now created.
 This was the most basic way to set up access to the database. In case of a live,
 production, public server, certain other measures need to be taken to ensure
 secure access. For full documentation, see:
-- Read more about the [`CREATE USER`](https://www.postgresql.org/docs/9.5/static/sql-createuser.html)
+- Read more about the [`CREATE USER`](https://www.postgresql.org/docs/12/sql-createuser.html)
   command.
-- [PostgreSQL access configuration file](https://www.postgresql.org/docs/9.5/static/auth-pg-hba-conf.html)
+- [PostgreSQL access configuration file](https://www.postgresql.org/docs/12/auth-pg-hba-conf.html)
 
 The databases inside PostgreSQL instance will be created automatically by the
 CodeCompass parser, so the user needs rights for adding new database.
@@ -70,9 +70,9 @@ A manually started PostgreSQL server is automatically configured to your user,
 and your user only. No extra user creation or configuration needs to take place.
 
 For full documentation see:
-- [Initialize PostgreSQL database](https://www.postgresql.org/docs/9.5/static/app-initdb.html)
+- [Initialize PostgreSQL database](https://www.postgresql.org/docs/12/app-initdb.html)
   (`-E SQL_ASCII` flag is recommended!)
-- [Start PostgreSQL database](https://www.postgresql.org/docs/9.5/static/app-postgres.html)
+- [Start PostgreSQL database](https://www.postgresql.org/docs/12/app-postgres.html)
 
 ## 1. Generate compilation database
 If you want to parse a C++ project, you have to create a [compilation database


### PR DESCRIPTION
CodeCompass does not require `SUPERUSER` privileges in PostgreSQL, only `CREATEDB`.

Also updating documentation links to more up to date version (`9.5` -> `12`).