### PR TITLE
Update C++ metrics service with our new metrics

### DIFF
--- a/plugins/cpp_metrics/service/cxxmetrics.thrift
+++ b/plugins/cpp_metrics/service/cxxmetrics.thrift
@@ -8,8 +8,9 @@ enum CppAstNodeMetricsType
 {
   ParameterCount = 1,
   McCabe = 2,
-  LackOfCohesion = 3,
-  LackOfCohesionHS = 4
+  BumpyRoad = 3,
+  LackOfCohesion = 4,
+  LackOfCohesionHS = 5,
 }
 
 enum CppModuleMetricsType

--- a/plugins/cpp_metrics/service/src/cppmetricsservice.cpp
+++ b/plugins/cpp_metrics/service/src/cppmetricsservice.cpp
@@ -33,15 +33,19 @@ void CppMetricsServiceHandler::getCppAstNodeMetricsTypeNames(
   _return.push_back(typeName);
 
   typeName.type = CppAstNodeMetricsType::McCabe;
-  typeName.name = "McCabe metric";
+  typeName.name = "Cyclomatic (McCabe) complexity of function";
+  _return.push_back(typeName);
+
+  typeName.type = CppAstNodeMetricsType::BumpyRoad;
+  typeName.name = "Bumpy road complexity of function";
   _return.push_back(typeName);
 
   typeName.type = CppAstNodeMetricsType::LackOfCohesion;
-  typeName.name = "Lack of cohesion of function";
+  typeName.name = "Lack of cohesion of type";
   _return.push_back(typeName);
 
   typeName.type = CppAstNodeMetricsType::LackOfCohesionHS;
-  typeName.name = "Lack of cohesion of function (Henderson-Sellers variant)";
+  typeName.name = "Lack of cohesion of type (Henderson-Sellers variant)";
   _return.push_back(typeName);
 }
 


### PR DESCRIPTION
I added the bumpy road metric to the C++ metrics service, as requested in [#714](https://github.com/Ericsson/CodeCompass/pull/714#issuecomment-2109520197).
I added it as the third value to `CppAstNodeMetricsType` so that the order and values of the metrics here match that of `CppAstNodeMetrics::Type`.

I also changed the description of:
- McCabe to "Cyclomatic (McCabe) complexity of function". I added the fact that this is for _functions_ explicitly, as we are also expected to have a version for types soon (#683).
- Lack of Cohesion: these are actually _type-level_ metrics, not _function-level_ metrics (#681).
