### PR TITLE
Google analytics integration in the new webgui

### DIFF
--- a/webgui-new/next.config.js
+++ b/webgui-new/next.config.js
@@ -15,14 +15,6 @@ const nextConfig = {
     assetPrefix: `${process.env.PUBLIC_URL || ''}/new`,
     basePath: `${process.env.PUBLIC_URL || ''}/new`,
   }),
-  async rewrites() {
-    return [
-      {
-        source: '/ga.txt',
-        destination: `${process.env.BACKEND_URL}/ga.txt`,
-      },
-    ];
-  },
 };
 
 module.exports = nextConfig;

--- a/webgui-new/next.config.js
+++ b/webgui-new/next.config.js
@@ -15,6 +15,14 @@ const nextConfig = {
     assetPrefix: `${process.env.PUBLIC_URL || ''}/new`,
     basePath: `${process.env.PUBLIC_URL || ''}/new`,
   }),
+  async rewrites() {
+    return [
+      {
+        source: '/ga.txt',
+        destination: `${process.env.BACKEND_URL}/ga.txt`,
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;

--- a/webgui-new/package-lock.json
+++ b/webgui-new/package-lock.json
@@ -24,6 +24,7 @@
         "react": "^18.2.0",
         "react-diff-viewer-continued": "^3.2.6",
         "react-dom": "^18.2.0",
+        "react-ga4": "^2.1.0",
         "react-i18next": "^13.0.1",
         "react-icons": "^4.8.0",
         "react-toastify": "^9.1.2",
@@ -5983,6 +5984,11 @@
       "peerDependencies": {
         "react": "^18.2.0"
       }
+    },
+    "node_modules/react-ga4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-2.1.0.tgz",
+      "integrity": "sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ=="
     },
     "node_modules/react-i18next": {
       "version": "13.2.2",

--- a/webgui-new/package.json
+++ b/webgui-new/package.json
@@ -45,6 +45,7 @@
     "react": "^18.2.0",
     "react-diff-viewer-continued": "^3.2.6",
     "react-dom": "^18.2.0",
+    "react-ga4": "^2.1.0",
     "react-i18next": "^13.0.1",
     "react-icons": "^4.8.0",
     "react-toastify": "^9.1.2",

--- a/webgui-new/src/components/codebites/codebites-node.tsx
+++ b/webgui-new/src/components/codebites/codebites-node.tsx
@@ -18,6 +18,7 @@ import { IconButton, Tooltip } from '@mui/material';
 import { Close } from '@mui/icons-material';
 import { AppContext } from 'global-context/app-context';
 import dagre from 'dagre';
+import { sendGAEvent } from 'utils/analytics';
 
 type CodeBitesElement = {
   astNodeInfo: AstNodeInfo;
@@ -94,6 +95,7 @@ class CustomOffsetGutterMarker extends GutterMarker {
 
 export const CodeBitesNode = ({ data }: NodeProps<DataProps>): JSX.Element => {
   const { diagramGenId: initialNodeId } = useContext(AppContext);
+  const appCtx = useContext(AppContext);
   const { theme } = useContext(ThemeContext);
 
   const [fileInfo, setFileInfo] = useState<FileInfo | undefined>(undefined);
@@ -108,11 +110,16 @@ export const CodeBitesNode = ({ data }: NodeProps<DataProps>): JSX.Element => {
     const init = async () => {
       const initFileInfo = await getFileInfo(data.astNodeInfo.range?.file as string);
       const initText = await getCppSourceText(data.astNodeInfo.id as string);
+      sendGAEvent({
+        event_action: 'code_bites',
+        event_category: appCtx.workspaceId,
+        event_label: `${initFileInfo?.name}: ${initText}`,
+      });
       setFileInfo(initFileInfo);
       setText(initText);
     };
     init();
-  }, [data.astNodeInfo]);
+  }, [appCtx.workspaceId, data.astNodeInfo]);
 
   const handleClick = async () => {
     if (!editorRef.current) return;

--- a/webgui-new/src/components/codemirror-editor/codemirror-editor.tsx
+++ b/webgui-new/src/components/codemirror-editor/codemirror-editor.tsx
@@ -18,6 +18,7 @@ import { RouterQueryType } from 'utils/types';
 import { Tooltip, alpha } from '@mui/material';
 import * as SC from './styled-components';
 import { useTranslation } from 'react-i18next';
+import { sendGAEvent } from 'utils/analytics';
 
 export const CodeMirrorEditor = (): JSX.Element => {
   const { t } = useTranslation();
@@ -111,6 +112,11 @@ export const CodeMirrorEditor = (): JSX.Element => {
         ? null
         : await getCppAstNodeInfoByPosition(fileInfo?.id as string, line.number, column);
     if (astNodeInfo) {
+      sendGAEvent({
+        event_action: 'click_on_word',
+        event_category: appCtx.workspaceId,
+        event_label: `${fileInfo?.name}: ${astNodeInfo.astNodeValue}`,
+      });
       dispatchSelection(astNodeInfo?.range?.range as Range);
       router.push({
         pathname: '/project',
@@ -131,6 +137,11 @@ export const CodeMirrorEditor = (): JSX.Element => {
           line: line.number,
           column: line.length + 1,
         }),
+      });
+      sendGAEvent({
+        event_action: 'click_on_word',
+        event_category: appCtx.workspaceId,
+        event_label: `${fileInfo?.name}: ${convertSelectionRangeToString(range)}`,
       });
       dispatchSelection(range);
       router.push({

--- a/webgui-new/src/components/cookie-notice/cookie-notice.tsx
+++ b/webgui-new/src/components/cookie-notice/cookie-notice.tsx
@@ -1,0 +1,181 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { getStore, setStore } from 'utils/store';
+import ReactGA from 'react-ga4';
+import {
+  Paper,
+  Typography,
+  Button,
+  IconButton,
+  Snackbar,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TableContainer,
+  TableRow,
+  TableCell,
+  Table,
+  TableHead,
+  TableBody,
+  Link,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import { useRouter } from 'next/router';
+
+export const CookieNotice = (): JSX.Element => {
+  const { t } = useTranslation();
+  const router = useRouter();
+  const [isCookieConsent, setIsCookieConsent] = useState<boolean | undefined>(undefined);
+  const [gaTrackingCode, setGaTrackingCode] = useState<string | undefined>(undefined);
+  const [openPolicyModal, setOpenPolicyModal] = useState(false);
+  const [showNoticeSnackbar, setShowNoticeSnackbar] = useState(true);
+
+  useEffect(() => {
+    const fetchGaTrackingCode = async () => {
+      try {
+        const res = await fetch(`/ga.txt`);
+        const gaCode = await res.text();
+        setGaTrackingCode(gaCode);
+      } catch (e) {
+        setGaTrackingCode(undefined);
+      }
+      const store = getStore();
+      setIsCookieConsent(store.storedCookieConsent);
+    };
+    fetchGaTrackingCode();
+  }, []);
+
+  useEffect(() => {
+    if (!isCookieConsent || !gaTrackingCode) {
+      ReactGA.reset();
+      return;
+    }
+    if (!ReactGA.isInitialized) {
+      ReactGA.initialize(gaTrackingCode);
+      console.log(`Google Analytics initialized - ${gaTrackingCode}`);
+    }
+
+    const handleRouteChange = (url: string) => {
+      ReactGA.send({ hitType: 'pageview', page: url, title: window.document.title });
+    };
+    router.events.on('routeChangeComplete', handleRouteChange);
+
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange);
+    };
+  }, [isCookieConsent, gaTrackingCode, router.events]);
+
+  const handleCookieAccept = () => {
+    setIsCookieConsent(true);
+    setShowNoticeSnackbar(false);
+    setStore({ storedCookieConsent: true });
+  };
+
+  if (!isCookieConsent && gaTrackingCode)
+    return (
+      <>
+        <Snackbar
+          open={showNoticeSnackbar}
+          autoHideDuration={null}
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        >
+          <Paper
+            sx={{
+              p: 2,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+            }}
+          >
+            <Typography variant="body2">
+              {t('cookie.INTRO_TEXT')}
+              <Button color="primary" size="small" onClick={() => setOpenPolicyModal(true)}>
+                {t('cookie.LEARN_MORE')}
+              </Button>
+            </Typography>
+            <Button
+              color="primary"
+              size="small"
+              variant="contained"
+              onClick={() => {
+                handleCookieAccept();
+              }}
+            >
+              {t('cookie.ACCEPT')}
+            </Button>
+            <IconButton
+              size="small"
+              color="inherit"
+              sx={{ ml: 2 }}
+              onClick={() => setShowNoticeSnackbar(false)}
+            >
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </Paper>
+        </Snackbar>
+        <Dialog open={openPolicyModal} maxWidth="lg" onClose={() => setOpenPolicyModal(false)}>
+          <DialogTitle>{t('cookiePolicy.TITLE')}</DialogTitle>
+          <DialogContent>
+            <>
+              <Typography sx={{ marginBottom: '0.8rem' }} variant="body1">
+                {t('cookiePolicy.sections.cookies.WHAT_COOKIES')}
+              </Typography>
+              <Typography sx={{ marginBottom: '0.8rem' }} variant="body2">
+                {t('cookiePolicy.sections.cookies.WHAT_COOKIES_DESCRIPTION')}
+              </Typography>
+              <Typography sx={{ marginBottom: '0.8rem' }} variant="body1">
+                {t('cookiePolicy.sections.cookies.HOW_USE_TITLE')}
+              </Typography>
+              <TableContainer component={Paper} sx={{ marginBottom: '0.8rem' }}>
+                <Table sx={{ minWidth: 650 }} aria-label="cookie-table">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>{t('cookiePolicy.sections.cookies.SERVICE')}</TableCell>
+                      <TableCell>{t('cookiePolicy.sections.cookies.COOKIE_NAMES')}</TableCell>
+                      <TableCell>{t('cookiePolicy.sections.cookies.DURATION')}</TableCell>
+                      <TableCell>{t('cookiePolicy.sections.cookies.PURPOSE')}</TableCell>
+                      <TableCell>{t('cookiePolicy.sections.cookies.MORE_INFORMATION')}</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    <TableRow key={1} sx={{ '&:last-child td, &:last-child th': { border: 0 } }}>
+                      <TableCell component="th" scope="row">
+                        <b>{t('cookiePolicy.sections.cookies.googleAnalytics.SERVICE')}</b>
+                      </TableCell>
+                      <TableCell>
+                        <b>{t('cookiePolicy.sections.cookies.googleAnalytics.COOKIE_NAMES')}</b>
+                      </TableCell>
+                      <TableCell>
+                        <b>{t('cookiePolicy.sections.cookies.googleAnalytics.DURATION')}</b>
+                      </TableCell>
+                      <TableCell>
+                        <b>{t('cookiePolicy.sections.cookies.googleAnalytics.PURPOSE')}</b>
+                      </TableCell>
+                      <TableCell>
+                        <Link
+                          target="_blank"
+                          rel="noreferrer"
+                          href={t('cookiePolicy.sections.cookies.googleAnalytics.MORE_INFORMATION')}
+                        >
+                          <b>{t('cookiePolicy.sections.cookies.MORE_INFORMATION')}</b>
+                        </Link>
+                      </TableCell>
+                    </TableRow>
+                  </TableBody>
+                </Table>
+              </TableContainer>
+              <Typography variant="body2">
+                {t('cookiePolicy.sections.cookies.CONCLUSION')}
+              </Typography>
+            </>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setOpenPolicyModal(false)} color="primary"></Button>
+          </DialogActions>
+        </Dialog>
+      </>
+    );
+
+  return <></>;
+};

--- a/webgui-new/src/components/cookie-notice/cookie-notice.tsx
+++ b/webgui-new/src/components/cookie-notice/cookie-notice.tsx
@@ -35,9 +35,14 @@ export const CookieNotice = (): JSX.Element => {
     const fetchGaTrackingCode = async () => {
       try {
         const res = await fetch(`/ga.txt`);
+        if (res.status !== 200) {
+          setGaTrackingCode(undefined);
+          return;
+        }
         const gaCode = await res.text();
         setGaTrackingCode(gaCode);
       } catch (e) {
+        // network-related error
         setGaTrackingCode(undefined);
       }
       const store = getStore();

--- a/webgui-new/src/components/diagrams/diagrams.tsx
+++ b/webgui-new/src/components/diagrams/diagrams.tsx
@@ -21,6 +21,7 @@ import { convertSelectionRangeToString } from 'utils/utils';
 import { useRouter } from 'next/router';
 import { RouterQueryType } from 'utils/types';
 import { useTranslation } from 'react-i18next';
+import { sendGAEvent } from 'utils/analytics';
 
 export const Diagrams = (): JSX.Element => {
   const { t } = useTranslation();
@@ -67,7 +68,18 @@ export const Diagrams = (): JSX.Element => {
           : initDiagramInfo instanceof AstNodeInfo
           ? await getCppDiagram(appCtx.diagramGenId, parseInt(appCtx.diagramTypeId))
           : '';
-
+      
+      sendGAEvent({
+        event_action: `load_diagram: ${appCtx.diagramTypeId}`,
+        event_category: appCtx.workspaceId,
+        event_label:
+          initDiagramInfo instanceof FileInfo
+            ? initDiagramInfo.name
+            : initDiagramInfo instanceof AstNodeInfo
+            ? initDiagramInfo.astNodeValue
+            : '',
+      });
+      
       const parser = new DOMParser();
       const parsedDiagram = parser.parseFromString(diagram, 'text/xml');
       const diagramSvg = parsedDiagram.getElementsByTagName('svg')[0];
@@ -81,7 +93,7 @@ export const Diagrams = (): JSX.Element => {
       setDiagramInfo(initDiagramInfo);
     };
     init();
-  }, [appCtx.diagramGenId, appCtx.diagramTypeId, appCtx.diagramType]);
+  }, [appCtx.diagramGenId, appCtx.diagramTypeId, appCtx.diagramType, appCtx.workspaceId]);
 
   const generateDiagram = async (e: MouseEvent) => {
     const parentNode = (e.target as HTMLElement)?.parentElement;

--- a/webgui-new/src/components/editor-context-menu/editor-context-menu.tsx
+++ b/webgui-new/src/components/editor-context-menu/editor-context-menu.tsx
@@ -21,6 +21,7 @@ import { useRouter } from 'next/router';
 import { RouterQueryType } from 'utils/types';
 import { useTranslation } from 'react-i18next';
 import { diagramTypeArray } from 'enums/entity-types';
+import { sendGAEvent } from 'utils/analytics';
 
 export const EditorContextMenu = ({
   contextMenu,
@@ -69,8 +70,14 @@ export const EditorContextMenu = ({
 
   const getDocs = async () => {
     const initDocs = await getCppDocumentation(astNodeInfo?.id as string);
+    const fileInfo = await getFileInfo(appCtx.projectFileId as string);
     const parser = new DOMParser();
     const parsedHTML = parser.parseFromString(initDocs, 'text/html');
+    sendGAEvent({
+      event_action: 'documentation',
+      event_category: appCtx.workspaceId,
+      event_label: `${fileInfo?.name}: ${astNodeInfo?.astNodeValue}`,
+    });
     setModalOpen(true);
     setContextMenu(null);
     if (!docsContainerRef.current) return;
@@ -87,6 +94,12 @@ export const EditorContextMenu = ({
     const initAstHTML = await getAsHTMLForNode(astNodeInfo?.id as string);
     const parser = new DOMParser();
     const parsedHTML = parser.parseFromString(initAstHTML, 'text/html');
+    const fileInfo = await getFileInfo(appCtx.projectFileId as string);
+    sendGAEvent({
+      event_action: 'cpp_reparse_node',
+      event_category: appCtx.workspaceId,
+      event_label: `${fileInfo?.name}: ${astNodeInfo?.astNodeValue}`,
+    });
     setModalOpen(true);
     setContextMenu(null);
     if (!astHTMLContainerRef.current) return;
@@ -115,6 +128,12 @@ export const EditorContextMenu = ({
     }
 
     const fileId = def.range?.file as string;
+    const fileInfo = await getFileInfo(appCtx.projectFileId as string);
+    sendGAEvent({
+      event_action: 'jump_to_def',
+      event_category: appCtx.workspaceId,
+      event_label: `${fileInfo?.name}: ${astNodeInfo.astNodeValue}`,
+    });
 
     router.push({
       pathname: '/project',
@@ -145,6 +164,11 @@ export const EditorContextMenu = ({
       currentRepo?.repoPath as string,
       fileInfo?.id as string
     );
+    sendGAEvent({
+      event_action: 'git_blame',
+      event_category: appCtx.workspaceId,
+      event_label: fileInfo?.name,
+    });
     return blameInfo;
   };
 

--- a/webgui-new/src/components/file-context-menu/file-context-menu.tsx
+++ b/webgui-new/src/components/file-context-menu/file-context-menu.tsx
@@ -12,6 +12,7 @@ import { useRouter } from 'next/router';
 import { RouterQueryType } from 'utils/types';
 import { useTranslation } from 'react-i18next';
 import { diagramTypeArray } from 'enums/entity-types';
+import { sendGAEvent } from 'utils/analytics';
 
 export const FileContextMenu = ({
   contextMenu,
@@ -67,6 +68,11 @@ export const FileContextMenu = ({
       {fileInfo && fileInfo.isDirectory && (
         <MenuItem
           onClick={async () => {
+            sendGAEvent({
+              event_action: 'metrics',
+              event_category: appCtx.workspaceId,
+              event_label: fileInfo.name,
+            });
             setContextMenu(null);
             router.push({
               pathname: '/project',

--- a/webgui-new/src/components/header/header.tsx
+++ b/webgui-new/src/components/header/header.tsx
@@ -15,6 +15,7 @@ import { AppContext } from 'global-context/app-context';
 import * as SC from './styled-components';
 import { useRouter } from 'next/router';
 import { RouterQueryType } from 'utils/types';
+import { sendGAEvent } from 'utils/analytics';
 
 export const Header = (): JSX.Element => {
   const router = useRouter();
@@ -83,6 +84,12 @@ export const Header = (): JSX.Element => {
 
       setStore({
         storedSearchProps: initSearchProps,
+      });
+
+      sendGAEvent({
+        event_action: `search: ${searchType ? searchType.name : 'undefined'}`,
+        event_category: appCtx.workspaceId,
+        event_label: query,
       });
 
       router.push({

--- a/webgui-new/src/i18n/locales/en.json
+++ b/webgui-new/src/i18n/locales/en.json
@@ -355,5 +355,34 @@
     "INCLUDE_DEPENDENCY": "Include Dependency",
     "INTERFACE": "Interface Diagram",
     "SUBSYSTEM_DEPENDENCY": "Internal architecture of this module"
+  },
+  "cookie": {
+    "ACCEPT": "Accept",
+    "INTRO_TEXT": "Our website uses cookies to improve your experience.",
+    "LEARN_MORE": "Learn more"
+  },
+  "cookiePolicy": {
+    "TITLE": "Cookie policy",
+    "sections": {
+      "cookies": {
+        "SERVICE": "Service",
+        "PURPOSE": "Purpose",
+        "DURATION": "Duration",
+        "MORE_INFORMATION": "More Information",
+        "COOKIE_NAMES": "Cookie names",
+        "WHAT_COOKIES": "What are cookies?",
+        "WHAT_COOKIES_DESCRIPTION": "Cookies are small text files that websites store on a user's device, primarily for analytics purposes. They enable websites to gather valuable data about user interactions, helping businesses understand user behavior, preferences, and engagement. By analyzing this data, organizations can make informed decisions to improve their websites, content, and marketing strategies. Cookies play a crucial role in optimizing the online experience and tailoring content to better serve users' needs while respecting their privacy through proper consent mechanisms.",
+        "HOW_USE_TITLE": "How we use cookies?",
+        "TABLE": "The table below explains the cookies we use and why:",
+        "CONCLUSION": "By clicking \"Accept\", you agree to the use of cookies on this website, enhancing your browsing experience and enabling us to gather valuable analytics data for continual improvement. You can always withdraw your consent later on by simply removing the corresponding cookies from your device.",
+        "googleAnalytics": {
+          "SERVICE": "Google Analytics",
+          "COOKIE_NAMES": "_ga, _ga_<MEASUREMENT_ID>",
+          "DURATION": "2 years",
+          "PURPOSE": "Tracking of page views, code editor operations, diagram generations, metrics collection, and version-control actions.",
+          "MORE_INFORMATION": "https://policies.google.com/technologies/cookies"
+        }
+      }
+    }
   }
 }

--- a/webgui-new/src/i18n/locales/en.json
+++ b/webgui-new/src/i18n/locales/en.json
@@ -373,7 +373,6 @@
         "WHAT_COOKIES": "What are cookies?",
         "WHAT_COOKIES_DESCRIPTION": "Cookies are small text files that websites store on a user's device, primarily for analytics purposes. They enable websites to gather valuable data about user interactions, helping businesses understand user behavior, preferences, and engagement. By analyzing this data, organizations can make informed decisions to improve their websites, content, and marketing strategies. Cookies play a crucial role in optimizing the online experience and tailoring content to better serve users' needs while respecting their privacy through proper consent mechanisms.",
         "HOW_USE_TITLE": "How we use cookies?",
-        "TABLE": "The table below explains the cookies we use and why:",
         "CONCLUSION": "By clicking \"Accept\", you agree to the use of cookies on this website, enhancing your browsing experience and enabling us to gather valuable analytics data for continual improvement. You can always withdraw your consent later on by simply removing the corresponding cookies from your device.",
         "googleAnalytics": {
           "SERVICE": "Google Analytics",

--- a/webgui-new/src/pages/_app.tsx
+++ b/webgui-new/src/pages/_app.tsx
@@ -6,6 +6,7 @@ import { ThemeContextController } from 'global-context/theme-context';
 import { I18nextProvider } from 'react-i18next';
 import i18n from 'i18n/i18n';
 import React from 'react';
+import { CookieNotice } from 'components/cookie-notice/cookie-notice';
 
 const App = ({ Component, pageProps }: AppProps): JSX.Element => {
   return (
@@ -14,6 +15,7 @@ const App = ({ Component, pageProps }: AppProps): JSX.Element => {
         <ThemeContextController>
           <CssBaseline />
           <Component {...pageProps} />
+          <CookieNotice />
         </ThemeContextController>
       </AppContextController>
     </I18nextProvider>

--- a/webgui-new/src/server.ts
+++ b/webgui-new/src/server.ts
@@ -16,10 +16,10 @@ const main = async () => {
   const proxyHandler = createProxyMiddleware({
     target: process.env.BACKEND_URL,
     changeOrigin: true,
-    pathFilter: ['**/*Service', '**/*ga.txt'],
+    pathFilter: ['**/*Service', '**/ga.txt'],
     pathRewrite: {
       '^/[^/]+/(.+Service)$': '/$1',
-      '^/ga.txt' : '/$1'
+      '^/ga.txt' : '/ga.txt'
     },
   });
 

--- a/webgui-new/src/server.ts
+++ b/webgui-new/src/server.ts
@@ -16,9 +16,10 @@ const main = async () => {
   const proxyHandler = createProxyMiddleware({
     target: process.env.BACKEND_URL,
     changeOrigin: true,
-    pathFilter: '**/*Service',
+    pathFilter: ['**/*Service', '**/*ga.txt'],
     pathRewrite: {
       '^/[^/]+/(.+Service)$': '/$1',
+      '^/ga.txt' : '/$1'
     },
   });
 

--- a/webgui-new/src/utils/analytics.ts
+++ b/webgui-new/src/utils/analytics.ts
@@ -1,0 +1,19 @@
+import ReactGA from 'react-ga4';
+
+type EventType = {
+  event_action: string;
+  event_category: string;
+  event_label?: string;
+};
+
+export const sendGAEvent = ({
+  event_action,
+  event_category,
+  event_label = 'undefined',
+}: EventType) => {
+  if (!ReactGA.isInitialized) {
+    return;
+  }
+  // We have to use this signature to prevent ReactGA from making the starting letters automatically uppercase.
+  ReactGA.event(event_action, { event_category, event_label });
+};

--- a/webgui-new/src/utils/store.ts
+++ b/webgui-new/src/utils/store.ts
@@ -3,6 +3,7 @@ import { FileNode, SearchProps, TreeNode } from './types';
 
 type StoreOptions = {
   storedTheme?: 'light' | 'dark';
+  storedCookieConsent?: boolean;
   storedSearchProps?: SearchProps;
   storedSearchType?: SearchType;
   storedSearchLanguage?: string;
@@ -16,6 +17,7 @@ type StoreOptions = {
 
 type StoreOptionKey =
   | 'storedTheme'
+  | 'storedCookieConsent'
   | 'storedSearchProps'
   | 'storedSearchType'
   | 'storedSearchLanguage'


### PR DESCRIPTION
Google Analytics integration with the [react-ga4](https://www.npmjs.com/package/react-ga4) library.

The data should be collected in the same format as it was declared in #526.

I didn't implement the `info_tree` event, because on the new GUI, clicking on a word in the editor (a.k.a. firing the `click_on_word` event), automatically brings up the Info tree (and there is no dedicated context menu item for it), so it should be considered a duplicated event.

The GA script only loads when the user gives direct consent by clicking on "Accept."
If there is an error during accessing the `ga.txt` file content (it does not exist), the cookie notice won't show up.

fixes #616 
fixes #530 