### PR TITLE
Fix ODB install in Docker images

### DIFF
--- a/docker/dev/install_odb.sh
+++ b/docker/dev/install_odb.sh
@@ -33,10 +33,7 @@ for pack in "$BUILD_LIST"; do
   bpkg build $pack --yes
 done
 # Install ODB (to /usr/local)
-INSTALL_LIST="$BUILD_LIST libstudxml libcutl"
-for pack in "$INSTALL_LIST"; do
-  bpkg install $pack
-done
+bpkg install --all --recursive
 # Clean up
 cd /
 sh install_latest_build2.sh --uninstall


### PR DESCRIPTION
Fixes #712.

Bug introduced in #644, as installation for `libstudxml` fails. Instead, a recursive installation of the selected packages and their dependencies should be performed - [as described in the CodeCompass build guide](https://github.com/Ericsson/CodeCompass/blob/master/doc/deps.md#odb-for-ubuntu-2204).

I have already resolved this as part of #710 (not merged yet), but I did not realize the severity of the issue at that time. Therefore now I create a separate PR for this.