### PR TITLE
LLVM 19 migration

### DIFF
--- a/plugins/cpp/parser/include/cppparser/filelocutil.h
+++ b/plugins/cpp/parser/include/cppparser/filelocutil.h
@@ -91,7 +91,7 @@ public:
     if (fid.isInvalid())
       return std::string();
 
-    const clang::FileEntry* fileEntry = _clangSrcMan.getFileEntryForID(fid);
+    const clang::OptionalFileEntryRef fileEntry = _clangSrcMan.getFileEntryRefForID(fid);
     if (!fileEntry)
       return std::string();
 

--- a/plugins/cpp/parser/src/cppparser.cpp
+++ b/plugins/cpp/parser/src/cppparser.cpp
@@ -232,7 +232,7 @@ model::BuildActionPtr CppParser::addBuildAction(
 
   model::BuildActionPtr buildAction(new model::BuildAction);
 
-  std::string extension = fs::extension(command_.Filename);
+  std::string extension = fs::path(command_.Filename).extension().string();
 
   buildAction->command = boost::algorithm::join(command_.CommandLine, " ");
   buildAction->type

--- a/plugins/cpp/parser/src/doccommentformatter.cpp
+++ b/plugins/cpp/parser/src/doccommentformatter.cpp
@@ -58,10 +58,10 @@ FullCommentParts::FullCommentParts(
 
     switch (child->getCommentKind())
     {
-      case Comment::NoCommentKind:
+      case CommentKind::None:
         continue;
 
-      case Comment::ParagraphCommentKind:
+      case CommentKind::ParagraphComment:
       {
         const ParagraphComment* pc = llvm::cast<ParagraphComment>(child);
 
@@ -75,7 +75,7 @@ FullCommentParts::FullCommentParts(
         break;
       }
 
-      case Comment::BlockCommandCommentKind:
+      case CommentKind::BlockCommandComment:
       {
         const BlockCommandComment* bcc = llvm::cast<BlockCommandComment>(child);
         const CommandInfo* Info = traits_.getCommandInfo(bcc->getCommandID());
@@ -94,7 +94,7 @@ FullCommentParts::FullCommentParts(
         break;
       }
 
-      case Comment::ParamCommandCommentKind:
+      case CommentKind::ParamCommandComment:
       {
         const ParamCommandComment* pcc = llvm::cast<ParamCommandComment>(child);
 
@@ -108,7 +108,7 @@ FullCommentParts::FullCommentParts(
         break;
       }
 
-      case Comment::TParamCommandCommentKind:
+      case CommentKind::TParamCommandComment:
       {
         const TParamCommandComment* tpcc
           = llvm::cast<TParamCommandComment>(child);
@@ -123,11 +123,11 @@ FullCommentParts::FullCommentParts(
         break;
       }
 
-      case Comment::VerbatimBlockCommentKind:
+      case CommentKind::VerbatimBlockComment:
         _miscBlocks.push_back(cast<BlockCommandComment>(child));
         break;
 
-      case Comment::VerbatimLineCommentKind:
+      case CommentKind::VerbatimLineComment:
       {
         const VerbatimLineComment* vlc = llvm::cast<VerbatimLineComment>(child);
         const CommandInfo* Info = traits_.getCommandInfo(vlc->getCommandID());
@@ -251,22 +251,22 @@ void CommentToMarkdownConverter::visitInlineCommandComment(
 
   switch (c_->getRenderKind())
   {
-    case InlineCommandComment::RenderNormal:
+    case InlineCommandRenderKind::Normal:
       for (unsigned i = 0, e = c_->getNumArgs(); i != e; ++i)
         _res << c_->getArgText(i).str() << ' ';
       return;
 
-    case InlineCommandComment::RenderBold:
+    case InlineCommandRenderKind::Bold:
       assert(c_->getNumArgs() == 1);
       _res << "**" << arg0.str() << "**";
       return;
 
-    case InlineCommandComment::RenderMonospaced:
+    case InlineCommandRenderKind::Monospaced:
       assert(c_->getNumArgs() == 1);
       _res << '`' << arg0.str() << '`';
       return;
 
-    case InlineCommandComment::RenderEmphasized:
+    case InlineCommandRenderKind::Emphasized:
       assert(c_->getNumArgs() == 1);
       _res << '*' << arg0.str() << '*';
       return;
@@ -336,9 +336,9 @@ void CommentToMarkdownConverter::visitParamCommandComment(
 {
   switch (c_->getDirection())
   {
-    case ParamCommandComment::In:    _res << "- *in*: ";     break;
-    case ParamCommandComment::Out:   _res << "- *out*: ";    break;
-    case ParamCommandComment::InOut: _res << "- *in,out*: "; break;
+    case ParamCommandPassDirection::In:    _res << "- *in*: ";     break;
+    case ParamCommandPassDirection::Out:   _res << "- *out*: ";    break;
+    case ParamCommandPassDirection::InOut: _res << "- *in,out*: "; break;
   }
 
   _res << "**" << (c_->isParamIndexValid()

--- a/plugins/cpp/parser/src/ppincludecallback.cpp
+++ b/plugins/cpp/parser/src/ppincludecallback.cpp
@@ -61,10 +61,11 @@ void PPIncludeCallback::InclusionDirective(
   clang::StringRef fileName_,
   bool,
   clang::CharSourceRange filenameRange_,
-  clang::Optional<clang::FileEntryRef>,
+  clang::OptionalFileEntryRef,
   clang::StringRef searchPath_,
   clang::StringRef,
   const clang::Module*,
+  bool,
   clang::SrcMgr::CharacteristicKind)
 {
   if (searchPath_.empty())

--- a/plugins/cpp/parser/src/ppincludecallback.h
+++ b/plugins/cpp/parser/src/ppincludecallback.h
@@ -38,10 +38,11 @@ public:
     clang::StringRef FileName,
     bool IsAngled,
     clang::CharSourceRange FilenameRange,
-    clang::Optional<clang::FileEntryRef> File,
+    clang::OptionalFileEntryRef File,
     clang::StringRef SearchPath,
     clang::StringRef RelativePath,
     const clang::Module *Imported,
+    bool ModuleImported,
     clang::SrcMgr::CharacteristicKind FileType) override;
 
 private:

--- a/plugins/dummy/parser/src/dummyparser.cpp
+++ b/plugins/dummy/parser/src/dummyparser.cpp
@@ -17,7 +17,7 @@ DummyParser::DummyParser(ParserContext& ctx_): AbstractParser(ctx_)
 
 bool DummyParser::accept(const std::string& path_)
 {
-  std::string ext = boost::filesystem::extension(path_);
+  std::string ext = boost::filesystem::path(path_).string();
   return ext == ".dummy";
 }
 

--- a/service/workspace/src/workspaceservice.cpp
+++ b/service/workspace/src/workspaceservice.cpp
@@ -1,5 +1,6 @@
 #include <boost/filesystem.hpp>
 #include <workspaceservice/workspaceservice.h>
+#include <algorithm>
 
 namespace cc
 { 

--- a/util/include/util/hash.h
+++ b/util/include/util/hash.h
@@ -36,18 +36,18 @@ inline std::string sha1Hash(const std::string& data_)
   using namespace boost::uuids::detail;
 
   sha1 hasher;
-  unsigned int digest[5];
+  unsigned char digest[20];
 
   hasher.process_bytes(data_.c_str(), data_.size());
   hasher.get_digest(digest);
 
   std::stringstream ss;
   ss.setf(std::ios::hex, std::ios::basefield);
-  ss.width(8);
+  ss.width(2);
   ss.fill('0');
 
-  for (int i = 0; i < 5; ++i)
-    ss << digest[i];
+  for (int i = 0; i < 20; ++i)
+    ss << (int)digest[i];
 
   return ss.str();
 }


### PR DESCRIPTION
This patch implements LLVM 19, clang-19 support. The changes are **not** backwards compatible, meaning it no longer compiles with older LLVM.

### Upgraded dependencies:

- Boost: version `1.86.0` (current Boost version 1.74.0 does not compile with clang-19)
- C++ standard upgraded to `17` (required by clang-19)

### Prerequisites
The new Boost version is not in the Ubuntu 22.04 repositories, it needs to be compiled from source.
Download from https://www.boost.org/users/download/, steps:
```
./bootstrap.sh --prefix=path/to/installation/prefix
./b2 install
```

LLVM 19 is also not in the repositories.
Download from https://apt.llvm.org/, steps:
```
wget https://apt.llvm.org/llvm.sh
chmod +x llvm.sh
sudo ./llvm.sh 19 all
```
### Compiling CodeCompass
Configure CMake with these flags:
```
-DLLVM_DIR=/usr/lib/llvm-19/cmake
-DClang_DIR=/usr/lib/cmake/clang-19 
-DCMAKE_C_COMPILER=clang-19 
-DCMAKE_CXX_COMPILER=clang++-19
```
We may encounter the following error:
```
In file included from CodeCompass/plugins/cpp/parser/src/cppparser.cpp:26:
In file included from CodeCompass/util/include/util/logutil.h:4:
In file included from /usr/local/include/boost/log/trivial.hpp:23:
In file included from /usr/local/include/boost/log/sources/severity_logger.hpp:23:
In file included from /usr/local/include/boost/log/sources/basic_logger.hpp:36:
In file included from /usr/local/include/boost/log/core/core.hpp:23:
In file included from /usr/local/include/boost/log/core/record.hpp:21:
In file included from /usr/local/include/boost/log/attributes/attribute_value_set.hpp:27:
In file included from /usr/local/include/boost/log/attributes/attribute_value.hpp:18:
In file included from /usr/local/include/boost/type_index.hpp:29:
In file included from /usr/local/include/boost/type_index/stl_type_index.hpp:34:
In file included from /usr/local/include/boost/core/demangle.hpp:32:
/usr/lib/llvm-19/include/cxxabi.h:55:1: error: functions that differ only in their return type cannot be overloaded
   50 | extern _LIBCXXABI_FUNC_VIS __cxa_exception*
      |                            ~~~~~~~~~~~~~~~~
   51 | #ifdef __wasm__
   52 | // In Wasm, a destructor returns its argument
   53 | __cxa_init_primary_exception(void* object, std::type_info* tinfo, void*(_LIBCXXABI_DTOR_FUNC* dest)(void*)) throw();
   54 | #else
   55 | __cxa_init_primary_exception(void* object, std::type_info* tinfo, void(_LIBCXXABI_DTOR_FUNC* dest)(void*)) throw();
      | ^
/usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/cxxabi_init_exception.h:70:7: note: previous declaration is here
   69 |       __cxa_refcounted_exception*
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~
   70 |       __cxa_init_primary_exception(void *object, std::type_info *tinfo,
      |       ^
```

This can be resolved by ~~installing LLVM-18~~ removing the following packages:
```
sudo apt purge libc++1-19 libc++-19-dev libc++abi1-19 libc++abi-19-dev
```

Finally, CodeCompass should build without errors.
I also successfully parsed the `gtest` C++ project.