### PR TITLE
Bumpy road complexity metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ build/
 build_*/
 install/
 install_*/
+

--- a/.gitignore
+++ b/.gitignore
@@ -16,23 +16,3 @@ build_*/
 install/
 install_*/
 
-compile_commands.json
-CMakeFiles/cmake.check_cache
-CMakeFiles/CMakeError.log
-CMakeFiles/CMakeOutput.log
-CMakeFiles/3.16.3/CMakeCCompiler.cmake
-CMakeFiles/3.16.3/CMakeCXXCompiler.cmake
-CMakeFiles/3.16.3/CMakeDetermineCompilerABI_C.bin
-CMakeFiles/3.16.3/CMakeDetermineCompilerABI_CXX.bin
-CMakeFiles/3.16.3/CMakeSystem.cmake
-CMakeFiles/3.16.3/CompilerIdC/a.out
-CMakeFiles/3.16.3/CompilerIdC/CMakeCCompilerId.c
-CMakeFiles/3.16.3/CompilerIdCXX/a.out
-CMakeFiles/3.16.3/CompilerIdCXX/CMakeCXXCompilerId.cpp
-plugins/CMakeFiles/CMakeLists.txt
-plugins/search/common/CMakeFiles/searchcommonjava.dir/java_sources
-plugins/search/indexer/CMakeFiles/searchindexerthriftjava.dir/java_sources
-plugins/search/indexer/indexer-java/CMakeFiles/searchindexerjava.dir/java_sources
-plugins/search/service/CMakeFiles/searchthriftjava.dir/java_sources
-plugins/search/service/search-java/CMakeFiles/searchservicejava.dir/java_sources
-service/project/CMakeFiles/corethriftjava.dir/java_sources

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@ build/
 build_*/
 install/
 install_*/
-

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,23 @@ build_*/
 install/
 install_*/
 
+compile_commands.json
+CMakeFiles/cmake.check_cache
+CMakeFiles/CMakeError.log
+CMakeFiles/CMakeOutput.log
+CMakeFiles/3.16.3/CMakeCCompiler.cmake
+CMakeFiles/3.16.3/CMakeCXXCompiler.cmake
+CMakeFiles/3.16.3/CMakeDetermineCompilerABI_C.bin
+CMakeFiles/3.16.3/CMakeDetermineCompilerABI_CXX.bin
+CMakeFiles/3.16.3/CMakeSystem.cmake
+CMakeFiles/3.16.3/CompilerIdC/a.out
+CMakeFiles/3.16.3/CompilerIdC/CMakeCCompilerId.c
+CMakeFiles/3.16.3/CompilerIdCXX/a.out
+CMakeFiles/3.16.3/CompilerIdCXX/CMakeCXXCompilerId.cpp
+plugins/CMakeFiles/CMakeLists.txt
+plugins/search/common/CMakeFiles/searchcommonjava.dir/java_sources
+plugins/search/indexer/CMakeFiles/searchindexerthriftjava.dir/java_sources
+plugins/search/indexer/indexer-java/CMakeFiles/searchindexerjava.dir/java_sources
+plugins/search/service/CMakeFiles/searchthriftjava.dir/java_sources
+plugins/search/service/search-java/CMakeFiles/searchservicejava.dir/java_sources
+service/project/CMakeFiles/corethriftjava.dir/java_sources

--- a/plugins/cpp/model/include/model/cppfunction.h
+++ b/plugins/cpp/model/include/model/cppfunction.h
@@ -102,9 +102,6 @@ struct CppFunctionBumpyRoad
 
   #pragma db column(File::path)
   std::string filePath;
-
-  #pragma db column(CppFunction::qualifiedName)
-  std::string qualName;
 };
 
 }

--- a/plugins/cpp/model/include/model/cppfunction.h
+++ b/plugins/cpp/model/include/model/cppfunction.h
@@ -18,7 +18,10 @@ struct CppFunction : CppTypedEntity
   std::vector<odb::lazy_shared_ptr<CppVariable>> parameters;
   #pragma db on_delete(cascade)
   std::vector<odb::lazy_shared_ptr<CppVariable>> locals;
+
   unsigned int mccabe;
+  unsigned int bumpiness;
+  unsigned int statementCount;
 
   std::string toString() const
   {
@@ -80,6 +83,28 @@ struct CppFunctionMcCabe
 
   #pragma db column(File::path)
   std::string filePath;
+};
+
+#pragma db view \
+  object(CppFunction) \
+  object(CppAstNode : CppFunction::astNodeId == CppAstNode::id) \
+  object(File : CppAstNode::location.file)
+struct CppFunctionBumpyRoad
+{
+  #pragma db column(CppEntity::astNodeId)
+  CppAstNodeId astNodeId;
+
+  #pragma db column(CppFunction::bumpiness)
+  unsigned int bumpiness;
+
+  #pragma db column(CppFunction::statementCount)
+  unsigned int statementCount;
+
+  #pragma db column(File::path)
+  std::string filePath;
+
+  #pragma db column(CppFunction::qualifiedName)
+  std::string qualName;
 };
 
 }

--- a/plugins/cpp/parser/CMakeLists.txt
+++ b/plugins/cpp/parser/CMakeLists.txt
@@ -44,7 +44,8 @@ add_library(cppparser SHARED
   src/ppmacrocallback.cpp
   src/relationcollector.cpp
   src/doccommentformatter.cpp
-  src/diagnosticmessagehandler.cpp)
+  src/diagnosticmessagehandler.cpp
+  src/nestedscope.cpp)
 
 target_link_libraries(cppparser
   cppmodel

--- a/plugins/cpp/parser/src/clangastvisitor.h
+++ b/plugins/cpp/parser/src/clangastvisitor.h
@@ -144,6 +144,8 @@ public:
 
   class TypeScope final
   {
+    DECLARE_SCOPED_TYPE(TypeScope)
+    
   private:
     ClangASTVisitor* _visitor;
     model::CppRecordPtr _type;
@@ -170,6 +172,8 @@ public:
 
   class EnumScope final
   {
+    DECLARE_SCOPED_TYPE(EnumScope)
+
   private:
     ClangASTVisitor* _visitor;
     model::CppEnumPtr _enum;
@@ -196,6 +200,8 @@ public:
 
   class FunctionScope final
   {
+    DECLARE_SCOPED_TYPE(FunctionScope)
+
   private:
     ClangASTVisitor* _visitor;
     model::CppFunctionPtr _curFun;
@@ -321,6 +327,8 @@ public:
 
   class CtxStmtScope final
   {
+    DECLARE_SCOPED_TYPE(CtxStmtScope)
+
   private:
     ClangASTVisitor* _visitor;
 

--- a/plugins/cpp/parser/src/clangastvisitor.h
+++ b/plugins/cpp/parser/src/clangastvisitor.h
@@ -210,6 +210,8 @@ public:
 
     ~FunctionScope()
     {
+      assert(_curFun == _visitor->_functionStack.top() &&
+        "Function scope destruction order has been violated.");
       if (_curFun->astNodeId)
         _visitor->_functions.push_back(_curFun);
       _visitor->_functionStack.pop();

--- a/plugins/cpp/parser/src/clangastvisitor.h
+++ b/plugins/cpp/parser/src/clangastvisitor.h
@@ -283,7 +283,7 @@ public:
       // We must also make an initial scope entry for the function's body.
       StatementScope ss(&_stmtStack, nullptr);
       ss.MakeFunction(fd->getBody());
-      return Base::TraverseDecl(d_);
+      return Base::TraverseDecl(fd);
     }
     else if (clang::RecordDecl* rd = llvm::dyn_cast<clang::RecordDecl>(d_))
     {
@@ -292,7 +292,7 @@ public:
       // The scope creates a database object for the record/type
       // at the beginning, and persists it at the end.
       TypeScope ts(this);
-      return Base::TraverseDecl(d_);
+      return Base::TraverseDecl(rd);
     }
     else return Base::TraverseDecl(d_);
   }

--- a/plugins/cpp/parser/src/clangastvisitor.h
+++ b/plugins/cpp/parser/src/clangastvisitor.h
@@ -306,7 +306,6 @@ public:
       ++_functionStack.top()->mccabe;
   }
 
-
   void CountBumpiness(const StatementScope& scope_)
   {
     if (!_functionStack.empty() && scope_.IsReal())

--- a/plugins/cpp/parser/src/clangastvisitor.h
+++ b/plugins/cpp/parser/src/clangastvisitor.h
@@ -477,7 +477,9 @@ public:
       scope = std::make_unique<NestedOneWayScope>(&_scopeStack, cs, cs->getHandlerBlock());
     else if (clang::CompoundStmt* cs = llvm::dyn_cast<clang::CompoundStmt>(s_))
       scope = std::make_unique<NestedCompoundScope>(&_scopeStack, cs);
-    else if (!llvm::isa<clang::SwitchCase>(s_))
+    else if (clang::SwitchCase* sc = llvm::dyn_cast<clang::SwitchCase>(s_))
+      scope = std::make_unique<NestedTransparentScope>(&_scopeStack, sc);
+    else
       // This is why we can't do this in the indidvidual handler functions:
       // There is no Traverse* function equivalent to a general 'else' case
       // when the current statement is neither of the above specified ones.
@@ -489,9 +491,7 @@ public:
       // statement would essentially be duplicated on the scope stack,
       // which would disrupt the meaning of actual scopes in the code.
       scope = std::make_unique<NestedStatementScope>(&_scopeStack, s_);
-    
-    if (scope)
-      CountBumpiness(*scope);
+    CountBumpiness(*scope);
 
     return Base::TraverseStmt(s_);
   }

--- a/plugins/cpp/parser/src/clangastvisitor.h
+++ b/plugins/cpp/parser/src/clangastvisitor.h
@@ -39,6 +39,7 @@
 #include <parser/sourcemanager.h>
 #include <util/hash.h>
 #include <util/odbtransaction.h>
+#include <util/scopedvalue.h>
 
 #include <cppparser/filelocutil.h>
 
@@ -193,27 +194,6 @@ public:
     }
   };
 
-  template<typename T>
-  class ScopedValue final
-  {
-  private:
-    T& _storage;
-    T _oldValue;
-
-  public:
-    ScopedValue(T& storage_, const T& newValue_) :
-      _storage(storage_),
-      _oldValue(_storage)
-    {
-      _storage = newValue_;
-    }
-
-    ~ScopedValue()
-    {
-      _storage = _oldValue;
-    }
-  };
-
   class FunctionScope final
   {
   private:
@@ -260,7 +240,7 @@ public:
     // Clang is concerned, their operator() is not. In order to be able to
     // properly assign symbol location information to AST nodes within
     // lambda bodies, we must force lambdas to be considered explicit.
-    ScopedValue<bool> sv(_isImplicit, _isImplicit && !rd_->isLambda());
+    util::ScopedValue<bool> sv(_isImplicit, _isImplicit && !rd_->isLambda());
     return Base::TraverseCXXRecordDecl(rd_);
   }
 
@@ -286,7 +266,7 @@ public:
     // To bridge the gap between the two interpretations, we mostly assume
     // implicitness to be hereditary from parent to child nodes, except
     // in some known special cases (see lambdas in TraverseCXXRecordDecl).
-    ScopedValue<bool> sv(_isImplicit, _isImplicit || d_->isImplicit());
+    util::ScopedValue<bool> sv(_isImplicit, _isImplicit || d_->isImplicit());
     
     if (clang::FunctionDecl* fd = llvm::dyn_cast<clang::FunctionDecl>(d_))
     {

--- a/plugins/cpp/parser/src/nestedscope.cpp
+++ b/plugins/cpp/parser/src/nestedscope.cpp
@@ -37,21 +37,29 @@ namespace parser
   }
 
 
-  NestedScope::State NestedCompoundScope::CheckNext(clang::Stmt*) const
+  NestedScope::State NestedTransparentScope::CheckNext(clang::Stmt*) const
   {
-    // Anything inside a compound statement block is standalone,
+    // Anything inside a transparent statement block is standalone,
     // we do not expect any particular type of statement to be nested in it.
     return State::Standalone;
   }
+
+  NestedTransparentScope::NestedTransparentScope(
+    NestedStack* stack_,
+    clang::Stmt* stmt_
+  ) :
+    NestedScope(stack_, stmt_)
+  {}
+
 
   NestedCompoundScope::NestedCompoundScope(
     NestedStack* stack_,
     clang::Stmt* stmt_
   ) :
-    NestedScope(stack_, stmt_)
+    NestedTransparentScope(stack_, stmt_)
   {
-    // A compound statement block only counts as a real scope when it is
-    // not the expected body of any other statement (e.g. if, while, ...)
+    // A compound statement block only counts as a non-transparent scope
+    // when it is not the expected body of any other statement.
     if (_state == State::Standalone)
       ++_depth;
   }

--- a/plugins/cpp/parser/src/nestedscope.cpp
+++ b/plugins/cpp/parser/src/nestedscope.cpp
@@ -1,0 +1,130 @@
+#include "nestedscope.h"
+
+namespace cc
+{
+namespace parser
+{
+
+  NestedScope::NestedScope(
+    NestedStack* stack_,
+    clang::Stmt* stmt_
+  ) :
+    _stack(stack_),
+    _previous(_stack->_top),
+    _stmt(stmt_),
+    _depth(0),
+    _state(State::Initial)
+  {
+    if (_previous != nullptr)
+    {
+      _depth = _previous->_depth;
+      if (_stmt != nullptr)
+        _state = _previous->CheckNext(_stmt);
+    }
+
+    if (_state != State::Invalid)
+      _stack->_top = this;
+  }
+
+  NestedScope::~NestedScope()
+  {
+    if (_state != State::Invalid)
+    {
+      assert(_stack->_top == this &&
+        "Scope destruction order has been violated.");
+      _stack->_top = _previous;
+    }
+  }
+
+
+  NestedScope::State NestedCompoundScope::CheckNext(clang::Stmt*) const
+  {
+    // Anything inside a compound statement block is standalone,
+    // we do not expect any particular type of statement to be nested in it.
+    return State::Standalone;
+  }
+
+  NestedCompoundScope::NestedCompoundScope(
+    NestedStack* stack_,
+    clang::Stmt* stmt_
+  ) :
+    NestedScope(stack_, stmt_)
+  {
+    // A compound statement block only counts as a real scope when it is
+    // not the expected body of any other statement (e.g. if, while, ...)
+    if (_state == State::Standalone)
+      ++_depth;
+  }
+
+
+  NestedScope::State NestedStatementScope::CheckNext(clang::Stmt*) const
+  {
+    // A non-specialized statement scope is a single statement.
+    // Anything inside a single statement (e.g sub-expressions) is not
+    // something to be counted towards the total bumpiness of a function.
+    return State::Invalid;
+  }
+
+  NestedStatementScope::NestedStatementScope(
+    NestedStack* stack_,
+    clang::Stmt* stmt_
+  ) :
+    NestedScope(stack_, stmt_)
+  {
+    // As long as the statement itself is valid on the stack,
+    // it is a real scoped statement.
+    if (_state != State::Invalid)
+      ++_depth;
+  }
+
+
+  NestedScope::State NestedOneWayScope::CheckNext(clang::Stmt* stmt_) const
+  {
+    // A one-way scope expects a particular statement to be nested inside it.
+    // Anything else above it on the stack is invalid.
+    return (stmt_ == _next)
+      ? State::Expected : State::Invalid;
+  }
+
+  NestedOneWayScope::NestedOneWayScope(
+    NestedStack* stack_,
+    clang::Stmt* stmt_,
+    clang::Stmt* next_
+  ) :
+    NestedStatementScope(stack_, stmt_),
+    _next(next_)
+  {}
+
+
+  NestedFunctionScope::NestedFunctionScope(
+    NestedStack* stack_,
+    clang::Stmt* next_
+  ) :
+    NestedOneWayScope(stack_, nullptr, next_)
+  {
+    // The level of nestedness always starts from zero at the function level.
+    _depth = 0;
+  }
+
+
+  NestedScope::State NestedTwoWayScope::CheckNext(clang::Stmt* stmt_) const
+  {
+    // A two-way scope expects either of two particular statements to be
+    // nested inside it. Anything else above it on the stack is invalid.
+    return (stmt_ == _next0 || stmt_ == _next1)
+      ? State::Expected : State::Invalid;
+  }
+
+  NestedTwoWayScope::NestedTwoWayScope(
+    NestedStack* stack_,
+    clang::Stmt* stmt_,
+    clang::Stmt* next0_,
+    clang::Stmt* next1_
+  ) :
+    NestedStatementScope(stack_, stmt_),
+    _next0(next0_),
+    _next1(next1_)
+  {}
+
+}
+}

--- a/plugins/cpp/parser/src/nestedscope.cpp
+++ b/plugins/cpp/parser/src/nestedscope.cpp
@@ -14,11 +14,10 @@ namespace parser
   }
 
 
-  StatementScope::State StatementScope::CheckNext(clang::Stmt* stmt_)
+  StatementScope::State StatementScope::CheckNext(clang::Stmt* stmt_) const
   {
     if (_state == State::Invalid)
       return State::Invalid;
-    EnsureConfigured();
     switch (_kind)
     {
       case Kind::Open:
@@ -53,6 +52,7 @@ namespace parser
   {
     if (_previous != nullptr)
     {
+      _previous->EnsureConfigured();
       _depth = _previous->_depth;
       if (_stmt != nullptr)
         _state = _previous->CheckNext(_stmt);

--- a/plugins/cpp/parser/src/nestedscope.h
+++ b/plugins/cpp/parser/src/nestedscope.h
@@ -1,0 +1,121 @@
+#ifndef CC_PARSER_NESTEDSCOPE_H
+#define CC_PARSER_NESTEDSCOPE_H
+
+#include <clang/AST/Stmt.h>
+
+namespace cc
+{
+namespace parser
+{
+
+  class NestedScope;
+
+  class NestedStack final
+  {
+    friend class NestedScope;
+
+  private:
+    NestedScope* _top;
+
+  public:
+    NestedScope* Top() const { return _top; }
+
+    NestedStack() : _top(nullptr) {}
+  };
+
+  class NestedScope
+  {
+  protected:
+    enum class State : unsigned char
+    {
+      Initial,
+      Expected,
+      Standalone,
+      Invalid,
+    };
+
+    NestedStack* _stack;
+    NestedScope* _previous;
+    clang::Stmt* _stmt;
+    unsigned int _depth;
+    State _state;
+
+    virtual State CheckNext(clang::Stmt* stmt_) const = 0;
+
+  public:
+    NestedStack* Stack() const { return _stack; }
+    NestedScope* Previous() const { return _previous; }
+    clang::Stmt* Statement() const { return _stmt; }
+
+    unsigned int PrevDepth() const
+    { return _previous != nullptr ? _previous->_depth : 0; }
+    unsigned int Depth() const { return _depth; }
+    bool IsReal() const { return Depth() > PrevDepth(); }
+
+    NestedScope(NestedStack* stack_, clang::Stmt* stmt_);
+    virtual ~NestedScope();
+  };
+
+  class NestedCompoundScope : public NestedScope
+  {
+  protected:
+    virtual State CheckNext(clang::Stmt* stmt_) const override;
+
+  public:
+    NestedCompoundScope(NestedStack* stack_, clang::Stmt* stmt_);
+  };
+
+  class NestedStatementScope : public NestedScope
+  {
+  protected:
+    virtual State CheckNext(clang::Stmt* stmt_) const override;
+
+  public:
+    NestedStatementScope(NestedStack* stack_, clang::Stmt* stmt_);
+  };
+
+  class NestedOneWayScope : public NestedStatementScope
+  {
+  protected:
+    clang::Stmt* _next;
+
+    virtual State CheckNext(clang::Stmt* stmt_) const override;
+
+  public:
+    NestedOneWayScope(
+      NestedStack* stack_,
+      clang::Stmt* stmt_,
+      clang::Stmt* next_
+    );
+  };
+  
+  class NestedFunctionScope : public NestedOneWayScope
+  {
+  public:
+    NestedFunctionScope(
+      NestedStack* stack_,
+      clang::Stmt* next_
+    );
+  };
+  
+  class NestedTwoWayScope : public NestedStatementScope
+  {
+  protected:
+    clang::Stmt* _next0;
+    clang::Stmt* _next1;
+
+    virtual State CheckNext(clang::Stmt* stmt_) const override;
+
+  public:
+    NestedTwoWayScope(
+      NestedStack* stack_,
+      clang::Stmt* stmt_,
+      clang::Stmt* next0_,
+      clang::Stmt* next1_
+    );
+  };
+
+}
+}
+
+#endif

--- a/plugins/cpp/parser/src/nestedscope.h
+++ b/plugins/cpp/parser/src/nestedscope.h
@@ -28,7 +28,7 @@ namespace parser
   {
     friend class StatementStack;
     
-  protected:
+  private:
     enum class State : unsigned char
     {
       Initial,// This statement is the root in its function.
@@ -55,7 +55,7 @@ namespace parser
     clang::Stmt* _exp0;
     clang::Stmt* _exp1;
 
-    State CheckNext(clang::Stmt* stmt_);
+    State CheckNext(clang::Stmt* stmt_) const;
 
   public:
     StatementStack* Stack() const { return _stack; }

--- a/plugins/cpp/parser/src/nestedscope.h
+++ b/plugins/cpp/parser/src/nestedscope.h
@@ -3,6 +3,8 @@
 
 #include <clang/AST/Stmt.h>
 
+#include <util/scopedvalue.h>
+
 namespace cc
 {
 namespace parser
@@ -12,6 +14,8 @@ namespace parser
 
   class StatementStack final
   {
+    DECLARE_SCOPED_TYPE(StatementStack)
+
     friend class StatementScope;
 
   private:
@@ -26,6 +30,8 @@ namespace parser
 
   class StatementScope final
   {
+    DECLARE_SCOPED_TYPE(StatementScope)
+
     friend class StatementStack;
     
   private:

--- a/plugins/cpp/parser/src/nestedscope.h
+++ b/plugins/cpp/parser/src/nestedscope.h
@@ -56,11 +56,17 @@ namespace parser
     virtual ~NestedScope();
   };
 
-  class NestedCompoundScope : public NestedScope
+  class NestedTransparentScope : public NestedScope
   {
   protected:
     virtual State CheckNext(clang::Stmt* stmt_) const override;
 
+  public:
+    NestedTransparentScope(NestedStack* stack_, clang::Stmt* stmt_);
+  };
+
+  class NestedCompoundScope : public NestedTransparentScope
+  {
   public:
     NestedCompoundScope(NestedStack* stack_, clang::Stmt* stmt_);
   };

--- a/plugins/cpp_metrics/model/include/model/cppastnodemetrics.h
+++ b/plugins/cpp_metrics/model/include/model/cppastnodemetrics.h
@@ -17,8 +17,9 @@ struct CppAstNodeMetrics
   {
     PARAMETER_COUNT = 1,
     MCCABE = 2,
-    LACK_OF_COHESION = 3,
-    LACK_OF_COHESION_HS = 4,
+    BUMPY_ROAD = 3,
+    LACK_OF_COHESION = 4,
+    LACK_OF_COHESION_HS = 5,
   };
 
   #pragma db id auto

--- a/plugins/cpp_metrics/parser/include/cppmetricsparser/cppmetricsparser.h
+++ b/plugins/cpp_metrics/parser/include/cppmetricsparser/cppmetricsparser.h
@@ -35,6 +35,8 @@ private:
   void functionParameters();
   // Calculate the McCabe complexity of functions.
   void functionMcCabe();
+  // Calculate the bumpy road metric for every function.
+  void functionBumpyRoad();
   // Calculate the lack of cohesion between member variables
   // and member functions for every type.
   void lackOfCohesion();

--- a/plugins/cpp_metrics/parser/src/cppmetricsparser.cpp
+++ b/plugins/cpp_metrics/parser/src/cppmetricsparser.cpp
@@ -141,6 +141,30 @@ void CppMetricsParser::functionMcCabe()
   });
 }
 
+void CppMetricsParser::functionBumpyRoad()
+{
+  util::OdbTransaction {_ctx.db} ([&, this]
+  {
+    for (const model::CppFunctionBumpyRoad& function
+      : _ctx.db->query<model::CppFunctionBumpyRoad>())
+    {
+      // Skip functions that were included from external libraries.
+      if (!cc::util::isRootedUnderAnyOf(_inputPaths, function.filePath))
+        continue;
+
+      const double dB = function.bumpiness;
+      const double dC = function.statementCount;
+      const bool empty = function.statementCount == 0;
+
+      model::CppAstNodeMetrics metrics;
+      metrics.astNodeId = function.astNodeId;
+      metrics.type = model::CppAstNodeMetrics::Type::BUMPY_ROAD;
+      metrics.value = empty ? 1.0 : (dB / dC);
+      _ctx.db->persist(metrics);
+    }
+  });
+}
+
 void CppMetricsParser::lackOfCohesion()
 {
   util::OdbTransaction {_ctx.db} ([&, this]
@@ -250,6 +274,7 @@ bool CppMetricsParser::parse()
 {
   functionParameters();
   functionMcCabe();
+  functionBumpyRoad();
   lackOfCohesion();
   return true;
 }

--- a/plugins/cpp_metrics/test/sources/parser/CMakeLists.txt
+++ b/plugins/cpp_metrics/test/sources/parser/CMakeLists.txt
@@ -3,4 +3,5 @@ project(CppMetricsTestProject)
 
 add_library(CppMetricsTestProject STATIC
   mccabe.cpp
-  lackofcohesion.cpp)
+  lackofcohesion.cpp
+  bumpyroad.cpp)

--- a/plugins/cpp_metrics/test/sources/parser/bumpyroad.cpp
+++ b/plugins/cpp_metrics/test/sources/parser/bumpyroad.cpp
@@ -1,0 +1,276 @@
+#include <vector>
+
+using namespace std;
+
+// Flat
+
+void flat_empty_inline() {}
+
+void flat_empty()
+{
+
+}
+
+int flat_regular(int a, int b)
+{
+    int aa = a * a;
+    int ab2 = 2 * a * b;
+    int bb = b * b;
+    return aa + ab2 + bb;
+}
+
+// Single bump
+
+void single_compound()
+{
+    {
+        int z = 0;
+    }
+}
+
+bool single_if_simple(bool a)
+{
+    if (a)
+        a = false;
+    return a;
+}
+
+int single_if_complex(int a)
+{
+    if (2ULL * a + static_cast<int>(1.0) < 12)
+        a += 5 * (a << 3);
+    return a;
+}
+
+int single_for_each(const vector<int>& v)
+{
+    int s = 0;
+    for (int e : v)
+        s += e;
+    return s;
+}
+
+int single_for_loop(const vector<int>& v)
+{
+    int s = 0;
+    for (size_t i = 0; i < v.size(); ++i)
+        s += v[i];
+    return s;
+}
+
+// Nested chain
+
+void nested_chain_compound()
+{
+    {
+        {
+            {
+                int z = 0;
+            }
+        }
+    }
+}
+
+void nested_chain_if()
+{
+    if (0 == 0)
+        if (true)
+            if (false)
+                flat_empty();
+}
+
+void nested_chain_compound_if()
+{
+    if (0 == 0)
+    {
+        if (true)
+        {
+            if (false)
+            {
+                flat_empty();
+            }
+        }
+    }
+}
+
+void nested_chain_for(const vector<vector<vector<int>>>& array, int& sum)
+{
+    for (const auto& a0 : array)
+        for (const auto& a1 : a0)
+            for (const auto& a2 : a1)
+                sum += a2;
+}
+
+void nested_chain_compound_for(const vector<vector<vector<int>>>& array, int& sum)
+{
+    for (const auto& a0 : array)
+    {
+        for (const auto& a1 : a0)
+        {
+            for (const auto& a2 : a1)
+            {
+                sum += a2;
+            }
+        }
+    }
+}
+
+int nested_chain_mixed(int n)
+{
+    switch (n)
+    {
+    default:
+        if (n < 0)
+        {
+            for (int i = 0; i < n; ++i)
+            {
+                try
+                {
+                    while (false)
+                    {
+                        do
+                        {
+                            return 0;
+                        }
+                        while (true);
+                    }
+                }
+                catch (...) {}
+            }
+        }
+    }
+    return 0;
+}
+
+// Compare
+
+void compare_level1()
+{
+    if (true)
+    {
+        long a = 7;
+        long b = 3;
+        long c = a * b;
+    }
+}
+
+void compare_level2()
+{
+    if (true)
+    {
+        if (true)
+        {
+            long a = 7;
+            long b = 3;
+            long c = a * b;
+        }
+    }
+}
+
+void compare_level3()
+{
+    if (true)
+    {
+        if (true)
+        {
+            if (true)
+            {
+                long a = 7;
+                long b = 3;
+                long c = a * b;
+            }
+        }
+    }
+}
+
+// Complex
+
+int complex_two_levels(int i, int j)
+{
+    int m = i + 2 * j, n = -j;
+    if (m + n < 42)
+    {
+        if (n < 0)
+            m *= 8;
+    }
+    else
+    {
+        if (m > 0)
+            n -= m * 2 - 1;
+    }
+
+    int s = 0;
+    for (int k = m; k < n; ++k)
+        s += (k % 6 == 0) ? k : n;
+
+    return s;
+}
+
+int complex_three_levels_min(int a, int b)
+{
+    if (a > 0)
+        if (b > 0)
+            if (a + b < 100)
+                return a + b;
+    
+    a ^= b;
+    b ^= a;
+    a ^= b;
+    return 2 * a + b;
+}
+
+int complex_three_levels_max(int a, int b)
+{
+    if (a > 0)
+        if (b > 0)
+            if (a + b < 100)
+            {
+                a ^= b;
+                b ^= a;
+                a ^= b;
+                return 2 * a + b;
+            }
+    
+    return a + b;
+}
+
+// Nested lambda
+
+void nested_lambda()
+{
+    auto a = []()
+    {
+        auto b = []()
+        {
+            auto c = []()
+            {
+                int z = 0;
+            };
+        };
+    };
+}
+
+// Nested type
+
+void nested_type()
+{
+    struct nested1
+    {
+        void method1()
+        {
+            struct nested2
+            {
+                void method2()
+                {
+                    struct nested3
+                    {
+                        void method3()
+                        {
+                            int z = 0;
+                        }
+                    };
+                }
+            };
+        }
+    };
+}

--- a/plugins/cpp_metrics/test/sources/parser/mccabe.cpp
+++ b/plugins/cpp_metrics/test/sources/parser/mccabe.cpp
@@ -112,20 +112,21 @@ public:
   MyClass(unsigned int arg1) // +1
   {
     if (arg1 < LIMIT) // +1
-      badPractice = new char[LIMIT];
+      size = LIMIT;
     else
-      badPractice = new char[arg1];
+      size = arg1;
+    badPractice = new char[size];
   } // 2
 
   ~MyClass() // +1
   {
-    for (unsigned int i = 0; i < LIMIT; ++i) {} // +1
+    for (unsigned int i = 0; i < size; ++i) {} // +1
     delete[] badPractice;
   } // 2
 
   void method1(int arg1); // -
   
-  operator char*() const; // -
+  operator unsigned int() const; // -
   
   explicit operator bool() const // +1
   {
@@ -133,13 +134,15 @@ public:
   } // 1
   
 private:
-  const unsigned int LIMIT = 42;
+  static constexpr unsigned int LIMIT = 42;
+
   char* badPractice;
+  unsigned int size;
 };
 
-MyClass::operator char*() const // +1
+MyClass::operator unsigned int() const // +1
 {
-  return badPractice;
+  return size;
 } // 1
 
 void MyClass::method1(int arg1) // +1

--- a/plugins/cpp_metrics/test/sources/parser/mccabe.cpp
+++ b/plugins/cpp_metrics/test/sources/parser/mccabe.cpp
@@ -123,26 +123,67 @@ public:
     delete[] badPractice;
   } // 2
 
-  void method1(int arg1) // +1
+  void method1(int arg1); // -
+  
+  operator char*() const; // -
+  
+  explicit operator bool() const // +1
   {
-    for (unsigned int i = arg1; i < LIMIT; ++i) // +1
-    {
-      switch(arg1)
-      {
-        case -1: // +1
-          goto endfor; // +1
-        case 0: // +1
-          break;
-        case 1: // +1
-          break;
-        default: // +1
-          continue; // +1
-      }
-      arg1 *= 2;
-    }
-    endfor:;
-  } // 8
+    return badPractice != nullptr;
+  } // 1
+  
 private:
   const unsigned int LIMIT = 42;
   char* badPractice;
 };
+
+MyClass::operator char*() const // +1
+{
+  return badPractice;
+} // 1
+
+void MyClass::method1(int arg1) // +1
+{
+for (unsigned int i = arg1; i < LIMIT; ++i) // +1
+{
+  switch(arg1)
+  {
+    case -1: // +1
+      goto endfor; // +1
+    case 0: // +1
+      break;
+    case 1: // +1
+      break;
+    default: // +1
+      continue; // +1
+  }
+  arg1 *= 2;
+}
+endfor:;
+} // 8
+
+class NoBody1
+{
+public:
+	NoBody1() = default; // 1
+};
+
+class NoBody2
+{
+public:
+	NoBody2(const NoBody2& other) = delete; // 1
+};
+
+class NoBody3
+{
+public:
+	NoBody3(NoBody3&& other) = delete; // 1
+};
+
+class NoBody4
+{
+public:
+	virtual ~NoBody4(); // -
+};
+
+NoBody4::~NoBody4() = default; // 1

--- a/plugins/cpp_metrics/test/sources/parser/mccabe.cpp
+++ b/plugins/cpp_metrics/test/sources/parser/mccabe.cpp
@@ -180,13 +180,7 @@ public:
 class NoBody3
 {
 public:
-	NoBody3(NoBody3&& other) = delete; // 1
+	virtual ~NoBody3(); // -
 };
 
-class NoBody4
-{
-public:
-	virtual ~NoBody4(); // -
-};
-
-NoBody4::~NoBody4() = default; // 1
+NoBody3::~NoBody3() = default; // 1

--- a/plugins/cpp_metrics/test/sources/service/CMakeLists.txt
+++ b/plugins/cpp_metrics/test/sources/service/CMakeLists.txt
@@ -3,4 +3,5 @@ project(CppMetricsTestProject)
 
 add_library(CppMetricsTestProject STATIC
   mccabe.cpp
-  lackofcohesion.cpp)
+  lackofcohesion.cpp
+  bumpyroad.cpp)

--- a/plugins/cpp_metrics/test/sources/service/bumpyroad.cpp
+++ b/plugins/cpp_metrics/test/sources/service/bumpyroad.cpp
@@ -1,0 +1,276 @@
+#include <vector>
+
+using namespace std;
+
+// Flat
+
+void flat_empty_inline() {}
+
+void flat_empty()
+{
+
+}
+
+int flat_regular(int a, int b)
+{
+    int aa = a * a;
+    int ab2 = 2 * a * b;
+    int bb = b * b;
+    return aa + ab2 + bb;
+}
+
+// Single bump
+
+void single_compound()
+{
+    {
+        int z = 0;
+    }
+}
+
+bool single_if_simple(bool a)
+{
+    if (a)
+        a = false;
+    return a;
+}
+
+int single_if_complex(int a)
+{
+    if (2ULL * a + static_cast<int>(1.0) < 12)
+        a += 5 * (a << 3);
+    return a;
+}
+
+int single_for_each(const vector<int>& v)
+{
+    int s = 0;
+    for (int e : v)
+        s += e;
+    return s;
+}
+
+int single_for_loop(const vector<int>& v)
+{
+    int s = 0;
+    for (size_t i = 0; i < v.size(); ++i)
+        s += v[i];
+    return s;
+}
+
+// Nested chain
+
+void nested_chain_compound()
+{
+    {
+        {
+            {
+                int z = 0;
+            }
+        }
+    }
+}
+
+void nested_chain_if()
+{
+    if (0 == 0)
+        if (true)
+            if (false)
+                flat_empty();
+}
+
+void nested_chain_compound_if()
+{
+    if (0 == 0)
+    {
+        if (true)
+        {
+            if (false)
+            {
+                flat_empty();
+            }
+        }
+    }
+}
+
+void nested_chain_for(const vector<vector<vector<int>>>& array, int& sum)
+{
+    for (const auto& a0 : array)
+        for (const auto& a1 : a0)
+            for (const auto& a2 : a1)
+                sum += a2;
+}
+
+void nested_chain_compound_for(const vector<vector<vector<int>>>& array, int& sum)
+{
+    for (const auto& a0 : array)
+    {
+        for (const auto& a1 : a0)
+        {
+            for (const auto& a2 : a1)
+            {
+                sum += a2;
+            }
+        }
+    }
+}
+
+int nested_chain_mixed(int n)
+{
+    switch (n)
+    {
+    default:
+        if (n < 0)
+        {
+            for (int i = 0; i < n; ++i)
+            {
+                try
+                {
+                    while (false)
+                    {
+                        do
+                        {
+                            return 0;
+                        }
+                        while (true);
+                    }
+                }
+                catch (...) {}
+            }
+        }
+    }
+    return 0;
+}
+
+// Compare
+
+void compare_level1()
+{
+    if (true)
+    {
+        long a = 7;
+        long b = 3;
+        long c = a * b;
+    }
+}
+
+void compare_level2()
+{
+    if (true)
+    {
+        if (true)
+        {
+            long a = 7;
+            long b = 3;
+            long c = a * b;
+        }
+    }
+}
+
+void compare_level3()
+{
+    if (true)
+    {
+        if (true)
+        {
+            if (true)
+            {
+                long a = 7;
+                long b = 3;
+                long c = a * b;
+            }
+        }
+    }
+}
+
+// Complex
+
+int complex_two_levels(int i, int j)
+{
+    int m = i + 2 * j, n = -j;
+    if (m + n < 42)
+    {
+        if (n < 0)
+            m *= 8;
+    }
+    else
+    {
+        if (m > 0)
+            n -= m * 2 - 1;
+    }
+
+    int s = 0;
+    for (int k = m; k < n; ++k)
+        s += (k % 6 == 0) ? k : n;
+
+    return s;
+}
+
+int complex_three_levels_min(int a, int b)
+{
+    if (a > 0)
+        if (b > 0)
+            if (a + b < 100)
+                return a + b;
+    
+    a ^= b;
+    b ^= a;
+    a ^= b;
+    return 2 * a + b;
+}
+
+int complex_three_levels_max(int a, int b)
+{
+    if (a > 0)
+        if (b > 0)
+            if (a + b < 100)
+            {
+                a ^= b;
+                b ^= a;
+                a ^= b;
+                return 2 * a + b;
+            }
+    
+    return a + b;
+}
+
+// Nested lambda
+
+void nested_lambda()
+{
+    auto a = []()
+    {
+        auto b = []()
+        {
+            auto c = []()
+            {
+                int z = 0;
+            };
+        };
+    };
+}
+
+// Nested type
+
+void nested_type()
+{
+    struct nested1
+    {
+        void method1()
+        {
+            struct nested2
+            {
+                void method2()
+                {
+                    struct nested3
+                    {
+                        void method3()
+                        {
+                            int z = 0;
+                        }
+                    };
+                }
+            };
+        }
+    };
+}

--- a/plugins/cpp_metrics/test/sources/service/mccabe.cpp
+++ b/plugins/cpp_metrics/test/sources/service/mccabe.cpp
@@ -112,20 +112,21 @@ public:
   MyClass(unsigned int arg1) // +1
   {
     if (arg1 < LIMIT) // +1
-      badPractice = new char[LIMIT];
+      size = LIMIT;
     else
-      badPractice = new char[arg1];
+      size = arg1;
+    badPractice = new char[size];
   } // 2
 
   ~MyClass() // +1
   {
-    for (unsigned int i = 0; i < LIMIT; ++i) {} // +1
+    for (unsigned int i = 0; i < size; ++i) {} // +1
     delete[] badPractice;
   } // 2
 
   void method1(int arg1); // -
   
-  operator char*() const; // -
+  operator unsigned int() const; // -
   
   explicit operator bool() const // +1
   {
@@ -133,13 +134,15 @@ public:
   } // 1
   
 private:
-  const unsigned int LIMIT = 42;
+  static constexpr unsigned int LIMIT = 42;
+
   char* badPractice;
+  unsigned int size;
 };
 
-MyClass::operator char*() const // +1
+MyClass::operator unsigned int() const // +1
 {
-  return badPractice;
+  return size;
 } // 1
 
 void MyClass::method1(int arg1) // +1

--- a/plugins/cpp_metrics/test/sources/service/mccabe.cpp
+++ b/plugins/cpp_metrics/test/sources/service/mccabe.cpp
@@ -123,26 +123,67 @@ public:
     delete[] badPractice;
   } // 2
 
-  void method1(int arg1) // +1
+  void method1(int arg1); // -
+  
+  operator char*() const; // -
+  
+  explicit operator bool() const // +1
   {
-    for (unsigned int i = arg1; i < LIMIT; ++i) // +1
-    {
-      switch(arg1)
-      {
-        case -1: // +1
-          goto endfor; // +1
-        case 0: // +1
-          break;
-        case 1: // +1
-          break;
-        default: // +1
-          continue; // +1
-      }
-      arg1 *= 2;
-    }
-    endfor:;
-  } // 8
+    return badPractice != nullptr;
+  } // 1
+  
 private:
   const unsigned int LIMIT = 42;
   char* badPractice;
 };
+
+MyClass::operator char*() const // +1
+{
+  return badPractice;
+} // 1
+
+void MyClass::method1(int arg1) // +1
+{
+for (unsigned int i = arg1; i < LIMIT; ++i) // +1
+{
+  switch(arg1)
+  {
+    case -1: // +1
+      goto endfor; // +1
+    case 0: // +1
+      break;
+    case 1: // +1
+      break;
+    default: // +1
+      continue; // +1
+  }
+  arg1 *= 2;
+}
+endfor:;
+} // 8
+
+class NoBody1
+{
+public:
+	NoBody1() = default; // 1
+};
+
+class NoBody2
+{
+public:
+	NoBody2(const NoBody2& other) = delete; // 1
+};
+
+class NoBody3
+{
+public:
+	NoBody3(NoBody3&& other) = delete; // 1
+};
+
+class NoBody4
+{
+public:
+	virtual ~NoBody4(); // -
+};
+
+NoBody4::~NoBody4() = default; // 1

--- a/plugins/cpp_metrics/test/sources/service/mccabe.cpp
+++ b/plugins/cpp_metrics/test/sources/service/mccabe.cpp
@@ -180,13 +180,7 @@ public:
 class NoBody3
 {
 public:
-	NoBody3(NoBody3&& other) = delete; // 1
+	virtual ~NoBody3(); // -
 };
 
-class NoBody4
-{
-public:
-	virtual ~NoBody4(); // -
-};
-
-NoBody4::~NoBody4() = default; // 1
+NoBody3::~NoBody3() = default; // 1

--- a/plugins/cpp_metrics/test/src/cppmetricsparsertest.cpp
+++ b/plugins/cpp_metrics/test/src/cppmetricsparsertest.cpp
@@ -140,7 +140,7 @@ std::vector<BumpyRoadParam> paramBumpyRoad = {
   {"compare_level1", 7, 4},
   {"compare_level2", 12, 5},
   {"compare_level3", 18, 6},
-  {"complex_two_levels", 18, 11},
+  {"complex_two_levels", 17, 10},
   {"complex_three_levels_min", 14, 8},
   {"complex_three_levels_max", 23, 8},
   {"nested_lambda()" BR_LAM "()" BR_LAM "()" BR_LAM, 1, 1},

--- a/plugins/cpp_metrics/test/src/cppmetricsparsertest.cpp
+++ b/plugins/cpp_metrics/test/src/cppmetricsparsertest.cpp
@@ -84,8 +84,7 @@ std::vector<McCabeParam> paramMcCabe = {
   {"MyClass::method1", 8},
   {"NoBody1::NoBody1", 1},
   {"NoBody2::NoBody2", 1},
-  {"NoBody3::NoBody3", 1},
-  {"NoBody4::NoBody4", 1},
+  {"NoBody3::~NoBody3", 1},
 };
 
 TEST_P(ParameterizedMcCabeTest, McCabeTest) {

--- a/plugins/cpp_metrics/test/src/cppmetricsparsertest.cpp
+++ b/plugins/cpp_metrics/test/src/cppmetricsparsertest.cpp
@@ -79,7 +79,13 @@ std::vector<McCabeParam> paramMcCabe = {
   {"trycatch", 3},
   {"MyClass::MyClass", 2},
   {"MyClass::~MyClass", 2},
-  {"MyClass::method1", 8}
+  {"MyClass::operator bool", 1},
+  {"MyClass::operator char *", 1},
+  {"MyClass::method1", 8},
+  {"NoBody1::NoBody1", 1},
+  {"NoBody2::NoBody2", 1},
+  {"NoBody3::NoBody3", 1},
+  {"NoBody4::NoBody4", 1},
 };
 
 TEST_P(ParameterizedMcCabeTest, McCabeTest) {
@@ -87,7 +93,8 @@ TEST_P(ParameterizedMcCabeTest, McCabeTest) {
     model::CppFunction func = _db->query_value<model::CppFunction>(
       odb::query<model::CppFunction>::qualifiedName == GetParam().first);
 
-    EXPECT_EQ(GetParam().second, func.mccabe);
+    if (func.mccabe != 0)
+      EXPECT_EQ(GetParam().second, func.mccabe);
   });
 }
 

--- a/plugins/cpp_metrics/test/src/cppmetricsparsertest.cpp
+++ b/plugins/cpp_metrics/test/src/cppmetricsparsertest.cpp
@@ -80,7 +80,7 @@ std::vector<McCabeParam> paramMcCabe = {
   {"MyClass::MyClass", 2},
   {"MyClass::~MyClass", 2},
   {"MyClass::operator bool", 1},
-  {"MyClass::operator char *", 1},
+  {"MyClass::operator unsigned int", 1},
   {"MyClass::method1", 8},
   {"NoBody1::NoBody1", 1},
   {"NoBody2::NoBody2", 1},

--- a/plugins/cpp_metrics/test/src/cppmetricsparsertest.cpp
+++ b/plugins/cpp_metrics/test/src/cppmetricsparsertest.cpp
@@ -6,7 +6,7 @@
   const auto v1 = val1; const auto v2 = val2; \
   const bool n1 = isnan(v1); const bool n2 = isnan(v2); \
   EXPECT_EQ(n1, n2); \
-  if (!n1 && !n2) EXPECT_NEAR(v1, v2, abs_error); \
+  if (!n1 && !n2) { EXPECT_NEAR(v1, v2, abs_error); } \
 }
 
 #include <model/cppfunction.h>

--- a/plugins/cpp_metrics/test/src/cppmetricsparsertest.cpp
+++ b/plugins/cpp_metrics/test/src/cppmetricsparsertest.cpp
@@ -90,11 +90,11 @@ std::vector<McCabeParam> paramMcCabe = {
 
 TEST_P(ParameterizedMcCabeTest, McCabeTest) {
   _transaction([&, this]() {
+    typedef odb::query<model::CppFunction> QFun;
     model::CppFunction func = _db->query_value<model::CppFunction>(
-      odb::query<model::CppFunction>::qualifiedName == GetParam().first);
+      QFun::qualifiedName == GetParam().first && QFun::mccabe != 0);
 
-    if (func.mccabe != 0)
-      EXPECT_EQ(GetParam().second, func.mccabe);
+    EXPECT_EQ(GetParam().second, func.mccabe);
   });
 }
 
@@ -155,8 +155,9 @@ std::vector<BumpyRoadParam> paramBumpyRoad = {
 
 TEST_P(ParameterizedBumpyRoadTest, BumpyRoadTest) {
   _transaction([&, this]() {
+    typedef odb::query<model::CppFunction> QFun;
     model::CppFunction func = _db->query_value<model::CppFunction>(
-      odb::query<model::CppFunction>::qualifiedName == GetParam().funName);
+      QFun::qualifiedName == GetParam().funName);
 
     EXPECT_EQ(GetParam().expBumpiness, func.bumpiness);
     EXPECT_EQ(GetParam().expStmtCount, func.statementCount);

--- a/util/include/util/scopedvalue.h
+++ b/util/include/util/scopedvalue.h
@@ -1,0 +1,43 @@
+#ifndef CC_UTIL_SCOPEDVALUE_H
+#define CC_UTIL_SCOPEDVALUE_H
+
+#include <memory>
+
+namespace cc
+{
+namespace util
+{
+
+  /**
+   * @brief Scoped value manager.
+   *
+   * Temporarily stores the given value in a variable upon construction,
+   * and restores its original value upon destruction.
+   *
+   * @tparam TValue The type of the variable and value to store.
+   */
+  template<typename TValue>
+  class ScopedValue final
+  {
+  private:
+    TValue& _storage;
+    TValue _oldValue;
+
+  public:
+    ScopedValue(TValue& storage_, TValue&& newValue_) :
+      _storage(storage_),
+      _oldValue(std::move(_storage))
+    {
+      _storage = std::forward<TValue>(newValue_);
+    }
+
+    ~ScopedValue()
+    {
+      _storage = std::move(_oldValue);
+    }
+  };
+
+} // util
+} // cc
+
+#endif // CC_UTIL_SCOPEDVALUE_H

--- a/util/include/util/scopedvalue.h
+++ b/util/include/util/scopedvalue.h
@@ -3,6 +3,14 @@
 
 #include <memory>
 
+#define DECLARE_SCOPED_TYPE(type) \
+private: \
+  type(const type&) = delete; \
+  type(type&&) = delete; \
+  type& operator=(const type&) = delete; \
+  type& operator=(type&&) = delete; \
+
+
 namespace cc
 {
 namespace util
@@ -19,6 +27,8 @@ namespace util
   template<typename TValue>
   class ScopedValue final
   {
+    DECLARE_SCOPED_TYPE(ScopedValue)
+    
   private:
     TValue& _storage;
     TValue _oldValue;


### PR DESCRIPTION
Fixes #684 

### Formula
The _bumpy road_ metric of a function is computed as the function's _total bumpiness_ divided by the number of statements considered. The _total bumpiness_ of a function is the sum of the depth of each considered statement, where _depth_ is the level of the statement's indentation. (_How many parent scopes does it have?_)

`bumpy_road(F) = ( SUM {s in S} (depth(s)) ) / count(S)`

where S is the set of considered statements in function F.

Note: Functions with `count(S)=0` are considered empty. In this case the result of the formula is `1`.

### Domain
The _bumpy road_ metric only considers

- control flow (e.g `if`, `for`, ...),
- scope (e.g. `{ ... }`, function body), and
- top-level statements (e.g. `int a;`, `x += y + 8;`, ...) (basically only the "proper" statements terminated by a semicolon)

when traversing the AST. Anything else (e.g. labels, sub-expressions, ...) is not counted towards this metric.

### Range
For every function `F`, let `max(D)` be the depth of its deepest statement. The bumpy road metric of `F` falls within the range:

`[1, max(D)]`

where

- `1` means completely flat (_=good_), and
- `max(D)` means completely nested/bumpy (_=bad_).

### Changes
In order to integrate this metric into CodeCompass, the _total bumpiness_ and statement count had to be computed during parsing (since we do not store the necessary statement info in the database that the metrics plugin could utilize).

For these values, the `CppFunction` table now has two extra fields: `bumpiness` and `statementCount`.
The metrics parser is then responsible for computing the quotient that makes up the final metric.

In the parser, most of our existing `Traverse*` functions had to be restructured. As this also impacted existing features (notably: _McCabe_ and destructor usage via statement stacks), some refactoring also had to be done to ensure they still work like before.

Instead of the old template decorator approach, we now use scope objects (`StatementScope`, `TypeScope`, `EnumScope`, `FunctionScope`, `CtxStmtScope` and `ScopedValue`) to perform pre- and post- actions around `Base::Traverse*` calls with their ctors and dtors. Combined with some further generalizations at the root `TraverseDecl` and `TraverseStmt` functions, this not only reduces the number of specialized `Traverse*` functions (which usually contained duplicate bodies), but also shortens/condenses the code of the parser.

In order to be able to track nested statements, scopes, and therefore the _depth_ of the current statement during traversal, a new `_stmtStack` member has been introduced to the parser. This member is of a special `StatementStack` type that is built up from `StatementScope` objects (one per each statement during traversal) to form the "parent chain" of the currently inspected statement.
Individual statement scopes can then be further configured by the specialized `Traverse*` functions to describe how that particular statement affects the depth of further statements on the stack. (Note: I did my best to add documentation/comments to the non-trivial parts of each scope type.)
With this new mechanism, the old `_mcCabeStack` and `_statements` stacks could be successfully folded into this logic, thus further reducing complexity (and unnecessary duplication of the same statement stack pattern).

### Testing
Unit tests for _bumpy road_ have been added into to the test directory. Test cases have been written in a similar style as with the _McCabe_ metric. Further _McCabe_ test cases have also been added to check previously untested cases that I have discovered during my attempts at manual regression testing.