### PR TITLE
Debug info upon C++ parser finished a TU

### DIFF
--- a/plugins/cpp/parser/src/cppparser.cpp
+++ b/plugins/cpp/parser/src/cppparser.cpp
@@ -779,6 +779,10 @@ bool CppParser::parseByJson(
           LOG(warning)
             << '(' << job_.index << '/' << numCompileCommands << ')'
             << " Parsing " << command.Filename << " has been failed.";
+        else          
+          LOG(debug)
+            << '(' << job_.index << '/' << numCompileCommands << ')'
+            << " Parsing " << command.Filename << " finished successfully.";
       });
 
   //--- Push all commands into the thread pool's queue ---//


### PR DESCRIPTION
Print debug info upon successful completion of TU parsing. This would be useful when debugging CodeCompass parser crash issues during parallel parsing, to better locate the TU yielding the failure.