### PR TITLE
Do not run OSSF Scorecard analysis on forks

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -21,6 +21,7 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'Ericsson/CodeCompass' && github.ref_name == 'master' }}
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write


### PR DESCRIPTION
Do not run OSSF Scorecard analysis on forked repositories.