### PR TITLE
Maximize disk space in CI

### DIFF
--- a/.github/scripts/ubuntu-20.04/postcompile_runtime.sh
+++ b/.github/scripts/ubuntu-20.04/postcompile_runtime.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-# Post compilation configuration for runtime (environmental variables, library location settings etc..)
-
-echo "LD_LIBRARY_PATH=${INSTALL_PATH}/thrift/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV

--- a/.github/scripts/ubuntu-20.04/setup_runtime.sh
+++ b/.github/scripts/ubuntu-20.04/setup_runtime.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Install required packages for CodeCompass runtime
-sudo apt-get install -y git cmake make g++ graphviz \
-  libboost-filesystem1.71.0 libboost-log1.71.0 libboost-program-options1.71.0 \
-  libllvm11 clang-11 libclang1-11 default-jre libssl1.1 libmagic1 \
-  libgit2-28 ctags googletest libldap-2.4-2

--- a/.github/scripts/ubuntu-22.04/postcompile_runtime.sh
+++ b/.github/scripts/ubuntu-22.04/postcompile_runtime.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-# Post compilation configuration for runtime (environmental variables, library location settings etc..)
-
-echo "LD_LIBRARY_PATH=${INSTALL_PATH}/odb/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,10 @@ jobs:
           - 5432:5432
 
     steps:
+      # Clean up docker images to save space
+      - name: Clean up docker images
+        run: docker image prune -a -f
+
       - uses: actions/checkout@v3
 
       - name: Update apt-get
@@ -238,14 +242,6 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-compile-install-${{ needs.build.outputs.ubuntu-20-04-compile-hash-key }}
             ${{ matrix.os }}-compile-install-${{ needs.build.outputs.ubuntu-22-04-compile-hash-key }}
-
-      - name: Post compilation configuration (runtime)
-        if: ${{ env.HAS_COMPILED_DEPENDENCIES == 'true' }}
-        run: |
-          if [ -f ./.github/scripts/${{ matrix.os }}/postcompile_runtime.sh ]; then
-           chmod +x ./.github/scripts/${{ matrix.os }}/postcompile_runtime.sh
-           ./.github/scripts/${{ matrix.os }}/postcompile_runtime.sh
-          fi
 
       - name: Download CodeCompass binaries
         uses: actions/download-artifact@v2


### PR DESCRIPTION
Maximize disk space in **parse** GitHub Action job, as it tends to fail when parsing CodeCompass with PostgreSQL, due to low disk space.

Also remove unused steps from CI.