### PR TITLE
Fix: Move gitblame tooltip to the left

### DIFF
--- a/plugins/git/webgui/js/gitBlame.js
+++ b/plugins/git/webgui/js/gitBlame.js
@@ -39,7 +39,7 @@ function (on, topic, declare, Color, dom, Tooltip, Text, model, viewHandler,
         commitCache[tooltipId] = gitUtil.createTooltip(commit);
       }
 
-      Tooltip.show(commitCache[tooltipId], domNode, ['above']);
+      Tooltip.show(commitCache[tooltipId], domNode, ['before']);
       on.once(domNode, 'mouseleave', function(){
         Tooltip.hide(domNode);
       })

--- a/webgui/style/codecompass.css
+++ b/webgui/style/codecompass.css
@@ -709,3 +709,7 @@ div.CodeMirror-linenumber {
 .cm-s-default .cm-Function { font-weight: bold; }
 .cm-s-default .cm-Type { color:rgb(43, 145, 175); }
 .cm-s-default .cm-Enum { color:rgb(47, 79, 79); }
+
+.git-message {
+  overflow-wrap: break-word;
+}


### PR DESCRIPTION
This is a possible solution to fix: https://github.com/Ericsson/CodeCompass/issues/762

In this patch, the tooltip is moved to the left:

![image](https://github.com/user-attachments/assets/0529a05b-f9b8-4c27-8115-e539c399df68)

A CSS change is also needed to fix cases where the words are too long and overflow.