### PR TITLE
Add paging support for C++ metrics

### DIFF
--- a/Config.cmake
+++ b/Config.cmake
@@ -87,7 +87,7 @@ set(ODBFLAGS
   --default-pointer "std::shared_ptr")
 
 # Set CXX standard
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/plugins/cpp_metrics/model/include/model/cppastnodemetrics.h
+++ b/plugins/cpp_metrics/model/include/model/cppastnodemetrics.h
@@ -117,6 +117,17 @@ struct CppAstNodeMetricsAndDataForPathView
   double value;
 };
 
+#pragma db view \
+  object(CppAstNodeMetrics) \
+  object(CppAstNode : CppAstNodeMetrics::astNodeId == CppAstNode::id) \
+  object(File : CppAstNode::location.file) \
+  query(distinct)
+struct CppAstNodeMetricsDistinctView
+{
+  #pragma db column(CppAstNodeMetrics::astNodeId)
+  CppAstNodeId astNodeId;
+};
+
 } //model
 } //cc
 

--- a/plugins/cpp_metrics/model/include/model/cppfilemetrics.h
+++ b/plugins/cpp_metrics/model/include/model/cppfilemetrics.h
@@ -47,6 +47,16 @@ struct CppModuleMetricsForPathView
   unsigned value;
 };
 
+#pragma db view \
+  object(CppFileMetrics) \
+  object(File : CppFileMetrics::file == File::id) \
+  query(distinct)
+struct CppModuleMetricsDistinctView
+{
+  #pragma db column(CppFileMetrics::file)
+  FileId fileId;
+};
+
 } //model
 } //cc
 

--- a/plugins/cpp_metrics/service/CMakeLists.txt
+++ b/plugins/cpp_metrics/service/CMakeLists.txt
@@ -19,8 +19,9 @@ add_custom_command(
     ${CMAKE_CURRENT_BINARY_DIR}/gen-cpp/CppMetricsService.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/gen-cpp/CppMetricsService.h
     ${CMAKE_CURRENT_BINARY_DIR}/gen-cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/gen-js
   COMMAND
-    ${THRIFT_EXECUTABLE} --gen cpp --gen js:jquery
+    ${THRIFT_EXECUTABLE} --gen cpp --gen js
       -o ${CMAKE_CURRENT_BINARY_DIR}
       -I ${PROJECT_SOURCE_DIR}/service
       ${CMAKE_CURRENT_SOURCE_DIR}/cxxmetrics.thrift

--- a/plugins/cpp_metrics/service/CMakeLists.txt
+++ b/plugins/cpp_metrics/service/CMakeLists.txt
@@ -20,7 +20,7 @@ add_custom_command(
     ${CMAKE_CURRENT_BINARY_DIR}/gen-cpp/CppMetricsService.h
     ${CMAKE_CURRENT_BINARY_DIR}/gen-cpp
   COMMAND
-    ${THRIFT_EXECUTABLE} --gen cpp
+    ${THRIFT_EXECUTABLE} --gen cpp --gen js:jquery
       -o ${CMAKE_CURRENT_BINARY_DIR}
       -I ${PROJECT_SOURCE_DIR}/service
       ${CMAKE_CURRENT_SOURCE_DIR}/cxxmetrics.thrift

--- a/plugins/cpp_metrics/service/cxxmetrics.thrift
+++ b/plugins/cpp_metrics/service/cxxmetrics.thrift
@@ -99,6 +99,17 @@ service CppMetricsService
     1:string path)
 
   /**
+   * This is a paged function which returns all available C++ metrics
+   * (AST node-level) for a particular path.
+   *
+   * The given path is a handled as a prefix.
+   */
+  map<common.AstNodeId, list<CppMetricsAstNodeSingle>> getPagedCppAstNodeMetricsForPath(
+    1:string path
+    2:i32 pageSize,
+    3:i32 pageNumber)
+
+  /**
    * This function returns all available C++ metrics
    * (AST node-level) and miscellaneous data for a particular path.
    *
@@ -108,6 +119,17 @@ service CppMetricsService
     1:string path)
 
   /**
+   * This is a paged function which returns all available C++ metrics
+   * (AST node-level) and miscellaneous data for a particular path.
+   *
+   * The given path is a handled as a prefix.
+   */
+  map<common.AstNodeId, CppMetricsAstNodeDetailed> getPagedCppAstNodeMetricsDetailedForPath(
+    1:string path,
+    2:i32 pageSize,
+    3:i32 pageNumber)
+
+  /**
    * This function returns all available C++ metrics
    * (file-level) for a particular path.
    *
@@ -115,6 +137,17 @@ service CppMetricsService
    */
   map<common.FileId, list<CppMetricsModuleSingle>> getCppFileMetricsForPath(
     1:string path)
+
+  /**
+   * This is a paged function which returns all available C++ metrics
+   * (file-level) for a particular path.
+   *
+   * The given path is a handled as a prefix.
+   */
+  map<common.FileId, list<CppMetricsModuleSingle>> getPagedCppFileMetricsForPath(
+    1:string path,
+    2:i32 pageSize,
+    3:i32 pageNumber)
 
   /**
    * This function returns the names of the AST node-level C++ metrics.


### PR DESCRIPTION
This PR implements paged versions of existing functions in `CppMetricsService`:
- `getPagedCppAstNodeMetricsForPath`
- `getPagedCppAstNodeMetricsDetailedForPath`
- `getPagedCppFileMetricsForPath`

I also upgraded the C++ standard to 17, since I used `if constexpr` in a function template.

The Thrift `CppMetricsService` was missing JavaScript bindings, I think this is a mistake so I added that as well to `plugins/metrics/service/CMakeLists.txt`.

On a high level, the paging is implemented as follows:
1. We select `DISTINCT` `astNodeId` from table `CppAstNodeMetrics`.
2. We filter for `path` (using `LIKE`) and also for `pageSize` and `pageNumber` (using `LIMIT` and `OFFSET`).
3. Finally, we have a list of `astNodeId` with exact size as `pageSize`. We run `SELECT` on `CppAstNodeMetrics` once again, selecting all rows where the `astNodeId` is in the list (using SQL `IN` keyword).

The PR was also tested using Thrift JS bindings.
