### PR TITLE
chore: `wget` Build2 script instead of code view HTML

### DIFF
--- a/doc/deps.md
+++ b/doc/deps.md
@@ -120,7 +120,7 @@ The ODB installation uses the build2 build system. (Build2 is not needed for
 CodeCompass so you may delete it right after the installation of ODB.)
 
 ```bash
-wget https://github.com/Ericsson/CodeCompass/blob/master/scripts/install_latest_build2.sh
+wget https://raw.githubusercontent.com/Ericsson/CodeCompass/master/scripts/install_latest_build2.sh
 sh install_latest_build2.sh "<build2_install_dir>"
 ```
 


### PR DESCRIPTION
Executing `wget http://github.com/...` will download a `text/html` that is the web page with the code view. To obtain the script itself, we have to use `http://raw.githubusercontent.com`.

In another location, the command was already the proper one, it is only the human-readable documentation that was misleading:

https://github.com/Ericsson/CodeCompass/blob/8e84d84e29a0cec6cb0af9f6dcc587ea9ff34480/docker/dev/install_odb.sh#L5