### PR TITLE
Optionally run Plugin parsers after DB indexing

### DIFF
--- a/parser/include/parser/abstractparser.h
+++ b/parser/include/parser/abstractparser.h
@@ -44,6 +44,16 @@ public:
    * @return Returns true if the parse succeeded, false otherwise.
    */
   virtual bool parse() = 0;
+  /**
+   * Returns true in case database indices are required for the parser, due to performance reasons.
+   *
+   * Should return the same value on each call for the same object.
+   * @return Returns true if the database indexing has to be performed before the parser is executed.
+   */
+  virtual bool isDatabaseIndexRequired() const
+  {
+    return false;
+  }
   
 protected:
   ParserContext& _ctx;

--- a/plugins/cpp_metrics/parser/include/cppmetricsparser/cppmetricsparser.h
+++ b/plugins/cpp_metrics/parser/include/cppmetricsparser/cppmetricsparser.h
@@ -59,6 +59,11 @@ public:
   virtual bool cleanupDatabase() override;
   virtual bool parse() override;
 
+  virtual bool isDatabaseIndexRequired() const override
+  {
+    return true;
+  }
+
 private:
   // Calculate the count of parameters for every function.
   void functionParameters();


### PR DESCRIPTION
CodeCompass currently builds database indexes for projects at the end of parsing. Previously this was fine, since little to no SELECT queries were executed during parsing, therefore it is unnecessary to maintain the indexes. However, the C++ metrics computation executes many SELECT queries on the C++ parsing result. The lack of these database indexes can greatly impair the performance.

Parsing Xerces I got the following measurement results:
- If the database indexes are created at the beginning of parsing, the duration of C++ parsing is increased by 6%.
- However, the type-level McCabe calculation time reduced from 9 minutes to 112 seconds (480% speedup).
- Also, the Lack of Cohesion (type level again) reduced from 6 minutes to 5 seconds (7200% acceleration!).

Therefore this PR introduces an enhancement to optionally run Plugin parsers after DB indexing.