### PR TITLE
Webgui-new language service

### DIFF
--- a/webgui-new/package-lock.json
+++ b/webgui-new/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
+        "@codemirror/lang-python": "^6.1.6",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
         "@mui/icons-material": "^5.11.0",
@@ -305,6 +306,18 @@
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@lezer/cpp": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-python": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-6.1.6.tgz",
+      "integrity": "sha512-ai+01WfZhWqM92UqjnvorkxosZ2aq2u28kHvr+N3gu012XqY2CThD67JPMHnGceRfXPDBmn1HnyqowdpF57bNg==",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.3.2",
+        "@codemirror/language": "^6.8.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/python": "^1.1.4"
       }
     },
     "node_modules/@codemirror/language": {
@@ -738,6 +751,16 @@
       "integrity": "sha512-Wst46p51km8gH0ZUmeNrtpRYmdlRHUpN1DQd3GFAyKANi8WVz8c2jHYTf1CVScFaCjQw1iO3ZZdqGDxQPRErTg==",
       "dependencies": {
         "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/python": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@lezer/python/-/python-1.1.14.tgz",
+      "integrity": "sha512-ykDOb2Ti24n76PJsSa4ZoDF0zH12BSw1LGfQXCYJhJyOGiFTfGaX0Du66Ze72R+u/P35U+O6I9m8TFXov1JzsA==",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
       }
     },
     "node_modules/@mui/base": {

--- a/webgui-new/package.json
+++ b/webgui-new/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@codemirror/lang-cpp": "^6.0.2",
+    "@codemirror/lang-python": "^6.1.6",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
     "@mui/icons-material": "^5.11.0",

--- a/webgui-new/src/components/editor-context-menu/editor-context-menu.tsx
+++ b/webgui-new/src/components/editor-context-menu/editor-context-menu.tsx
@@ -3,12 +3,13 @@ import { IconButton, Menu, MenuItem, Modal, Tooltip } from '@mui/material';
 import { ChevronRight, Close } from '@mui/icons-material';
 import { TabName } from 'enums/tab-enum';
 import {
-  getCppAstNodeInfo,
-  getCppDiagramTypes,
-  getCppDocumentation,
-  getCppReferenceTypes,
-  getCppReferences,
-} from 'service/cpp-service';
+  createClient,
+  getAstNodeInfo,
+  getDiagramTypes,
+  getDocumentation,
+  getReferenceTypes,
+  getReferences,
+} from 'service/language-service';
 import { getAsHTMLForNode } from 'service/cpp-reparse-service';
 import { AstNodeInfo, Range } from '@thrift-generated';
 import { convertSelectionRangeToString } from 'utils/utils';
@@ -52,10 +53,13 @@ export const EditorContextMenu = ({
   useEffect(() => {
     if (!appCtx.languageNodeId) return;
     const init = async () => {
-      const initAstNodeInfo = await getCppAstNodeInfo(appCtx.languageNodeId);
+      const fileInfo = await getFileInfo(appCtx.projectFileId);
+      createClient(appCtx.workspaceId, fileInfo?.type);
+
+      const initAstNodeInfo = await getAstNodeInfo(appCtx.languageNodeId);
       setAstNodeInfo(initAstNodeInfo);
 
-      const initDiagramTypes = await getCppDiagramTypes(appCtx.languageNodeId);
+      const initDiagramTypes = await getDiagramTypes(appCtx.languageNodeId);
       setDiagramTypes(initDiagramTypes);
     };
     init();
@@ -69,7 +73,7 @@ export const EditorContextMenu = ({
   };
 
   const getDocs = async () => {
-    const initDocs = await getCppDocumentation(astNodeInfo?.id as string);
+    const initDocs = await getDocumentation(astNodeInfo?.id as string);
     const fileInfo = await getFileInfo(appCtx.projectFileId as string);
     const parser = new DOMParser();
     const parsedHTML = parser.parseFromString(initDocs, 'text/html');
@@ -115,8 +119,8 @@ export const EditorContextMenu = ({
   const jumpToDef = async () => {
     if (!astNodeInfo) return;
 
-    const refTypes = await getCppReferenceTypes(astNodeInfo.id as string);
-    const defRefs = await getCppReferences(
+    const refTypes = await getReferenceTypes(astNodeInfo.id as string);
+    const defRefs = await getReferences(
       astNodeInfo.id as string,
       refTypes.get('Definition') as number,
       astNodeInfo.tags ?? []

--- a/webgui-new/src/service/language-service.ts
+++ b/webgui-new/src/service/language-service.ts
@@ -1,0 +1,296 @@
+import thrift from 'thrift';
+import { LanguageService, FilePosition, Position } from '@thrift-generated';
+import { config } from './config';
+import { toast } from 'react-toastify';
+
+let client: LanguageService.Client | undefined;
+export const createClient = (workspace: string, fileType: string | undefined) => {
+  if (!config || !fileType) return;
+  
+  const service = () => 
+  {
+    switch(fileType)
+    {
+      case "CPP":
+        return "CppService";
+      case "PY":
+        return "PythonService";
+    }
+  };
+
+  const connection = thrift.createXHRConnection(config.webserver_host, config.webserver_port, {
+    transport: thrift.TBufferedTransport,
+    protocol: thrift.TJSONProtocol,
+    https: config.webserver_https,
+    path: `${config.webserver_path}/${workspace}/${service()}`,
+  });
+  client = thrift.createXHRClient(LanguageService, connection);
+  return client;
+};
+
+export const getFileTypes = async () => {
+  if (!client) {
+    return [];
+  }
+  return await client.getFileTypes();
+};
+
+export const getFileDiagramTypes = async (fileId: string) => {
+  let resultMap = new Map<string, number>();
+  if (!client) {
+    return resultMap;
+  }
+  try {
+    resultMap = await client.getFileDiagramTypes(fileId);
+  } catch (e) {
+    console.error(e);
+    resultMap = new Map();
+  }
+  return resultMap;
+};
+
+export const getFileDiagram = async (fileId: string, diagramId: number) => {
+  if (!client) {
+    return '';
+  }
+  try {
+    return await client.getFileDiagram(fileId, diagramId);
+  } catch (e) {
+    toast.error('Could not display diagram.');
+    console.error(e);
+    return '';
+  }
+};
+
+export const getFileDiagramLegend = async (diagramId: number) => {
+  if (!client) {
+    return '';
+  }
+  try {
+    return await client.getFileDiagramLegend(diagramId);
+  } catch (e) {
+    toast.error('Could not display diagram legend.');
+    console.error(e);
+    return '';
+  }
+};
+
+export const getDiagramTypes = async (astNodeId: string) => {
+  let resultMap = new Map<string, number>();
+  if (!client) {
+    return resultMap;
+  }
+  try {
+    resultMap = await client.getDiagramTypes(astNodeId);
+  } catch (e) {
+    console.error(e);
+    resultMap = new Map();
+  }
+  return resultMap;
+};
+
+export const getDiagram = async (astNodeId: string, diagramId: number) => {
+  if (!client) {
+    return '';
+  }
+  try {
+    return await client.getDiagram(astNodeId, diagramId);
+  } catch (e) {
+    toast.error('Could not display diagram.');
+    console.error(e);
+    return '';
+  }
+};
+
+export const getDiagramLegend = async (diagramId: number) => {
+  if (!client) {
+    return '';
+  }
+  try {
+    return await client.getDiagramLegend(diagramId);
+  } catch (e) {
+    toast.error('Could not display diagram legend.');
+    console.error(e);
+    return '';
+  }
+};
+
+export const getFileReferenceTypes = async (fileId: string) => {
+  let resultMap = new Map<string, number>();
+  if (!client) {
+    return resultMap;
+  }
+  try {
+    resultMap = await client.getFileReferenceTypes(fileId);
+  } catch (e) {
+    console.error(e);
+    resultMap = new Map();
+  }
+  return resultMap;
+};
+
+export const getFileReferences = async (fileId: string, referenceId: number) => {
+  if (!client) {
+    return [];
+  }
+  try {
+    return await client.getFileReferences(fileId, referenceId);
+  } catch (e) {
+    console.error(e);
+    return [];
+  }
+};
+
+export const getFileReferenceCount = async (fileId: string, referenceId: number) => {
+  if (!client) {
+    return 0;
+  }
+  try {
+    return await client.getFileReferenceCount(fileId, referenceId);
+  } catch (e) {
+    console.error(e);
+    return 0;
+  }
+};
+
+export const getReferenceTypes = async (astNodeId: string) => {
+  let resultMap = new Map<string, number>();
+  if (!client) {
+    return resultMap;
+  }
+  try {
+    resultMap = await client.getReferenceTypes(astNodeId);
+  } catch (e) {
+    console.error(e);
+    resultMap = new Map();
+  }
+  return resultMap;
+};
+
+export const getReferences = async (astNodeId: string, referenceId: number, tags: string[]) => {
+  if (!client) {
+    return [];
+  }
+  try {
+    return await client.getReferences(astNodeId, referenceId, tags);
+  } catch (e) {
+    console.error(e);
+    return [];
+  }
+};
+
+export const getReferenceCount = async (astNodeId: string, referenceId: number) => {
+  if (!client) {
+    return 0;
+  }
+  try {
+    return await client.getReferenceCount(astNodeId, referenceId);
+  } catch (e) {
+    console.error(e);
+    return 0;
+  }
+};
+
+export const getReferencesInFile = async (
+  astNodeId: string,
+  referenceId: number,
+  fileId: string,
+  tags: string[]
+) => {
+  if (!client) {
+    return [];
+  }
+  try {
+    return await client.getReferencesInFile(astNodeId, referenceId, fileId, tags);
+  } catch (e) {
+    console.error(e);
+    return [];
+  }
+};
+
+export const getReferencesPage = async (
+  astNodeId: string,
+  referenceId: number,
+  pageSize: number,
+  pageNo: number
+) => {
+  if (!client) {
+    return [];
+  }
+  try {
+    return await client.getReferencesPage(astNodeId, referenceId, pageSize, pageNo);
+  } catch (e) {
+    console.error(e);
+    return [];
+  }
+};
+
+export const getSourceText = async (astNodeId: string) => {
+  if (!client) {
+    return '';
+  }
+  try {
+    return await client.getSourceText(astNodeId);
+  } catch (e) {
+    console.error(e);
+    return '';
+  }
+};
+
+export const getProperties = async (astNodeId: string) => {
+  let resultMap = new Map<string, string>();
+  if (!client) {
+    return resultMap;
+  }
+  try {
+    resultMap = await client.getProperties(astNodeId);
+  } catch (e) {
+    console.error(e);
+    resultMap = new Map();
+  }
+  return resultMap;
+};
+
+export const getDocumentation = async (astNodeId: string) => {
+  if (!client) {
+    return '';
+  }
+  try {
+    return await client.getDocumentation(astNodeId);
+  } catch (e) {
+    toast.error('Could not get documentation about this AST node.');
+    console.error(e);
+    return '';
+  }
+};
+
+export const getAstNodeInfo = async (astNodeId: string) => {
+  if (!client) {
+    return;
+  }
+  try {
+    return await client.getAstNodeInfo(astNodeId);
+  } catch (e) {
+    console.error(e);
+    return;
+  }
+};
+
+export const getAstNodeInfoByPosition = async (fileId: string, line: number, column: number) => {
+  if (!client) {
+    return;
+  }
+  try {
+    return await client.getAstNodeInfoByPosition(
+      new FilePosition({
+        file: fileId,
+        pos: new Position({
+          line,
+          column,
+        }),
+      })
+    );
+  } catch (e) {
+    return;
+  }
+};


### PR DESCRIPTION
The current implementation of `webgui-new` only calls the `CppService` as a Language Service. 
This is an issue when requesting information such as `getAstNodeInfoByPosition` since the `CppService` gets called even if we are not viewing C++ files.

In this patch, I added a universal `language-service` for `webgui-new`,  which decides the service to call based on file type.
Before using this `language-service`, one should call `createClient` with a file type and then it creates the appropriate Thrift connection.

I also replaced existing `CppService` calls with the new `language-service`.

For the codemirror-editor, I also added a `languageExtension` function, which selects the correct CodeMirror extension for syntax highlight.







