### PR TITLE
Handle namespace alias declarations

### DIFF
--- a/plugins/cpp/model/CMakeLists.txt
+++ b/plugins/cpp/model/CMakeLists.txt
@@ -6,6 +6,7 @@ set(ODB_SOURCES
   include/model/cppfunction.h
   include/model/cppinheritance.h
   include/model/cppnamespace.h
+  include/model/cppnamespacealias.h
   include/model/cpprelation.h
   include/model/cpptypedef.h
   include/model/cpprecord.h

--- a/plugins/cpp/model/include/model/cppastnode.h
+++ b/plugins/cpp/model/include/model/cppastnode.h
@@ -34,6 +34,7 @@ struct CppAstNode
     Enum,
     EnumConstant,
     Namespace,
+    NamespaceAlias,
     StringLiteral,
     File = 500,
     Other = 1000
@@ -103,6 +104,7 @@ inline std::string symbolTypeToString(CppAstNode::SymbolType type_)
     case CppAstNode::SymbolType::Enum: return "Enum";
     case CppAstNode::SymbolType::EnumConstant: return "EnumConstant";
     case CppAstNode::SymbolType::Namespace: return "Namespace";
+    case CppAstNode::SymbolType::NamespaceAlias: return "NamespaceAlias";
     case CppAstNode::SymbolType::StringLiteral: return "StringLiteral";
     case CppAstNode::SymbolType::File: return "File";
     case CppAstNode::SymbolType::Other: return "Other";

--- a/plugins/cpp/model/include/model/cppnamespacealias.h
+++ b/plugins/cpp/model/include/model/cppnamespacealias.h
@@ -11,11 +11,6 @@ namespace model
 #pragma db object
 struct CppNamespaceAlias : CppEntity
 {
-  #pragma db unique
-  CppAstNodeId aliasedNamespaceNodeId;
-
-  CppAstNodePtr aliasedNamespace;
-
   std::string toString() const
   {
     std::string ret("CppNamespaceAlias");

--- a/plugins/cpp/model/include/model/cppnamespacealias.h
+++ b/plugins/cpp/model/include/model/cppnamespacealias.h
@@ -1,0 +1,44 @@
+#ifndef CC_MODEL_CPPNAMESPACEALIAS_H
+#define CC_MODEL_CPPNAMESPACEALIAS_H
+
+#include "cppentity.h"
+
+namespace cc
+{
+namespace model
+{
+
+#pragma db object
+struct CppNamespaceAlias : CppEntity
+{
+  #pragma db unique
+  CppAstNodeId aliasedNamespaceNodeId;
+
+  CppAstNodePtr aliasedNamespace;
+
+  std::string toString() const
+  {
+    std::string ret("CppNamespaceAlias");
+
+    ret
+      .append("\nid = ").append(std::to_string(id))
+      .append("\nentityHash = ").append(std::to_string(entityHash))
+      .append("\nqualifiedName = ").append(qualifiedName);
+
+    if (!tags.empty())
+    {
+      ret.append("\ntags =");
+      for (const Tag& tag : tags)
+        ret.append(' ' + tagToString(tag));
+    }
+
+    return ret;
+  }
+};
+
+typedef std::shared_ptr<CppNamespaceAlias> CppNamespaceAliasPtr;
+
+}
+}
+
+#endif


### PR DESCRIPTION
An ast node is now created for namespace aliases, using the hash of the aliased namespace
closes #652