### PR TITLE
Build CodeCompass in Release mode in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Build project
 on: [push, pull_request, workflow_dispatch]
 
 env:
-  BUILD_TYPE: Debug
+  BUILD_TYPE: RelWithDebInfo
   ## For locally compiled dependencies
   INSTALL_PATH: ${{github.workspace}}/dependencies/install
   ## Temp directory for installers of the downloaded dependencies

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
   analyze-cpp:
     name: Analyze C-C++
     env:
-      BUILD_TYPE: Debug
+      BUILD_TYPE: RelWithDebInfo
       INSTALL_PATH: ${{github.workspace}}/dependencies/install
       DOWNLOAD_PATH: ${{github.workspace}}/dependencies/download
     runs-on: ubuntu-22.04

--- a/.gitlab/build-codecompass.sh
+++ b/.gitlab/build-codecompass.sh
@@ -63,7 +63,7 @@ cd $CC_BUILD_DIR
 cmake $CC_SRC_DIR \
   -DCMAKE_INSTALL_PREFIX=$CC_INSTALL_DIR \
   -DDATABASE=pgsql \
-  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DCMAKE_BUILD_TYPE=Release \
   -DWITH_AUTH="plain;ldap" \
   -DLLVM_DIR=$DEPS_INSTALL_RUNTIME_DIR/llvm/lib/cmake/llvm/ \
   -DClang_DIR=$DEPS_INSTALL_RUNTIME_DIR/llvm/lib/cmake/clang/


### PR DESCRIPTION
Build CodeCompass in `RelWithDebInfo` mode in the CI, which results in a 15-25% better performance during the parsing.

Build CodeCompass in `Release` mode during tarball packaging to shrink the output size.