### PR TITLE
Endpoints for module-level C++ metric types

### DIFF
--- a/model/include/model/file.h
+++ b/model/include/model/file.h
@@ -87,6 +87,16 @@ struct FileIdView
 {
   FileId id;
 };
+
+#pragma db view object(File)
+struct FilePathView
+{
+  #pragma db column(File::id)
+  FileId id;
+
+  #pragma db column(File::path)
+  std::string path;
+};
   
 #pragma db view object(File) query((?) + " GROUP BY " + File::type)
 struct FileTypeView

--- a/plugins/cpp/model/include/model/cppastnode.h
+++ b/plugins/cpp/model/include/model/cppastnode.h
@@ -230,6 +230,18 @@ struct AstCountGroupByFiles
   std::size_t count;
 };
 
+#pragma db view \
+  object(CppAstNode) \
+  object(File = LocFile : CppAstNode::location.file)
+struct CppAstNodeFilePath
+{
+  #pragma db column(CppAstNode::id)
+  CppAstNodeId id;
+
+  #pragma db column(LocFile::path)
+  std::string path;
+};
+
 #pragma db view object(CppAstNode)
 struct CppAstCount
 {

--- a/plugins/cpp_metrics/model/include/model/cppastnodemetrics.h
+++ b/plugins/cpp_metrics/model/include/model/cppastnodemetrics.h
@@ -44,6 +44,22 @@ struct CppRecordMetricsView
   double value;
 };
 
+#pragma db view \
+  object(CppAstNode) \
+  object(File = LocFile : CppAstNode::location.file) \
+  object(CppAstNodeMetrics : CppAstNode::id == CppAstNodeMetrics::astNodeId)
+struct CppAstNodeMetricsForPathView
+{
+  #pragma db column(CppAstNode::id)
+  CppAstNodeId astNodeId;
+
+  #pragma db column(CppAstNodeMetrics::type)
+  CppAstNodeMetrics::Type type;
+
+  #pragma db column(CppAstNodeMetrics::value)
+  double value;
+};
+
 } //model
 } //cc
 

--- a/plugins/cpp_metrics/model/include/model/cppastnodemetrics.h
+++ b/plugins/cpp_metrics/model/include/model/cppastnodemetrics.h
@@ -45,12 +45,12 @@ struct CppRecordMetricsView
 };
 
 #pragma db view \
-  object(CppAstNode) \
-  object(File = LocFile : CppAstNode::location.file) \
-  object(CppAstNodeMetrics : CppAstNode::id == CppAstNodeMetrics::astNodeId)
+  object(CppAstNodeMetrics) \
+  object(CppAstNode : CppAstNodeMetrics::astNodeId == CppAstNode::id) \
+  object(File = LocFile : CppAstNode::location.file)
 struct CppAstNodeMetricsForPathView
 {
-  #pragma db column(CppAstNode::id)
+  #pragma db column(CppAstNodeMetrics::astNodeId)
   CppAstNodeId astNodeId;
 
   #pragma db column(CppAstNodeMetrics::type)

--- a/plugins/cpp_metrics/model/include/model/cppastnodemetrics.h
+++ b/plugins/cpp_metrics/model/include/model/cppastnodemetrics.h
@@ -53,6 +53,9 @@ struct CppAstNodeMetricsForPathView
   #pragma db column(CppAstNodeMetrics::astNodeId)
   CppAstNodeId astNodeId;
 
+  #pragma db column(LocFile::path)
+  std::string path;
+
   #pragma db column(CppAstNodeMetrics::type)
   CppAstNodeMetrics::Type type;
 

--- a/plugins/cpp_metrics/model/include/model/cppfilemetrics.h
+++ b/plugins/cpp_metrics/model/include/model/cppfilemetrics.h
@@ -29,6 +29,21 @@ struct CppFileMetrics
   unsigned value;
 };
 
+#pragma db view \
+  object(File) \
+  object(CppFileMetrics : File::id == CppFileMetrics::file)
+struct CppModuleMetricsForPathView
+{
+  #pragma db column(File::id)
+  FileId fileId;
+
+  #pragma db column(CppFileMetrics::type)
+  CppFileMetrics::Type type;
+
+  #pragma db column(CppFileMetrics::value)
+  unsigned value;
+};
+
 } //model
 } //cc
 

--- a/plugins/cpp_metrics/model/include/model/cppfilemetrics.h
+++ b/plugins/cpp_metrics/model/include/model/cppfilemetrics.h
@@ -30,12 +30,15 @@ struct CppFileMetrics
 };
 
 #pragma db view \
-  object(File) \
-  object(CppFileMetrics : File::id == CppFileMetrics::file)
+  object(CppFileMetrics) \
+  object(File : CppFileMetrics::file == File::id)
 struct CppModuleMetricsForPathView
 {
-  #pragma db column(File::id)
+  #pragma db column(CppFileMetrics::file)
   FileId fileId;
+
+  #pragma db column(File::path)
+  std::string path;
 
   #pragma db column(CppFileMetrics::type)
   CppFileMetrics::Type type;

--- a/plugins/cpp_metrics/service/cxxmetrics.thrift
+++ b/plugins/cpp_metrics/service/cxxmetrics.thrift
@@ -94,7 +94,7 @@ service CppMetricsService
    * This function returns all available C++ metrics
    * (file-level) for a particular path.
    */
-  list<CppMetricsModuleAll> getCppFileMetricsForPath(
+  map<common.FileId, list<CppMetricsModuleSingle>> getCppFileMetricsForPath(
     1:string path)
 
   /**

--- a/plugins/cpp_metrics/service/cxxmetrics.thrift
+++ b/plugins/cpp_metrics/service/cxxmetrics.thrift
@@ -4,12 +4,6 @@ include "project/project.thrift"
 namespace cpp cc.service.cppmetrics
 namespace java cc.service.cppmetrics
 
-enum CppUnitType
-{
-  AstNodeUnit = 1,
-  FileUnit = 2
-}
-
 enum CppAstNodeMetricsType
 {
   ParameterCount = 1,

--- a/plugins/cpp_metrics/service/cxxmetrics.thrift
+++ b/plugins/cpp_metrics/service/cxxmetrics.thrift
@@ -37,8 +37,9 @@ struct CppModuleMetricsTypeName
 
 struct CppMetricsAstNodeSingle
 {
-  1:CppAstNodeMetricsType type,
-  2:double value
+  1:string path,
+  2:CppAstNodeMetricsType type,
+  3:double value
 }
 
 struct CppMetricsAstNodeAll
@@ -49,8 +50,9 @@ struct CppMetricsAstNodeAll
 
 struct CppMetricsModuleSingle
 {
-  1:CppModuleMetricsType type,
-  2:double value
+  1:string path,
+  2:CppModuleMetricsType type,
+  3:double value
 }
 
 struct CppMetricsModuleAll

--- a/plugins/cpp_metrics/service/cxxmetrics.thrift
+++ b/plugins/cpp_metrics/service/cxxmetrics.thrift
@@ -4,7 +4,7 @@ include "project/project.thrift"
 namespace cpp cc.service.cppmetrics
 namespace java cc.service.cppmetrics
 
-enum CppMetricsType
+enum CppAstNodeMetricsType
 {
   ParameterCount = 1,
   McCabe = 2,
@@ -12,15 +12,32 @@ enum CppMetricsType
   LackOfCohesionHS = 4
 }
 
-struct CppMetricsTypeName
+enum CppModuleMetricsType
 {
-  1:CppMetricsType type,
+  Placeholder = 1
+}
+
+struct CppAstNodeMetricsTypeName
+{
+  1:CppAstNodeMetricsType type,
+  2:string name
+}
+
+struct CppModuleMetricsTypeName
+{
+  1:CppModuleMetricsType type,
   2:string name
 }
 
 struct CppMetricsAstNode
 {
-  1:CppMetricsType type,
+  1:CppAstNodeMetricsType type,
+  2:double value
+}
+
+struct CppMetricsModule
+{
+  1:CppModuleMetricsType type,
   2:double value
 }
 
@@ -32,7 +49,7 @@ service CppMetricsService
    */
   double getSingleCppMetricForAstNode(
     1:common.AstNodeId astNodeId,
-    2:CppMetricsType metric)
+    2:CppAstNodeMetricsType metric)
 
   /**
    * This function returns all available C++ metrics
@@ -42,7 +59,19 @@ service CppMetricsService
     1:common.AstNodeId astNodeId)
 
   /**
-   * This function returns the names of metrics.
+   * This function returns all available C++ metrics
+   * for a particular module.
    */
-  list<CppMetricsTypeName> getCppMetricsTypeNames()
+  list<CppMetricsModule> getCppMetricsForModule(
+    1:common.FileId fileId)
+
+  /**
+   * This function returns the names of AST node metrics.
+   */
+  list<CppAstNodeMetricsTypeName> getCppAstNodeMetricsTypeNames()
+
+  /**
+   * This function returns the names of module-level metrics.
+   */
+   list<CppModuleMetricsTypeName> getCppModuleMetricsTypeNames()
 }

--- a/plugins/cpp_metrics/service/cxxmetrics.thrift
+++ b/plugins/cpp_metrics/service/cxxmetrics.thrift
@@ -4,6 +4,12 @@ include "project/project.thrift"
 namespace cpp cc.service.cppmetrics
 namespace java cc.service.cppmetrics
 
+enum CppUnitType
+{
+  AstNodeUnit = 1,
+  FileUnit = 2
+}
+
 enum CppAstNodeMetricsType
 {
   ParameterCount = 1,
@@ -35,10 +41,33 @@ struct CppMetricsAstNode
   2:double value
 }
 
+struct CppAllMetricsAstNode
+{
+  1:common.AstNodeId id,
+  2:list<CppMetricsAstNode> metrics
+}
+
 struct CppMetricsModule
 {
   1:CppModuleMetricsType type,
   2:double value
+}
+
+struct CppAllMetricsModule
+{
+  1:common.FileId id,
+  2:list<CppMetricsModule> metrics
+}
+
+// Thrift does not provide a union type,
+// the ids can remain empty.
+struct CppMetricsPath
+{
+  1:CppUnitType type
+  2:common.AstNodeId astNodeId
+  3:list<CppMetricsAstNode> astNodeIdMetrics
+  4:common.FileId fileId
+  5:list<CppMetricsModule> fileMetrics
 }
 
 service CppMetricsService
@@ -64,6 +93,20 @@ service CppMetricsService
    */
   list<CppMetricsModule> getCppMetricsForModule(
     1:common.FileId fileId)
+
+  /**
+   * This function returns all available C++ metrics
+   * (AST node-level) for a particular path.
+   */
+  list<CppAllMetricsAstNode> getCppAstNodeMetricsForPath(
+    1:string path)
+
+  /**
+   * This function returns all available C++ metrics
+   * (file-level) for a particular path.
+   */
+  list<CppAllMetricsModule> getCppFileMetricsForPath(
+    1:string path)
 
   /**
    * This function returns the names of AST node metrics.

--- a/plugins/cpp_metrics/service/cxxmetrics.thrift
+++ b/plugins/cpp_metrics/service/cxxmetrics.thrift
@@ -87,7 +87,7 @@ service CppMetricsService
    * This function returns all available C++ metrics
    * (AST node-level) for a particular path.
    */
-  list<CppMetricsAstNodeAll> getCppAstNodeMetricsForPath(
+  map<common.AstNodeId, list<CppMetricsAstNodeSingle>> getCppAstNodeMetricsForPath(
     1:string path)
 
   /**

--- a/plugins/cpp_metrics/service/cxxmetrics.thrift
+++ b/plugins/cpp_metrics/service/cxxmetrics.thrift
@@ -35,39 +35,28 @@ struct CppModuleMetricsTypeName
   2:string name
 }
 
-struct CppMetricsAstNode
+struct CppMetricsAstNodeSingle
 {
   1:CppAstNodeMetricsType type,
   2:double value
 }
 
-struct CppAllMetricsAstNode
+struct CppMetricsAstNodeAll
 {
   1:common.AstNodeId id,
-  2:list<CppMetricsAstNode> metrics
+  2:list<CppMetricsAstNodeSingle> metrics
 }
 
-struct CppMetricsModule
+struct CppMetricsModuleSingle
 {
   1:CppModuleMetricsType type,
   2:double value
 }
 
-struct CppAllMetricsModule
+struct CppMetricsModuleAll
 {
   1:common.FileId id,
-  2:list<CppMetricsModule> metrics
-}
-
-// Thrift does not provide a union type,
-// the ids can remain empty.
-struct CppMetricsPath
-{
-  1:CppUnitType type
-  2:common.AstNodeId astNodeId
-  3:list<CppMetricsAstNode> astNodeIdMetrics
-  4:common.FileId fileId
-  5:list<CppMetricsModule> fileMetrics
+  2:list<CppMetricsModuleSingle> metrics
 }
 
 service CppMetricsService
@@ -84,28 +73,28 @@ service CppMetricsService
    * This function returns all available C++ metrics
    * for a particular AST node.
    */
-  list<CppMetricsAstNode> getCppMetricsForAstNode(
+  list<CppMetricsAstNodeSingle> getCppMetricsForAstNode(
     1:common.AstNodeId astNodeId)
 
   /**
    * This function returns all available C++ metrics
    * for a particular module.
    */
-  list<CppMetricsModule> getCppMetricsForModule(
+  list<CppMetricsModuleSingle> getCppMetricsForModule(
     1:common.FileId fileId)
 
   /**
    * This function returns all available C++ metrics
    * (AST node-level) for a particular path.
    */
-  list<CppAllMetricsAstNode> getCppAstNodeMetricsForPath(
+  list<CppMetricsAstNodeAll> getCppAstNodeMetricsForPath(
     1:string path)
 
   /**
    * This function returns all available C++ metrics
    * (file-level) for a particular path.
    */
-  list<CppAllMetricsModule> getCppFileMetricsForPath(
+  list<CppMetricsModuleAll> getCppFileMetricsForPath(
     1:string path)
 
   /**
@@ -116,5 +105,5 @@ service CppMetricsService
   /**
    * This function returns the names of module-level metrics.
    */
-   list<CppModuleMetricsTypeName> getCppModuleMetricsTypeNames()
+  list<CppModuleMetricsTypeName> getCppModuleMetricsTypeNames()
 }

--- a/plugins/cpp_metrics/service/include/service/cppmetricsservice.h
+++ b/plugins/cpp_metrics/service/include/service/cppmetricsservice.h
@@ -48,6 +48,14 @@ public:
     std::vector<CppMetricsModule>& _return,
     const core::FileId& fileId_) override;
 
+  void getCppAstNodeMetricsForPath(
+    std::vector<CppAllMetricsAstNode>& _return,
+    const std::string& path_) override;
+
+  void getCppFileMetricsForPath(
+    std::vector<CppAllMetricsModule>& _return,
+    const std::string& path_) override;
+
   void getCppAstNodeMetricsTypeNames(
     std::vector<CppAstNodeMetricsTypeName>& _return) override;
 

--- a/plugins/cpp_metrics/service/include/service/cppmetricsservice.h
+++ b/plugins/cpp_metrics/service/include/service/cppmetricsservice.h
@@ -12,6 +12,8 @@
 #include <model/cppastnodemetrics-odb.hxx>
 #include <model/cppastnode.h>
 #include <model/cppastnode-odb.hxx>
+#include <model/cppfilemetrics.h>
+#include <model/cppfilemetrics-odb.hxx>
 
 #include <odb/database.hxx>
 #include <util/odbtransaction.h>
@@ -36,14 +38,21 @@ public:
 
   double getSingleCppMetricForAstNode(
     const core::AstNodeId& astNodeId_,
-    CppMetricsType::type metric_) override;
+    CppAstNodeMetricsType::type metric_) override;
 
   void getCppMetricsForAstNode(
     std::vector<CppMetricsAstNode>& _return,
     const core::AstNodeId& astNodeId_) override;
 
-  void getCppMetricsTypeNames(
-    std::vector<CppMetricsTypeName>& _return) override;
+  void getCppMetricsForModule(
+    std::vector<CppMetricsModule>& _return,
+    const core::FileId& fileId_) override;
+
+  void getCppAstNodeMetricsTypeNames(
+    std::vector<CppAstNodeMetricsTypeName>& _return) override;
+
+  void getCppModuleMetricsTypeNames(
+    std::vector<CppModuleMetricsTypeName>& _return) override;
 
 private:
   std::shared_ptr<odb::database> _db;

--- a/plugins/cpp_metrics/service/include/service/cppmetricsservice.h
+++ b/plugins/cpp_metrics/service/include/service/cppmetricsservice.h
@@ -54,7 +54,7 @@ public:
     const std::string& path_) override;
 
   void getCppFileMetricsForPath(
-    std::vector<CppMetricsModuleAll>& _return,
+    std::map<core::FileId, std::vector<CppMetricsModuleSingle>>& _return,
     const std::string& path_) override;
 
   void getCppAstNodeMetricsTypeNames(

--- a/plugins/cpp_metrics/service/include/service/cppmetricsservice.h
+++ b/plugins/cpp_metrics/service/include/service/cppmetricsservice.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <vector>
+#include <map>
 
 #include <boost/program_options/variables_map.hpp>
 
@@ -49,7 +50,7 @@ public:
     const core::FileId& fileId_) override;
 
   void getCppAstNodeMetricsForPath(
-    std::vector<CppMetricsAstNodeAll>& _return,
+    std::map<core::AstNodeId, std::vector<CppMetricsAstNodeSingle>>& _return,
     const std::string& path_) override;
 
   void getCppFileMetricsForPath(

--- a/plugins/cpp_metrics/service/include/service/cppmetricsservice.h
+++ b/plugins/cpp_metrics/service/include/service/cppmetricsservice.h
@@ -41,19 +41,19 @@ public:
     CppAstNodeMetricsType::type metric_) override;
 
   void getCppMetricsForAstNode(
-    std::vector<CppMetricsAstNode>& _return,
+    std::vector<CppMetricsAstNodeSingle>& _return,
     const core::AstNodeId& astNodeId_) override;
 
   void getCppMetricsForModule(
-    std::vector<CppMetricsModule>& _return,
+    std::vector<CppMetricsModuleSingle>& _return,
     const core::FileId& fileId_) override;
 
   void getCppAstNodeMetricsForPath(
-    std::vector<CppAllMetricsAstNode>& _return,
+    std::vector<CppMetricsAstNodeAll>& _return,
     const std::string& path_) override;
 
   void getCppFileMetricsForPath(
-    std::vector<CppAllMetricsModule>& _return,
+    std::vector<CppMetricsModuleAll>& _return,
     const std::string& path_) override;
 
   void getCppAstNodeMetricsTypeNames(

--- a/plugins/cpp_metrics/service/src/cppmetricsservice.cpp
+++ b/plugins/cpp_metrics/service/src/cppmetricsservice.cpp
@@ -54,10 +54,10 @@ void CppMetricsServiceHandler::getCppModuleMetricsTypeNames(
 }
 
 void CppMetricsServiceHandler::getCppMetricsForAstNode(
-  std::vector<CppMetricsAstNode>& _return,
+  std::vector<CppMetricsAstNodeSingle>& _return,
   const core::AstNodeId& astNodeId_)
 {
-  CppMetricsAstNode metric;
+  CppMetricsAstNodeSingle metric;
 
   _transaction([&, this](){
     typedef odb::query<model::CppAstNodeMetrics> CppAstNodeMetricsQuery;
@@ -97,10 +97,10 @@ double CppMetricsServiceHandler::getSingleCppMetricForAstNode(
 }
 
 void CppMetricsServiceHandler::getCppMetricsForModule(
-  std::vector<CppMetricsModule>& _return,
+  std::vector<CppMetricsModuleSingle>& _return,
   const core::FileId& fileId_)
 {
-  CppMetricsModule metric;
+  CppMetricsModuleSingle metric;
 
   _transaction([&, this](){
     typedef odb::query<model::CppFileMetrics> CppModuleMetricsQuery;
@@ -118,7 +118,7 @@ void CppMetricsServiceHandler::getCppMetricsForModule(
 }
 
 void CppMetricsServiceHandler::getCppAstNodeMetricsForPath(
-  std::vector<CppAllMetricsAstNode>& _return,
+  std::vector<CppMetricsAstNodeAll>& _return,
   const std::string& path_)
 {
   _transaction([&, this]()
@@ -142,9 +142,9 @@ void CppMetricsServiceHandler::getCppAstNodeMetricsForPath(
     {
       auto metricsQuery = _db->query<model::CppAstNodeMetrics>(
         CppAstNodeMetricsQuery::astNodeId == node.id);
-      std::vector<CppMetricsAstNode> metrics;
+      std::vector<CppMetricsAstNodeSingle> metrics;
 
-      CppMetricsAstNode metricsAstNode;
+      CppMetricsAstNodeSingle metricsAstNode;
       for (const auto& metric : metricsQuery)
       {
         metricsAstNode.type = static_cast<CppAstNodeMetricsType::type>(metric.type);
@@ -155,7 +155,7 @@ void CppMetricsServiceHandler::getCppAstNodeMetricsForPath(
       if (metrics.empty())
         continue;
 
-      CppAllMetricsAstNode nodeMetric;
+      CppMetricsAstNodeAll nodeMetric;
       nodeMetric.id = std::to_string(node.id);
       nodeMetric.metrics = metrics;
       _return.push_back(nodeMetric);
@@ -164,7 +164,7 @@ void CppMetricsServiceHandler::getCppAstNodeMetricsForPath(
 }
 
 void CppMetricsServiceHandler::getCppFileMetricsForPath(
-  std::vector<CppAllMetricsModule>& _return,
+  std::vector<CppMetricsModuleAll>& _return,
   const std::string& path_)
 {
   _transaction([&, this]()
@@ -188,9 +188,9 @@ void CppMetricsServiceHandler::getCppFileMetricsForPath(
     {
       CppFileMetricsResult metricsQuery = _db->query<model::CppFileMetrics>(
         CppFileMetricsQuery::file == file.id);
-      std::vector<CppMetricsModule> metrics;
+      std::vector<CppMetricsModuleSingle> metrics;
 
-      CppMetricsModule metricsModule;
+      CppMetricsModuleSingle metricsModule;
       for (const auto& metric : metricsQuery)
       {
         metricsModule.type = static_cast<CppModuleMetricsType::type>(metric.type);
@@ -201,7 +201,7 @@ void CppMetricsServiceHandler::getCppFileMetricsForPath(
       if (metrics.empty())
         continue;
 
-      CppAllMetricsModule nodeMetric;
+      CppMetricsModuleAll nodeMetric;
       nodeMetric.id = std::to_string(file.id);
       nodeMetric.metrics = metrics;
       _return.push_back(nodeMetric);

--- a/plugins/cpp_metrics/service/src/cppmetricsservice.cpp
+++ b/plugins/cpp_metrics/service/src/cppmetricsservice.cpp
@@ -1,6 +1,8 @@
 #include <service/cppmetricsservice.h>
 #include <util/dbutil.h>
 
+#include <odb/query.hxx>
+
 namespace cc
 {
 namespace service
@@ -19,7 +21,7 @@ CppMetricsServiceHandler::CppMetricsServiceHandler(
 {
   LOG(info) << "test";
   std::vector<CppAllMetricsAstNode> metrics;
-  getCppAstNodeMetricsForPath(metrics, "/home/efekane/repos/tinyxml2/tinyxml2.cpp");
+  getCppAstNodeMetricsForPath(metrics, "/home/efekane/repos/tinyxml2");
 
   for (const auto& metric : metrics)
   {
@@ -125,20 +127,22 @@ void CppMetricsServiceHandler::getCppMetricsForModule(
 
 void CppMetricsServiceHandler::getCppAstNodeMetricsForPath(
   std::vector<CppAllMetricsAstNode>& _return,
-  const std::string& path)
+  const std::string& path_)
 {
   _transaction([&, this](){
     typedef odb::query<model::CppAstNode> CppAstNodeQuery;
     typedef odb::query<model::CppAstNodeMetrics> CppAstNodeMetricsQuery;
+    typedef odb::query<model::CppAstNodeFilePath> CppAstNodeFilePathQuery;
 
     // ez így még nagyon todo
     // a kapott path legyen prefixe az ast node path-ának
-    auto nodes = _db->query<model::CppAstNodeFilePath>();
+    auto nodes = _db->query<model::CppAstNodeFilePath>(
+      CppAstNodeFilePathQuery::LocFile::path.like(path_ + '%'));
 
     if (nodes.empty())
     {
       core::InvalidInput ex;
-      ex.__set_msg("Invalid metric type for path: " + path);
+      ex.__set_msg("Invalid metric type for path: " + path_);
       throw ex;
     }
     else

--- a/plugins/cpp_metrics/service/src/cppmetricsservice.cpp
+++ b/plugins/cpp_metrics/service/src/cppmetricsservice.cpp
@@ -149,7 +149,11 @@ void CppMetricsServiceHandler::getCppAstNodeMetricsForPath(
       {
         metricsAstNode.type = static_cast<CppAstNodeMetricsType::type>(metric.type);
         metricsAstNode.value = metric.value;
+        metrics.push_back(metricsAstNode);
       }
+
+      if (metrics.empty())
+        continue;
 
       CppAllMetricsAstNode nodeMetric;
       nodeMetric.id = std::to_string(node.id);
@@ -191,7 +195,11 @@ void CppMetricsServiceHandler::getCppFileMetricsForPath(
       {
         metricsModule.type = static_cast<CppModuleMetricsType::type>(metric.type);
         metricsModule.value = metric.value;
+        metrics.push_back(metricsModule);
       }
+
+      if (metrics.empty())
+        continue;
 
       CppAllMetricsModule nodeMetric;
       nodeMetric.id = std::to_string(file.id);


### PR DESCRIPTION
As we discussed, endpoints for module-level C++ metric types are also required. I added a new endpoint to query all available module-level metric types and all stored metrics for one module. There are no module-level metrics implemented for now, so testing is difficult.
@mcserep please help me out on what else we might need, and how should I modify the endpoint if needed.