### PR TITLE
Fix Google Analytics usage on login page

### DIFF
--- a/webserver/src/mainrequesthandler.cpp
+++ b/webserver/src/mainrequesthandler.cpp
@@ -15,7 +15,8 @@ static bool isProtected(const char* uri_)
     "style/",      // Resource directory - contains no secret.
     "userguide/",  // Resource directory - contains no secret.
     "favicon.ico", // Resource - contains no secret.
-    "login.html"   // Allow to handle web browser auth.
+    "login.html",  // Allow to handle web browser auth.
+    "ga.txt"       // Google Analytics tracking ID.
   };
 
   // Swallow the leading '/' of the URI.


### PR DESCRIPTION
The login page tries to use Google Analytics, however `ga.txt`, containing the tracking ID is protected.

This PR makes that path unprotected.