### PR TITLE
C++ metrics Thrift API

### DIFF
--- a/docker/dev/install_odb.sh
+++ b/docker/dev/install_odb.sh
@@ -33,10 +33,7 @@ for pack in "$BUILD_LIST"; do
   bpkg build $pack --yes
 done
 # Install ODB (to /usr/local)
-INSTALL_LIST="$BUILD_LIST libstudxml libcutl"
-for pack in "$INSTALL_LIST"; do
-  bpkg install $pack
-done
+bpkg install --all --recursive
 # Clean up
 cd /
 sh install_latest_build2.sh --uninstall

--- a/plugins/cpp_metrics/model/include/model/cppastnodemetrics.h
+++ b/plugins/cpp_metrics/model/include/model/cppastnodemetrics.h
@@ -15,10 +15,10 @@ struct CppAstNodeMetrics
 {
   enum Type
   {
-    PARAMETER_COUNT,
-    MCCABE,
-    LACK_OF_COHESION,
-    LACK_OF_COHESION_HS,
+    PARAMETER_COUNT = 1,
+    MCCABE = 2,
+    LACK_OF_COHESION = 3,
+    LACK_OF_COHESION_HS = 4,
   };
 
   #pragma db id auto

--- a/plugins/cpp_metrics/service/CMakeLists.txt
+++ b/plugins/cpp_metrics/service/CMakeLists.txt
@@ -1,6 +1,11 @@
 include_directories(
   include
   ${CMAKE_CURRENT_BINARY_DIR}/gen-cpp
+  ${PROJECT_BINARY_DIR}/service/project/gen-cpp
+  ${PROJECT_SOURCE_DIR}/service/project/include
+  ${PROJECT_SOURCE_DIR}/model/include
+  ${PROJECT_BINARY_DIR}/service/language/gen-cpp
+  ${PLUGIN_DIR}/model/include
   ${PROJECT_SOURCE_DIR}/util/include
   ${PROJECT_SOURCE_DIR}/webserver/include)
 
@@ -9,35 +14,45 @@ include_directories(SYSTEM
 
 add_custom_command(
   OUTPUT
+    ${CMAKE_CURRENT_BINARY_DIR}/gen-cpp/cxxmetrics_types.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/gen-cpp/cxxmetrics_types.h
     ${CMAKE_CURRENT_BINARY_DIR}/gen-cpp/CppMetricsService.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/gen-cpp/CppMetricsService.h
     ${CMAKE_CURRENT_BINARY_DIR}/gen-cpp
   COMMAND
     ${THRIFT_EXECUTABLE} --gen cpp
       -o ${CMAKE_CURRENT_BINARY_DIR}
-  ${CMAKE_CURRENT_SOURCE_DIR}/cppmetrics.thrift
+      -I ${PROJECT_SOURCE_DIR}/service
+      ${CMAKE_CURRENT_SOURCE_DIR}/cxxmetrics.thrift
   DEPENDS
-  ${CMAKE_CURRENT_SOURCE_DIR}/cppmetrics.thrift
+    ${CMAKE_CURRENT_SOURCE_DIR}/cxxmetrics.thrift
   COMMENT
-    "Generating Thrift for cppmetrics.thrift")
+    "Generating Thrift for cxxmetrics.thrift")
 
-add_library(cppmetricsthrift STATIC
+add_library(cxxmetricsthrift STATIC
+  ${CMAKE_CURRENT_BINARY_DIR}/gen-cpp/cxxmetrics_types.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/gen-cpp/CppMetricsService.cpp)
 
-target_compile_options(cppmetricsthrift PUBLIC -fPIC)
+target_compile_options(cxxmetricsthrift PUBLIC -fPIC)
 
-add_library(cppmetricsservice SHARED
+add_dependencies(cxxmetricsthrift projectthrift)
+
+add_library(cxxmetricsservice SHARED
   src/cppmetricsservice.cpp
   src/plugin.cpp)
 
-target_compile_options(cppmetricsservice PUBLIC -Wno-unknown-pragmas)
+#target_compile_options(cxxmetricsservice PUBLIC -Wno-unknown-pragmas)
 
-target_link_libraries(cppmetricsservice
-  cppmetricsmodel
-  model
+target_link_libraries(cxxmetricsservice
   util
   ${THRIFT_LIBTHRIFT_LIBRARIES}
+  model
+  cppmetricsmodel
+  projectthrift
+  projectservice
+  commonthrift
   ${ODB_LIBRARIES}
-  cppmetricsthrift)
+  cxxmetricsthrift)
 
-install(TARGETS cppmetricsservice DESTINATION ${INSTALL_SERVICE_DIR})
+install(TARGETS cxxmetricsservice DESTINATION ${INSTALL_SERVICE_DIR})
+install_js_thrift()

--- a/plugins/cpp_metrics/service/CMakeLists.txt
+++ b/plugins/cpp_metrics/service/CMakeLists.txt
@@ -41,7 +41,7 @@ add_library(cxxmetricsservice SHARED
   src/cppmetricsservice.cpp
   src/plugin.cpp)
 
-#target_compile_options(cxxmetricsservice PUBLIC -Wno-unknown-pragmas)
+target_compile_options(cxxmetricsservice PUBLIC -Wno-unknown-pragmas)
 
 target_link_libraries(cxxmetricsservice
   util

--- a/plugins/cpp_metrics/service/cppmetrics.thrift
+++ b/plugins/cpp_metrics/service/cppmetrics.thrift
@@ -1,7 +1,0 @@
-namespace cpp cc.service.cppmetrics
-namespace java cc.service.cppmetrics
-
-service CppMetricsService
-{
-
-}

--- a/plugins/cpp_metrics/service/cxxmetrics.thrift
+++ b/plugins/cpp_metrics/service/cxxmetrics.thrift
@@ -12,9 +12,37 @@ enum CppMetricsType
   LackOfCohesionHS = 4
 }
 
+struct CppMetricsTypeName
+{
+  1:CppMetricsType type,
+  2:string name
+}
+
+struct CppMetricsAstNode
+{
+  1:CppMetricsType type,
+  2:double value
+}
+
 service CppMetricsService
 {
-  double getCppMetricsForAstNode(
+  /**
+   * This function returns the required C++ metric
+   * for a particular AST node.
+   */
+  double getSingleCppMetricForAstNode(
     1:common.AstNodeId astNodeId,
     2:CppMetricsType type)
+
+  /**
+   * This function returns all available C++ metrics
+   * for a particular AST node.
+   */
+  list<CppMetricsAstNode> getCppMetricsForAstNode(
+    1:common.AstNodeId astNodeId)
+
+  /**
+   * This function returns the names of metrics.
+   */
+  list<CppMetricsTypeName> getCppMetricsTypeNames()
 }

--- a/plugins/cpp_metrics/service/cxxmetrics.thrift
+++ b/plugins/cpp_metrics/service/cxxmetrics.thrift
@@ -1,0 +1,20 @@
+include "project/common.thrift"
+include "project/project.thrift"
+
+namespace cpp cc.service.cppmetrics
+namespace java cc.service.cppmetrics
+
+enum CppMetricsType
+{
+  ParameterCount = 1,
+  McCabe = 2,
+  LackOfCohesion = 3,
+  LackOfCohesionHS = 4
+}
+
+service CppMetricsService
+{
+  //double getCppMetricsForAstNode(
+    //1:common.AstNodeId astNodeId,
+    //2:CppMetricsType type)
+}

--- a/plugins/cpp_metrics/service/cxxmetrics.thrift
+++ b/plugins/cpp_metrics/service/cxxmetrics.thrift
@@ -32,7 +32,7 @@ service CppMetricsService
    */
   double getSingleCppMetricForAstNode(
     1:common.AstNodeId astNodeId,
-    2:CppMetricsType type)
+    2:CppMetricsType metric)
 
   /**
    * This function returns all available C++ metrics

--- a/plugins/cpp_metrics/service/cxxmetrics.thrift
+++ b/plugins/cpp_metrics/service/cxxmetrics.thrift
@@ -14,7 +14,7 @@ enum CppMetricsType
 
 service CppMetricsService
 {
-  //double getCppMetricsForAstNode(
-    //1:common.AstNodeId astNodeId,
-    //2:CppMetricsType type)
+  double getCppMetricsForAstNode(
+    1:common.AstNodeId astNodeId,
+    2:CppMetricsType type)
 }

--- a/plugins/cpp_metrics/service/include/service/cppmetricsservice.h
+++ b/plugins/cpp_metrics/service/include/service/cppmetricsservice.h
@@ -9,7 +9,7 @@
 #include <odb/database.hxx>
 
 #include <model/cppastnodemetrics.h>
-//#include <model/cppastnodemetrics-odb.hxx>
+#include <model/cppastnodemetrics-odb.hxx>
 #include <model/cppastnode.h>
 #include <model/cppastnode-odb.hxx>
 
@@ -41,6 +41,10 @@ public:
     const CppMetricsType::type metrics_) override;
 
 private:
+  double astNodeMetrics(
+    const ::cc::service::core::AstNodeId& astNodeId_,
+    const CppMetricsType::type type_);
+
   std::shared_ptr<odb::database> _db;
   util::OdbTransaction _transaction;
 

--- a/plugins/cpp_metrics/service/include/service/cppmetricsservice.h
+++ b/plugins/cpp_metrics/service/include/service/cppmetricsservice.h
@@ -13,8 +13,6 @@
 #include <model/cppastnode.h>
 #include <model/cppastnode-odb.hxx>
 
-//#include <projectservice/projectservice.h>
-
 #include <odb/database.hxx>
 #include <util/odbtransaction.h>
 #include <webserver/servercontext.h>
@@ -36,9 +34,16 @@ public:
     std::shared_ptr<std::string> datadir_,
     const cc::webserver::ServerContext& context_);
 
-  double getCppMetricsForAstNode(
-    const ::cc::service::core::AstNodeId& astNodeId_,
+  double getSingleCppMetricForAstNode(
+    const core::AstNodeId& astNodeId_,
     const CppMetricsType::type metrics_) override;
+
+  void getCppMetricsForAstNode(
+    std::vector<CppMetricsAstNode>& _return,
+    const core::AstNodeId& astNodeId_) override;
+
+  void getCppMetricsTypeNames(
+    std::vector<CppMetricsTypeName>& _return) override;
 
 private:
   double astNodeMetrics(

--- a/plugins/cpp_metrics/service/include/service/cppmetricsservice.h
+++ b/plugins/cpp_metrics/service/include/service/cppmetricsservice.h
@@ -1,10 +1,19 @@
-#ifndef CC_SERVICE_DUMMY_DUMMYSSERVICE_H
-#define CC_SERVICE_DUMMY_DUMMYSSERVICE_H
+#ifndef CC_SERVICE_CPPMETRICSSERVICE_H
+#define CC_SERVICE_CPPMETRICSSERVICE_H
 
 #include <memory>
 #include <vector>
 
 #include <boost/program_options/variables_map.hpp>
+
+#include <odb/database.hxx>
+
+#include <model/cppastnodemetrics.h>
+//#include <model/cppastnodemetrics-odb.hxx>
+#include <model/cppastnode.h>
+#include <model/cppastnode-odb.hxx>
+
+//#include <projectservice/projectservice.h>
 
 #include <odb/database.hxx>
 #include <util/odbtransaction.h>
@@ -27,6 +36,10 @@ public:
     std::shared_ptr<std::string> datadir_,
     const cc::webserver::ServerContext& context_);
 
+  //double getCppMetricsForAstNode(
+    //const ::cc::service::core::AstNodeId& astNodeId_,
+    //const CppMetricsType::type metrics_) override;
+
 private:
   std::shared_ptr<odb::database> _db;
   util::OdbTransaction _transaction;
@@ -38,4 +51,4 @@ private:
 } // service
 } // cc
 
-#endif // CC_SERVICE_DUMMY_CPPMETRICSSSERVICE_H
+#endif // CC_SERVICE_CPPMETRICSSERVICE_H

--- a/plugins/cpp_metrics/service/include/service/cppmetricsservice.h
+++ b/plugins/cpp_metrics/service/include/service/cppmetricsservice.h
@@ -36,9 +36,9 @@ public:
     std::shared_ptr<std::string> datadir_,
     const cc::webserver::ServerContext& context_);
 
-  //double getCppMetricsForAstNode(
-    //const ::cc::service::core::AstNodeId& astNodeId_,
-    //const CppMetricsType::type metrics_) override;
+  double getCppMetricsForAstNode(
+    const ::cc::service::core::AstNodeId& astNodeId_,
+    const CppMetricsType::type metrics_) override;
 
 private:
   std::shared_ptr<odb::database> _db;

--- a/plugins/cpp_metrics/service/include/service/cppmetricsservice.h
+++ b/plugins/cpp_metrics/service/include/service/cppmetricsservice.h
@@ -36,7 +36,7 @@ public:
 
   double getSingleCppMetricForAstNode(
     const core::AstNodeId& astNodeId_,
-    const CppMetricsType::type metrics_) override;
+    CppMetricsType::type metric_) override;
 
   void getCppMetricsForAstNode(
     std::vector<CppMetricsAstNode>& _return,
@@ -46,10 +46,6 @@ public:
     std::vector<CppMetricsTypeName>& _return) override;
 
 private:
-  double astNodeMetrics(
-    const ::cc::service::core::AstNodeId& astNodeId_,
-    const CppMetricsType::type type_);
-
   std::shared_ptr<odb::database> _db;
   util::OdbTransaction _transaction;
 

--- a/plugins/cpp_metrics/service/src/cppmetricsservice.cpp
+++ b/plugins/cpp_metrics/service/src/cppmetricsservice.cpp
@@ -16,6 +16,13 @@ CppMetricsServiceHandler::CppMetricsServiceHandler(
 {
 }
 
+//double CppMetricsServiceHandler::getCppMetricsForAstNode(
+  //const core::AstNodeId& astNodeId_,
+  //const CppMetricsType::type metrics_)
+//{
+
+//}
+
 } // cppmetrics
 } // service
 } // cc

--- a/plugins/cpp_metrics/service/src/cppmetricsservice.cpp
+++ b/plugins/cpp_metrics/service/src/cppmetricsservice.cpp
@@ -71,7 +71,11 @@ double CppMetricsServiceHandler::getSingleCppMetricForAstNode(
       CppAstNodeMetricsQuery::type == static_cast<model::CppAstNodeMetrics::Type>(metric_));
 
     if (nodeMetric.empty())
-      return -DBL_MAX;
+    {
+      core::InvalidInput ex;
+      ex.__set_msg("Invalid metric type for AST node: " + astNodeId_);
+      throw ex;
+    }
 
     return nodeMetric.begin()->value;
   });

--- a/plugins/cpp_metrics/service/src/cppmetricsservice.cpp
+++ b/plugins/cpp_metrics/service/src/cppmetricsservice.cpp
@@ -10,13 +10,52 @@ namespace cppmetrics
 
 CppMetricsServiceHandler::CppMetricsServiceHandler(
   std::shared_ptr<odb::database> db_,
-  std::shared_ptr<std::string> /*datadir_*/,
+  std::shared_ptr<std::string> datadir_,
   const cc::webserver::ServerContext& context_)
     : _db(db_), _transaction(db_), _config(context_.options)
 {
 }
 
-double CppMetricsServiceHandler::getCppMetricsForAstNode(
+void CppMetricsServiceHandler::getCppMetricsTypeNames(
+  std::vector<CppMetricsTypeName>& _return)
+{
+  CppMetricsTypeName typeName;
+
+  typeName.type = CppMetricsType::ParameterCount;
+  typeName.name = "Number of function parameters";
+  _return.push_back(typeName);
+
+  typeName.type = CppMetricsType::McCabe;
+  typeName.name = "McCabe metric";
+  _return.push_back(typeName);
+
+  typeName.type = CppMetricsType::LackOfCohesion;
+  typeName.name = "Lack of cohesion of function";
+  _return.push_back(typeName);
+
+  typeName.type = CppMetricsType::LackOfCohesionHS;
+  typeName.name = "Lack of cohesion HS of function";
+  _return.push_back(typeName);
+}
+
+void CppMetricsServiceHandler::getCppMetricsForAstNode(
+  std::vector<CppMetricsAstNode>& _return,
+  const core::AstNodeId& astNodeId_)
+{
+  std::vector<CppMetricsTypeName> types;
+  getCppMetricsTypeNames(types);
+  CppMetricsAstNode metric;
+
+  for (const auto& pair : types)
+  {
+    double value = astNodeMetrics(astNodeId_, pair.type);
+    metric.type = pair.type;
+    metric.value = value;
+    _return.push_back(metric);
+  }
+}
+
+double CppMetricsServiceHandler::getSingleCppMetricForAstNode(
   const core::AstNodeId& astNodeId_,
   const CppMetricsType::type metrics_)
 {
@@ -39,7 +78,7 @@ double CppMetricsServiceHandler::astNodeMetrics(
         static_cast<model::CppAstNodeMetrics::Type>(type_));
 
     if (nodeMetric.empty())
-      return -1.0;
+      return -DBL_MAX;
 
     return nodeMetric.begin()->value;
   });

--- a/plugins/cpp_metrics/service/src/cppmetricsservice.cpp
+++ b/plugins/cpp_metrics/service/src/cppmetricsservice.cpp
@@ -20,7 +20,29 @@ double CppMetricsServiceHandler::getCppMetricsForAstNode(
   const core::AstNodeId& astNodeId_,
   const CppMetricsType::type metrics_)
 {
+  return astNodeMetrics(astNodeId_, metrics_);
+}
 
+double CppMetricsServiceHandler::astNodeMetrics(
+  const ::cc::service::core::AstNodeId& astNodeId_,
+  const CppMetricsType::type type_)
+{
+  _transaction([&, this](){
+    typedef odb::result<model::CppAstNode> CppAstNodeResult;
+    typedef odb::query<model::CppAstNode> CppAstNodeQuery;
+    typedef odb::result<model::CppAstNodeMetrics> CppAstNodeMetricsResult;
+    typedef odb::query<model::CppAstNodeMetrics> CppAstNodeMetricsQuery;
+
+    auto nodeMetric = _db->query<model::CppAstNodeMetrics>(
+      CppAstNodeMetricsQuery::astNodeId == std::stoull(astNodeId_) &&
+      CppAstNodeMetricsQuery::type ==
+        static_cast<model::CppAstNodeMetrics::Type>(type_));
+
+    if (nodeMetric.empty())
+      return -1.0;
+
+    return nodeMetric.begin()->value;
+  });
 }
 
 } // cppmetrics

--- a/plugins/cpp_metrics/service/src/cppmetricsservice.cpp
+++ b/plugins/cpp_metrics/service/src/cppmetricsservice.cpp
@@ -16,12 +16,12 @@ CppMetricsServiceHandler::CppMetricsServiceHandler(
 {
 }
 
-//double CppMetricsServiceHandler::getCppMetricsForAstNode(
-  //const core::AstNodeId& astNodeId_,
-  //const CppMetricsType::type metrics_)
-//{
+double CppMetricsServiceHandler::getCppMetricsForAstNode(
+  const core::AstNodeId& astNodeId_,
+  const CppMetricsType::type metrics_)
+{
 
-//}
+}
 
 } // cppmetrics
 } // service

--- a/plugins/cpp_metrics/test/CMakeLists.txt
+++ b/plugins/cpp_metrics/test/CMakeLists.txt
@@ -1,10 +1,13 @@
 include_directories(
-        ${PLUGIN_DIR}/model/include
-        ${PLUGIN_DIR}/service/include
-        ${CMAKE_CURRENT_BINARY_DIR}/../service/gen-cpp
-        ${PROJECT_SOURCE_DIR}/model/include
-        ${PROJECT_SOURCE_DIR}/plugins/cpp_metrics/model/include
-        ${PROJECT_BINARY_DIR}/plugins/cpp_metrics/model/include)
+  include
+  ${PLUGIN_DIR}/model/include
+  ${PLUGIN_DIR}/service/include
+  ${CMAKE_CURRENT_BINARY_DIR}/../service/gen-cpp
+  ${PROJECT_SOURCE_DIR}/model/include
+  ${PROJECT_BINARY_DIR}/service/project/gen-cpp
+  ${PROJECT_SOURCE_DIR}/service/project/include
+  ${PROJECT_SOURCE_DIR}/plugins/cpp_metrics/model/include
+  ${PROJECT_BINARY_DIR}/plugins/cpp_metrics/model/include)
 
 include_directories(SYSTEM
         ${THRIFT_LIBTHRIFT_INCLUDE_DIRS})
@@ -24,6 +27,7 @@ target_link_libraries(cppmetricsservicetest
         model
         cppmodel
         cppservice
+        commonthrift
         ${Boost_LIBRARIES}
         ${GTEST_BOTH_LIBRARIES}
         pthread)


### PR DESCRIPTION
I added basic Thrift API endpoints to the C++ metrics plugin. Currently there is only one endpoint that can query any type of metrics to a particular AST node. @mcserep what do you think what else I can add?