### PR TITLE
Correct display for implicit and macro-expanded variables

### DIFF
--- a/plugins/cpp/parser/src/clangastvisitor.h
+++ b/plugins/cpp/parser/src/clangastvisitor.h
@@ -1258,13 +1258,15 @@ private:
 
     clang::SourceLocation realStart = start_;
     clang::SourceLocation realEnd = end_;
-
-    if (_clangSrcMgr.isMacroBodyExpansion(start_)
-      || _clangSrcMgr.isMacroArgExpansion(start_))
+    
+    if (_clangSrcMgr.isMacroBodyExpansion(start_))
+      realStart = _clangSrcMgr.getExpansionLoc(start_);
+    if (_clangSrcMgr.isMacroArgExpansion(start_))
       realStart = _clangSrcMgr.getSpellingLoc(start_);
 
-    if (_clangSrcMgr.isMacroBodyExpansion(end_)
-      || _clangSrcMgr.isMacroArgExpansion(end_))
+    if (_clangSrcMgr.isMacroBodyExpansion(end_))
+      realEnd = _clangSrcMgr.getExpansionLoc(end_);
+    if (_clangSrcMgr.isMacroArgExpansion(end_))
       realEnd = _clangSrcMgr.getSpellingLoc(end_);
 
     if (!_isImplicit)

--- a/plugins/cpp/parser/src/clangastvisitor.h
+++ b/plugins/cpp/parser/src/clangastvisitor.h
@@ -829,12 +829,11 @@ public:
 
     model::CppAstNodePtr astNode = std::make_shared<model::CppAstNode>();
 
-    astNode->astValue = getSourceText(
-      _clangSrcMgr,
-      vd_->getOuterLocStart(),
-      vd_->getEndLoc(),
-      true);
-    astNode->location = getFileLoc(vd_->getLocation(), vd_->getLocation());
+    astNode->astValue = vd_->getType().getAsString();
+    astNode->astValue.append(" ");
+    astNode->astValue.append(vd_->getNameAsString());
+
+    astNode->location = getFileLoc(vd_->getBeginLoc(), vd_->getEndLoc());
     astNode->entityHash = util::fnvHash(getUSR(vd_));
     astNode->symbolType
       = isFunctionPointer(vd_)
@@ -881,6 +880,8 @@ public:
 
     if (_functionStack.empty())
       variable->tags.insert(model::Tag::Global);
+    if (_isImplicit)
+      variable->tags.insert(model::Tag::Implicit);
 
     //--- CppMemberType ---//
 
@@ -1259,9 +1260,12 @@ private:
     clang::SourceLocation realStart = start_;
     clang::SourceLocation realEnd = end_;
 
-    if (_clangSrcMgr.isMacroArgExpansion(start_))
+    if (_clangSrcMgr.isMacroBodyExpansion(start_)
+      || _clangSrcMgr.isMacroArgExpansion(start_))
       realStart = _clangSrcMgr.getSpellingLoc(start_);
-    if (_clangSrcMgr.isMacroArgExpansion(end_))
+
+    if (_clangSrcMgr.isMacroBodyExpansion(end_)
+      || _clangSrcMgr.isMacroArgExpansion(end_))
       realEnd = _clangSrcMgr.getSpellingLoc(end_);
 
     if (!_isImplicit)

--- a/plugins/cpp/parser/src/clangastvisitor.h
+++ b/plugins/cpp/parser/src/clangastvisitor.h
@@ -766,11 +766,10 @@ public:
 
     model::CppAstNodePtr astNode = std::make_shared<model::CppAstNode>();
 
-    astNode->astValue = getSourceText(
-      _clangSrcMgr,
-      fd_->getSourceRange().getBegin(),
-      fd_->getSourceRange().getEnd(),
-      true);
+    astNode->astValue = fd_->getType().getAsString();
+    astNode->astValue.append(" ");
+    astNode->astValue.append(fd_->getNameAsString());
+
     astNode->location = getFileLoc(fd_->getBeginLoc(), fd_->getEndLoc());
     astNode->entityHash = util::fnvHash(getUSR(fd_));
     astNode->symbolType


### PR DESCRIPTION
Implicit local variables in functions are now marked with the Implicit flag (the same way compiler-generated methods are marked).

Class members and local variables expanded from macros now display the correct text (which is always the type + the name) and jump to the location of the macro's expansion.

Fixes #597.