### PR TITLE
Nodes inside lambdas are no longer considered inherently implicit

### DIFF
--- a/plugins/cpp/parser/src/clangastvisitor.h
+++ b/plugins/cpp/parser/src/clangastvisitor.h
@@ -864,7 +864,7 @@ public:
 
     if (_functionStack.empty())
       variable->tags.insert(model::Tag::Global);
-    if (_isImplicit)
+    if (vd_->isImplicit())
       variable->tags.insert(model::Tag::Implicit);
 
     //--- CppMemberType ---//

--- a/plugins/cpp/parser/src/clangastvisitor.h
+++ b/plugins/cpp/parser/src/clangastvisitor.h
@@ -138,7 +138,8 @@ public:
     // implicitness to be hereditary from parent to child nodes, except
     // in some known special cases (see lambdas in TraverseCXXRecordDecl).
     bool wasImplicit = _isImplicit;
-    _isImplicit |= decl_->isImplicit();
+    if (decl_ != nullptr)
+      _isImplicit |= decl_->isImplicit();
 
     bool b = Base::TraverseDecl(decl_);
 
@@ -245,7 +246,8 @@ public:
     // properly assign symbol location information to AST nodes within
     // lambda bodies, we must force lambdas to be considered explicit.
     bool wasImplicit = _isImplicit;
-    _isImplicit &= !rd_->isLambda();
+    if (rd_ != nullptr)
+      _isImplicit &= !rd_->isLambda();
     _typeStack.push(std::make_shared<model::CppRecord>());
 
     bool b = Base::TraverseCXXRecordDecl(rd_);

--- a/plugins/cpp/parser/src/clangastvisitor.h
+++ b/plugins/cpp/parser/src/clangastvisitor.h
@@ -135,15 +135,15 @@ public:
     // should be stored for AST nodes in our database. This differs somewhat
     // from Clang's concept of implicitness.
     // To bridge the gap between the two interpretations, we mostly assume
-    // implicitness to be hereditary from parent to child nodes,
-    // except in some special cases (see lambdas in TraverseCXXRecordDecl).
+    // implicitness to be hereditary from parent to child nodes, except
+    // in some known special cases (see lambdas in TraverseCXXRecordDecl).
     bool wasImplicit = _isImplicit;
     _isImplicit |= decl_->isImplicit();
 
     bool b = Base::TraverseDecl(decl_);
 
     _isImplicit = wasImplicit;
-    
+
     return b;
   }
 
@@ -240,7 +240,7 @@ public:
 
   bool TraverseCXXRecordDecl(clang::CXXRecordDecl* rd_)
   {
-    // Although lamba closure types are implicit by nature as far as
+    // Although lambda closure types are implicit by nature as far as
     // Clang is concerned, their operator() is not. In order to be able to
     // properly assign symbol location information to AST nodes within
     // lambda bodies, we must force lambdas to be considered explicit.


### PR DESCRIPTION
Lambda closure types have always been properly visited and parsed into the database with one notable exception: their source location was missing.
The _isImplicit variable prevented nodes rooted under any implicit node (anywhere in the parent chain) from being assigned a source location via _fileLocUtil, so even though the nodes were there, the UI could not locate them.

This fixes #583.

This is more or less a revert (+ some additional necessary refactor) of a much older commit mentioned in the issue (3bc3c7f1f69c4a1a0680dc289b50d835d7cf74a1 by @bruntib). I could not find the issue that this commit was originally supposed to fix, so any insights are welcome. But the assumption that implicit nodes will only have implicit sub-nodes clearly turns out to be incorrect (as shown by lambdas).