### PR TITLE
Fix ODB installation in web Docker image

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -71,6 +71,7 @@ ENV DATABASE=sqlite \
     TEST_DB="sqlite:database=$TEST_WORKSPACE/cc_test.sqlite" \
     WITH_AUTH="plain;ldap" \
     LLVM_DIR=/usr/lib/llvm-11/cmake \
-    Clang_DIR=/usr/lib/cmake/clang-11
+    Clang_DIR=/usr/lib/cmake/clang-11 \
+    CMAKE_PREFIX_PATH=/opt/odb
 
-ENV PATH="$INSTALL_DIR/bin:$PATH"
+ENV PATH="$INSTALL_DIR/bin:/opt/odb/bin:$PATH"

--- a/docker/dev/install_odb.sh
+++ b/docker/dev/install_odb.sh
@@ -11,8 +11,8 @@ cd /odb_build
 bpkg create --quiet --jobs $(nproc) cc \
   config.cxx=g++ \
   config.cc.coptions=-O3 \
-  config.bin.rpath=/usr/local/lib \
-  config.install.root=/usr/local
+  config.bin.rpath=/opt/odb/lib \
+  config.install.root=/opt/odb
 # Getting the source
 bpkg add https://pkg.cppget.org/1/beta --trust-yes
 bpkg fetch --trust-yes

--- a/docker/runtime/Dockerfile
+++ b/docker/runtime/Dockerfile
@@ -51,9 +51,6 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG CC_DATABASE
 ENV CC_DATABASE ${CC_DATABASE}
 
-# Copy install script
-COPY docker/dev/install_odb.sh /
-
 RUN set -x && apt-get update -qq && \
     apt-get install -qq --yes --no-install-recommends \
     curl ca-certificates gnupg \
@@ -80,14 +77,16 @@ RUN set -x && apt-get update -qq && \
       apt-get install -qq --yes --no-install-recommends \
       libsqlite3-dev; \
     fi && \
-    sh /install_odb.sh "${CC_DATABASE}" && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/ && \
     set +x
 
-# Copy CodeCompass installed directory. (Change permission of the CodeCompass package.)
+# Copy ODB install directory.
+COPY --from=builder /opt/odb /opt/odb
+
+# Copy CodeCompass install directory.
 COPY --from=builder /CodeCompass-install /codecompass
 
-ENV PATH="/codecompass/bin:$PATH"
+ENV PATH="/codecompass/bin:/opt/odb/bin:$PATH"
 
 ENTRYPOINT ["tini", "--"]

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -15,9 +15,6 @@ FROM ubuntu:22.04
 # variable prevents this interaction.
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Copy install script
-COPY docker/dev/install_odb.sh /
-
 RUN set -x && apt-get update -qq \
   && apt-get install -qqy --no-install-recommends \
     llvm-11 \
@@ -43,9 +40,6 @@ RUN set -x && apt-get update -qq \
   && rm -rf /var/lib/apt/lists/ \
   && set +x
 
-# Build ODB from source
-RUN sh /install_odb.sh && rm /install_odb.sh
-
 # Install NodeJS from NodeSource.
 RUN mkdir -p /etc/apt/keyrings && \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
@@ -55,22 +49,24 @@ RUN mkdir -p /etc/apt/keyrings && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/
 
+# Copy ODB install directory.
+COPY --from=runtime /opt/odb /opt/odb
+
 ARG CC_GID=960
 ARG CC_UID=960
 
 ENV CC_GID ${CC_GID}
 ENV CC_UID ${CC_UID}
 
-
 # Create user and group for CodeCompass.
 RUN groupadd --system codecompass --gid ${CC_GID} && \
     useradd --system --no-log-init --no-create-home --uid ${CC_UID} --gid codecompass codecompass
 
-# Copy CodeCompass installed directory. (Change permission of the CodeCompass package.)
+# Copy CodeCompass install directory. (Change permission of the CodeCompass package.)
 # TODO: only the webserver's binaries should be included in this image.
 COPY --from=runtime --chown=codecompass:codecompass /codecompass /codecompass
 
-ENV PATH="/codecompass/bin:$PATH"
+ENV PATH="/codecompass/bin:/opt/odb/bin:$PATH"
 
 COPY --chown=codecompass:codecompass docker/web/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod a+x /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
Fixes #742.

The ODB installation in the web only docker images were incorrect. While fixing this I also improved the previous approach, which made a full ODB custom compilation both for the `dev`, the `runtime` and the `web` images.

With this PR the ODB library will be only compiled for the `dev` image, and then the installation directory will be copied to the `runtime` and the `web` image without recompilation. This should speed up building the `runtime` and the `web` images significantly (by 20+ minutes on my machine).