### PR TITLE
Update Scorecard Action version

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,12 +32,12 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@e38b1902ae4f44df626f11ba0734b14fb91f8f86 # v2.1.2
+        uses: ossf/scorecard-action@v2
         with:
           results_file: results.sarif
           results_format: sarif
@@ -59,7 +59,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        uses: actions/upload-artifact@v3
         with:
           name: SARIF file
           path: results.sarif
@@ -67,6 +67,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@17573ee1cc1b9d061760f3a006fc4aac4f944fd5 # v2.2.4
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
The Scorecard job added in #716 started to fail a week after, stating:
> error signing payload: getting key from Fulcio: verifying SCT: updating local metadata and targets: error updating to TUF remote mirror: invalid key

See e.g. https://github.com/Ericsson/CodeCompass/actions/runs/8411925535/job/23032110561 for reference.

It is discussed in https://github.com/ossf/scorecard-action/issues/997, that the Scorecard Action should be updated to v2.3.1.  
I have replaced the pinned versions with semantic version requirements, so bugfixes and other non-breaking improvements are added automatically to newer pipeline runs. We do not use hash pinning in other CI pipelines as well.