### PR TITLE
LLVM 11 migration

### DIFF
--- a/.github/scripts/setup_build_ubuntu-20.04.sh
+++ b/.github/scripts/setup_build_ubuntu-20.04.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 # Install required packages for CodeCompass build
-sudo apt-get install -y git cmake make g++ libboost-all-dev llvm-10-dev clang-10 \
-  libclang-10-dev odb libodb-dev thrift-compiler libthrift-dev default-jdk libssl-dev \
+sudo apt-get install -y git cmake make g++ libboost-all-dev llvm-11-dev clang-11 \
+  libclang-11-dev odb libodb-dev thrift-compiler libthrift-dev default-jdk libssl-dev \
   libgraphviz-dev libmagic-dev libgit2-dev ctags doxygen libgtest-dev npm libldap2-dev

--- a/.github/scripts/setup_runtime_ubuntu-20.04.sh
+++ b/.github/scripts/setup_runtime_ubuntu-20.04.sh
@@ -3,5 +3,5 @@
 # Install required packages for CodeCompass runtime
 sudo apt-get install -y git cmake make g++ graphviz \
   libboost-filesystem1.71.0 libboost-log1.71.0 libboost-program-options1.71.0 \
-  libllvm10 clang-10 libclang1-10 libthrift-0.13.0 default-jre libssl1.1 libmagic1 \
+  libllvm11 clang-11 libclang1-11 libthrift-0.13.0 default-jre libssl1.1 libmagic1 \
   libgit2-28 ctags googletest libldap-2.4-2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,8 @@ jobs:
           -DCMAKE_INSTALL_PREFIX=$HOME/${{ matrix.os }}/${{ matrix.db }}/cc-install
           -DDATABASE=$DB_TYPE
           -DCMAKE_BUILD_TYPE=$BUILD_TYPE
-          -DLLVM_DIR=/usr/lib/llvm-10/cmake
-          -DClang_DIR=/usr/lib/cmake/clang-10
+          -DLLVM_DIR=/usr/lib/llvm-11/cmake
+          -DClang_DIR=/usr/lib/cmake/clang-11
           -DTEST_DB=$DB_CONNSTRING
 
       - name: Build

--- a/.gitlab/build-deps.sh
+++ b/.gitlab/build-deps.sh
@@ -254,9 +254,9 @@ export PATH=$DEPS_INSTALL_RUNTIME_DIR/python-install/bin:$PATH
 
 if [ ! -f $DEPS_INSTALL_RUNTIME_DIR/llvm-install/bin/clang ]; then
   cd $PACKAGES_DIR
-  wget --no-verbose --no-clobber https://github.com/llvm/llvm-project/archive/llvmorg-10.0.1.tar.gz
-  tar -xf llvmorg-10.0.1.tar.gz
-  mv llvm-project-llvmorg-10.0.1 llvm-project
+  wget --no-verbose --no-clobber https://github.com/llvm/llvm-project/archive/llvmorg-11.1.0.tar.gz
+  tar -xf llvmorg-11.1.0.tar.gz
+  mv llvm-project-llvmorg-11.1.0 llvm-project
   mkdir llvm-project/build
   cd llvm-project/build
 
@@ -268,7 +268,7 @@ if [ ! -f $DEPS_INSTALL_RUNTIME_DIR/llvm-install/bin/clang ]; then
     -DLLVM_ENABLE_RTTI=ON
 
   make install --quiet --jobs $(nproc)
-  rm -f $PACKAGES_DIR/llvmorg-10.0.1.tar.gz
+  rm -f $PACKAGES_DIR/llvmorg-11.1.0.tar.gz
 else
   echo "Found LLVM/Clang in cache."
 fi

--- a/doc/deps.md
+++ b/doc/deps.md
@@ -15,7 +15,7 @@ be installed from the official repository of the given Linux distribution.
   is required. (Alternatively, you can compile with Clang.)
 - **`gcc-X`, `gcc-X-plugin-dev`**: For building ODB.
 - **`libboost-all-dev`**: Boost can be used during the development.
-- **`llvm-10-dev`**, **`clang-10`**, **`libclang-10-dev`**: C++ parser uses
+- **`llvm-11-dev`**, **`clang-11`**, **`libclang-11-dev`**: C++ parser uses
   LLVM/Clang for parsing the source code.
 - **`odb`**, **`libodb-dev`**: For persistence ODB can be used which is an
   Object Relation Mapping (ORM) system.
@@ -59,10 +59,20 @@ sudo apt install git cmake make g++ gcc-7-plugin-dev libboost-all-dev \
 
 ```bash
 sudo apt install git cmake make g++ libboost-all-dev \
-  llvm-10-dev clang-10 libclang-10-dev \
+  llvm-11-dev clang-11 libclang-11-dev \
   odb libodb-dev thrift-compiler libthrift-dev \
   default-jdk libssl-dev libgraphviz-dev libmagic-dev libgit2-dev ctags doxygen \
   libldap2-dev libgtest-dev npm
+```
+
+#### Ubuntu 22.04 ("Jammy Jellyfish") LTS
+
+```bash
+sudo apt install git curl wget cmake make libboost-all-dev \
+  g++ gcc-11-plugin-dev \
+  llvm-11-dev clang-11 libclang-11-dev \
+  default-jdk libssl-dev libgraphviz-dev libmagic-dev libgit2-dev exuberant-ctags doxygen \
+  libldap2-dev libgtest-dev
 ```
 
 #### Database engine support
@@ -94,6 +104,15 @@ sudo apt install libodb-sqlite-dev libsqlite3-dev
 sudo apt install libodb-pgsql-dev postgresql-server-dev-<version>
 ```
 
+##### Ubuntu 22.04 ("Jammy Jellyfish") LTS
+
+```bash
+# For SQLite database systems:
+sudo apt install libsqlite3-dev
+
+# For PostgreSQL database systems:
+sudo apt install postgresql-server-dev-14
+```
 
 ## Known issues
 Some third-party tools are present in the distribution's package manager in a
@@ -106,7 +125,7 @@ by other processes which could, in extreme cases, make the system very hard or
 impossible to recover. **Please do NOT add a `sudo` in front of any `make` or
 other commands below, unless *explicitly* specified!**
 
-### ODB (for Ubuntu 18.04)
+### ODB (for Ubuntu 18.04, Ubuntu 22.04)
 ODB is an Object Relational Mapping tool, that is required by CodeCompass.
 For Ubuntu 18.04, the official release of ODB conflicts with the official
 compiler (GNU G++ 7) of the distribution. A newer version of ODB must be
@@ -153,7 +172,7 @@ time (depending on the machine one is using).
 > **Note:** now you may delete the *Build2* toolchain installed in the
 > `<build2_install_dir>` folder, if you do not need any longer.
 
-### Thrift (for Ubuntu 18.04)
+### Thrift (for Ubuntu 18.04, Ubuntu 22.04)
 CodeCompass needs [Thrift](https://thrift.apache.org/) which provides Remote
 Procedure Call (RPC) between the server and the client. A suitable version of
 Thrift is, unfortunately, not part of the official Ubuntu repositories for
@@ -215,7 +234,7 @@ seen by CMake. Please set this environment before executing the build.
 ```bash
 export GTEST_ROOT=<gtest_install_dir>
 
-# If using Ubuntu 18.04:
+# If using Ubuntu 18.04 or Ubuntu 22.04:
 export CMAKE_PREFIX_PATH=<thrift_install_dir>:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=<odb_install_directory>:$CMAKE_PREFIX_PATH
 
@@ -239,8 +258,8 @@ cmake .. \
   -DCMAKE_INSTALL_PREFIX=<CodeCompass_install_dir> \
   -DDATABASE=<database_type> \
   -DCMAKE_BUILD_TYPE=<build_type> \
-  -DLLVM_DIR=/usr/lib/llvm-10/cmake \
-  -DClang_DIR=/usr/lib/cmake/clang-10
+  -DLLVM_DIR=/usr/lib/llvm-11/cmake \
+  -DClang_DIR=/usr/lib/cmake/clang-11
 
 # To specify linker for building CodeCompass use
 #   -DCODECOMPASS_LINKER=<path_to_linker>

--- a/plugins/cpp/model/include/model/cppfriendship.h
+++ b/plugins/cpp/model/include/model/cppfriendship.h
@@ -2,6 +2,8 @@
 #define CC_MODEL_CPPFRIENDSHIP_H
 
 #include <memory>
+#include <cstdint>
+#include <string>
 
 namespace cc
 {

--- a/plugins/cpp/model/include/model/cpprelation.h
+++ b/plugins/cpp/model/include/model/cpprelation.h
@@ -2,6 +2,8 @@
 #define CC_MODEL_CPPRELATION_H
 
 #include <memory>
+#include <cstdint>
+#include <string>
 
 namespace cc
 {

--- a/plugins/cpp/parser/include/cppparser/filelocutil.h
+++ b/plugins/cpp/parser/include/cppparser/filelocutil.h
@@ -95,7 +95,7 @@ public:
     if (!fileEntry)
       return std::string();
 
-    return fileEntry->getName();
+    return std::string(fileEntry->getName());
   }
 
 private:

--- a/plugins/cpp/parser/src/clangastvisitor.h
+++ b/plugins/cpp/parser/src/clangastvisitor.h
@@ -10,6 +10,7 @@
 #include <clang/Basic/SourceManager.h>
 #include <clang/AST/Decl.h>
 #include <clang/AST/RecursiveASTVisitor.h>
+#include <clang/AST/ParentMapContext.h>
 #include <llvm/Support/raw_ostream.h>
 
 #include <model/cppastnode.h>
@@ -1385,7 +1386,7 @@ private:
   {
     while (expr_)
     {
-      clang::ASTContext::DynTypedNodeList parents
+      clang::DynTypedNodeList parents
         = _astContext.getParents(*expr_);
 
       const clang::ast_type_traits::DynTypedNode& parent = parents[0];

--- a/plugins/cpp_reparse/service/src/asthtml.cpp
+++ b/plugins/cpp_reparse/service/src/asthtml.cpp
@@ -192,13 +192,14 @@ public:
   {
     if (_locator.matchNodeAgainstLocation(s_))
     {
-      s_->dump(*_out, _context.getSourceManager());
+      s_->dump(*_out, _context);
       return true;
     }
     return Base::TraverseStmt(s_);
   }
 
 private:
+
   std::unique_ptr<raw_ostream> _out;
   ASTContext& _context;
   cc::service::reparse::ASTNodeLocator _locator;
@@ -221,7 +222,7 @@ std::unique_ptr<clang::ASTConsumer> ASTHTMLActionFactory::newASTConsumer()
   assert(_stream && "Must not call newASTConsumer twice as the underlying "
     "stream has been moved out.");
   return clang::CreateASTDumper(std::move(_stream), "",
-                                true, true, false, clang::ADOF_Default);
+                                true, true, false, false, clang::ADOF_Default);
 }
 
 std::unique_ptr<clang::ASTConsumer>

--- a/webserver/src/threadedmongoose.h
+++ b/webserver/src/threadedmongoose.h
@@ -8,6 +8,7 @@
 #include <thread>
 #include <vector>
 #include <signal.h>
+#include <stdexcept>
 
 #include <webserver/mongoose.h>
 


### PR DESCRIPTION
- Updated source code to support LLVM 11

In `clang::CreateASTDumper` function `DumpDeclTypes` seems new functionality, thus it was changed to `false`.
See:
https://github.com/llvm/llvm-project/blob/llvmorg-11.1.0/clang/lib/Frontend/ASTConsumers.cpp#L98
https://github.com/llvm/llvm-project/blob/llvmorg-10.0.0/clang/lib/Frontend/ASTConsumers.cpp#L81

- Added missing headers for g++-11 (default g++ on Ubuntu 22.04)
- Updated documentation

