### PR TITLE
Tag runtime postgresql Docker image on master with latest

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -100,7 +100,7 @@ jobs:
           docker push modelcpp/codecompass:${BRANCH_PREFIX}web-pgsql
 
       - name: Tag and push latest image
-        if: ${{ inputs.tag-latest == 'true' }}
+        if: ${{ inputs.tag-latest }}
         run: |
-          docker tag modelcpp/codecompass:runtime-pgsql modelcpp/codecompass:latest
+          docker tag modelcpp/codecompass:${BRANCH_PREFIX}runtime-pgsql modelcpp/codecompass:latest
           docker push modelcpp/codecompass:latest


### PR DESCRIPTION
For some time the `latest` image on the `master` branch is not tagged properly. (Therefore the `latest` tag is 9 months old on DockerHub.)

This PR fixes it.