### PR TITLE
Use Release build for CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,7 +42,7 @@ jobs:
   analyze-cpp:
     name: Analyze C-C++
     env:
-      BUILD_TYPE: RelWithDebInfo
+      BUILD_TYPE: Release
       INSTALL_PATH: ${{github.workspace}}/dependencies/install
       DOWNLOAD_PATH: ${{github.workspace}}/dependencies/download
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Use `Release` build for CodeQL to reduce build size. The CodeQL job recently gets an out of disk space failure, and this resolves the issue according to initial tests. A `ReleaseWithDebInfo` build is not required by CodeQL, because it only needs to observe the compilation commands.