### PR TITLE
Persist C++ metrics only for files of the analyzed project

### DIFF
--- a/plugins/cpp/model/include/model/cppfunction.h
+++ b/plugins/cpp/model/include/model/cppfunction.h
@@ -41,15 +41,21 @@ struct CppFunctionParamCount
 };
 
 #pragma db view \
-  object(CppFunction) object(CppVariable = Parameters : CppFunction::parameters) \
-  query((?) + "GROUP BY" + cc::model::CppEntity::astNodeId)
+  object(CppFunction) \
+  object(CppVariable = Parameters : CppFunction::parameters) \
+  object(CppAstNode : CppFunction::astNodeId == CppAstNode::id) \
+  object(File : CppAstNode::location.file) \
+  query((?) + "GROUP BY" + cc::model::CppEntity::astNodeId + "," + cc::model::File::path)
 struct CppFunctionParamCountWithId
 {
-  #pragma db column("CppEntity.astNodeId")
+  #pragma db column(CppEntity::astNodeId)
   CppAstNodeId id;
 
   #pragma db column("count(" + Parameters::id + ")")
   std::size_t count;
+
+  #pragma db column(File::path)
+  std::string filePath;
 };
 
 #pragma db view \
@@ -60,11 +66,20 @@ struct CppFunctionLocalCount
   std::size_t count;
 };
 
-#pragma db view object(CppFunction)
-struct CppFunctionMcCabeWithId
+#pragma db view \
+  object(CppFunction) \
+  object(CppAstNode : CppFunction::astNodeId == CppAstNode::id) \
+  object(File : CppAstNode::location.file)
+struct CppFunctionMcCabe
 {
+  #pragma db column(CppEntity::astNodeId)
   CppAstNodeId astNodeId;
+
+  #pragma db column(CppFunction::mccabe)
   unsigned int mccabe;
+
+  #pragma db column(File::path)
+  std::string filePath;
 };
 
 }

--- a/plugins/cpp_metrics/parser/include/cppmetricsparser/cppmetricsparser.h
+++ b/plugins/cpp_metrics/parser/include/cppmetricsparser/cppmetricsparser.h
@@ -30,6 +30,7 @@ private:
   void functionParameters();
   void functionMcCabe();
 
+  std::vector<std::string> _inputPaths;
   std::unordered_set<model::FileId> _fileIdCache;
   std::unordered_map<model::CppAstNodeId, model::FileId> _astNodeIdCache;
   std::unique_ptr<util::JobQueueThreadPool<std::string>> _pool;

--- a/util/include/util/filesystem.h
+++ b/util/include/util/filesystem.h
@@ -22,6 +22,19 @@ std::string binaryPathToInstallDir(const char* path);
  */
 std::string findCurrentExecutableDir();
 
+/**
+ * @brief Determines if the given path is rooted under
+ * any of the given other paths.
+ *
+ * @param paths_ A list of canonical paths.
+ * @param path_ A canonical path to match against the given paths.
+ * @return True if any of the paths in paths_ is a prefix of path_,
+ * otherwise false.
+*/
+bool isRootedUnderAnyOf(
+  const std::vector<std::string>& paths_,
+  const std::string& path_);
+
 } // namespace util
 } // namespace cc
 

--- a/util/src/filesystem.cpp
+++ b/util/src/filesystem.cpp
@@ -64,5 +64,16 @@ std::string findCurrentExecutableDir()
   return fs::path(exePath).parent_path().string();
 }
 
+bool isRootedUnderAnyOf(
+  const std::vector<std::string>& paths_,
+  const std::string& path_)
+{
+  auto it = paths_.begin();
+  const auto end = paths_.end();
+  while (it != end && path_.rfind(*it, 0) != 0)
+    ++it;
+  return it != end;
+}
+
 } // namespace util
 } // namespace cc


### PR DESCRIPTION
Persist function param count and McCabe complexity metrics only for functions of the analyzed project.

Based on concept designed in #688.