### PR TITLE
Upgrade NodeJS and NPM for tarball build

### DIFF
--- a/.gitlab/build-deps.sh
+++ b/.gitlab/build-deps.sh
@@ -377,12 +377,12 @@ rm -f $PACKAGES_DIR/release-1.10.0.tar.gz
 #######
 
 cd $PACKAGES_DIR
-wget --no-verbose --no-clobber https://nodejs.org/dist/v14.15.0/node-v14.15.0-linux-x64.tar.xz
-tar -xf node-v14.15.0-linux-x64.tar.xz -C $DEPS_INSTALL_RUNTIME_DIR
-rm -f node-v14.15.0-linux-x64.tar.xz
+wget --no-verbose --no-clobber https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.xz
+tar -xf node-v16.20.2-linux-x64.tar.xz -C $DEPS_INSTALL_RUNTIME_DIR
+rm -f node-v16.20.2-linux-x64.tar.xz
 
 cd $DEPS_INSTALL_RUNTIME_DIR
-mv node-v14.15.0-linux-x64 node-install
+mv node-v16.20.2-linux-x64 node-install
 export PATH=$DEPS_INSTALL_RUNTIME_DIR/node-install/bin:$PATH
 
 ############


### PR DESCRIPTION
The new web GUI officially requires NodeJS v18+, while in the Ubuntu 16.04 based tarball build script we have NodeJS 14 installed, which fails.

Unfortunately NodeJS v18 is not compatible with Ubuntu 16.04. (GLIBC mismatch error.)
This PR upgrade NodeJS from v14 to v16 and NPM from v6 to v8 in tarball CI build script and hopefully this will be enough.

@mdeme01 Do we really need NodeJS v18 for the new frontend to build, or was it specified simply as the current LTS version?

@intjftw, @zporky Do we still need these legacy tarball builds in Ericsson?