### PR TITLE
OpenSSF best practices: set GITHUB_TOKEN permission to read-all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on: [push, pull_request, workflow_dispatch]
 env:
   BUILD_TYPE: Debug
 
+permissions: read-all
+
 jobs:
 
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,8 @@ on:
       DOCKERHUB_TOKEN:
         required: true
 
+permissions: read-all
+
 jobs:
   docker:
     runs-on: ubuntu-20.04

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -2,6 +2,8 @@ name: Frontend linting
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions: read-all
+
 jobs:
     linting:
         runs-on: ubuntu-20.04

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -7,6 +7,8 @@ on:
       GITLAB_TRIGGER_TOKEN:
         required: true
 
+permissions: read-all
+
 jobs:
   tarball:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This change sets the GITHUB_TOKEN permission explicitly to read-only for GitHub actions.

Fixes #669 