### PR TITLE
Workspace and root files are now ordered by name.

### DIFF
--- a/service/project/src/projectservice.cpp
+++ b/service/project/src/projectservice.cpp
@@ -124,6 +124,8 @@ void ProjectServiceHandler::getRootFiles(std::vector<FileInfo>& return_)
       return_.push_back(makeFileInfo(f));
     }
   });
+
+  std::sort(return_.begin(), return_.end(), fileInfoOrder);
 }
 
 void ProjectServiceHandler::getChildFiles(

--- a/service/workspace/include/workspaceservice/workspaceservice.h
+++ b/service/workspace/include/workspaceservice/workspaceservice.h
@@ -18,6 +18,11 @@ public:
   void getWorkspaces(std::vector<WorkspaceInfo>& _return) override;
 
 private:
+  /**
+   * This function defines an ordering between WorkspaceInfo objects by name.
+   */
+  static bool workspaceInfoOrder(const WorkspaceInfo& left, const WorkspaceInfo& right);
+
   std::string _workspace;
 };
 

--- a/service/workspace/src/workspaceservice.cpp
+++ b/service/workspace/src/workspaceservice.cpp
@@ -13,7 +13,7 @@ WorkspaceServiceHandler::WorkspaceServiceHandler(const std::string& workspace_)
 {
 }
 
-void WorkspaceServiceHandler::getWorkspaces(std::vector<WorkspaceInfo>& _return)
+void WorkspaceServiceHandler::getWorkspaces(std::vector<WorkspaceInfo>& return_)
 {
   namespace fs = boost::filesystem;
 
@@ -35,8 +35,17 @@ void WorkspaceServiceHandler::getWorkspaces(std::vector<WorkspaceInfo>& _return)
     info.id = filename;
     info.description = filename;
 
-    _return.push_back(std::move(info));
+    return_.push_back(std::move(info));
   }
+
+  std::sort(return_.begin(), return_.end(), workspaceInfoOrder);
+}
+
+bool WorkspaceServiceHandler::workspaceInfoOrder(
+  const WorkspaceInfo& left_,
+  const WorkspaceInfo& right_)
+{
+  return left_.id < right_.id;
 }
 
 } // workspace


### PR DESCRIPTION
The issue originally mentions only workspaces not being in the correct order. But I noticed that root files in the file browser pane were also not ordered, and the fix is very similar in both cases (missing std::sort).

Fixes #626.