### PR TITLE
Add module configuration support for C++ metrics

### DIFF
--- a/parser/include/parser/parsercontext.h
+++ b/parser/include/parser/parsercontext.h
@@ -3,9 +3,9 @@
 
 #include <memory>
 #include <unordered_map>
+#include <vector>
 
 #include <boost/program_options.hpp>
-
 #include <odb/database.hxx>
 
 namespace po = boost::program_options; 
@@ -43,6 +43,7 @@ struct ParserContext
   std::string& compassRoot;
   po::variables_map& options;
   std::unordered_map<std::string, IncrementalStatus> fileStatus;
+  std::vector<std::string> moduleDirectories;
 };
 
 } // parser

--- a/parser/src/parser.cpp
+++ b/parser/src/parser.cpp
@@ -85,7 +85,11 @@ po::options_description commandLineArguments()
      "further actions modifying the state of the database.")
     ("incremental-threshold", po::value<int>()->default_value(10),
       "This is a threshold percentage. If the total ratio of changed files "
-      "is greater than this value, full parse is forced instead of incremental parsing.");
+      "is greater than this value, full parse is forced instead of incremental parsing.")
+    ("modules,m", po::value<std::string>(),
+      "For metrics calculations, you can specify the project's (sub)module structure."
+      "Provide the path of a text file for this setting."
+      "The file should contain directory paths, each on a separate line, which will be considered modules.");
 
   return desc;
 }

--- a/parser/src/parsercontext.cpp
+++ b/parser/src/parsercontext.cpp
@@ -1,3 +1,4 @@
+#include <boost/filesystem/exception.hpp>
 #include <fstream>
 
 #include <boost/filesystem.hpp>
@@ -86,7 +87,7 @@ ParserContext::ParserContext(
 
     if (!fileStream.good()) {
       LOG(error) << "Failed to open modules file: " << modulesFilePath;
-      exit(1);
+      return;
     }
 
     LOG(info) << "Processing modules file: " << modulesFilePath;
@@ -96,9 +97,9 @@ ParserContext::ParserContext(
       try {
         const fs::path p = fs::canonical(line);
         moduleDirectories.push_back(p.string());
-      } catch (...) {
+      } catch (fs::filesystem_error& err) {
         LOG(error) << "Failed to process path from modules file: " << line;
-        exit(1);
+        LOG(error) << err.what();
       }
     }
   }

--- a/parser/src/parsercontext.cpp
+++ b/parser/src/parsercontext.cpp
@@ -12,6 +12,7 @@
 #include <parser/sourcemanager.h>
 
 namespace po = boost::program_options;
+namespace fs = boost::filesystem;
 
 namespace cc
 {
@@ -76,6 +77,31 @@ ParserContext::ParserContext(
 
      // TODO: detect ADDED files
    });
+
+  // Fill moduleDirectories vector
+  if (options.count("modules")) {
+    const std::string& modulesFilePath = options["modules"].as<std::string>();
+
+    std::ifstream fileStream(modulesFilePath);
+
+    if (!fileStream.good()) {
+      LOG(error) << "Failed to open modules file: " << modulesFilePath;
+      exit(1);
+    }
+
+    LOG(info) << "Processing modules file: " << modulesFilePath;
+
+    std::string line;
+    while (std::getline(fileStream, line)) {
+      try {
+        const fs::path p = fs::canonical(line);
+        moduleDirectories.push_back(p.string());
+      } catch (...) {
+        LOG(error) << "Failed to process path from modules file: " << line;
+        exit(1);
+      }
+    }
+  }
 }
 }
 }


### PR DESCRIPTION
This patch implements `--modules` or `-m` flag for metrics calculations.