### PR TITLE
Log the start of each C++ metric computation

### DIFF
--- a/plugins/cpp_metrics/parser/src/cppmetricsparser.cpp
+++ b/plugins/cpp_metrics/parser/src/cppmetricsparser.cpp
@@ -272,9 +272,13 @@ void CppMetricsParser::lackOfCohesion()
 
 bool CppMetricsParser::parse()
 {
+  LOG(info) << "[cppmetricsparser] Computing function parameter count metric.";
   functionParameters();
+  LOG(info) << "[cppmetricsparser] Computing McCabe metric for functions.";
   functionMcCabe();
+  LOG(info) << "[cppmetricsparser] Computing Bumpy Road metric for functions.";
   functionBumpyRoad();
+  LOG(info) << "[cppmetricsparser] Computing Lack of Cohesion metric for types.";
   lackOfCohesion();
   return true;
 }


### PR DESCRIPTION
Required for performance analysis of the C++ metric computation