### PR TITLE
Implement efferent coupling at module level

### DIFF
--- a/plugins/cpp/model/include/model/cppfunction.h
+++ b/plugins/cpp/model/include/model/cppfunction.h
@@ -36,7 +36,7 @@ struct CppFunction : CppTypedEntity
 typedef std::shared_ptr<CppFunction> CppFunctionPtr;
 
 #pragma db view \
-  object(CppFunction) object(CppVariable = Parameters : CppFunction::parameters)
+  object(CppFunction) object(CppVariable = Parameters inner : CppFunction::parameters)
 struct CppFunctionParamCount
 {
   #pragma db column("count(" + Parameters::id + ")")
@@ -45,7 +45,7 @@ struct CppFunctionParamCount
 
 #pragma db view \
   object(CppFunction) \
-  object(CppVariable = Parameters : CppFunction::parameters) \
+  object(CppVariable = Parameters inner : CppFunction::parameters) \
   object(CppAstNode : CppFunction::astNodeId == CppAstNode::id) \
   object(File : CppAstNode::location.file) \
   query((?) + "GROUP BY" + cc::model::CppEntity::astNodeId + "," + cc::model::File::path)
@@ -59,7 +59,7 @@ struct CppFunctionParamCountWithId
 };
 
 #pragma db view \
-  object(CppFunction) object(CppVariable = Locals : CppFunction::locals)
+  object(CppFunction) object(CppVariable = Locals inner : CppFunction::locals)
 struct CppFunctionLocalCount
 {
   #pragma db column("count(" + Locals::id + ")")
@@ -97,7 +97,7 @@ struct CppFunctionBumpyRoad
 
 #pragma db view \
   object(CppFunction) \
-  object(CppVariable = Parameters : CppFunction::parameters)
+  object(CppVariable = Parameters inner : CppFunction::parameters)
 struct CppFunctionParamTypeView
 {
   #pragma db column(CppFunction::astNodeId)
@@ -109,7 +109,7 @@ struct CppFunctionParamTypeView
 
 #pragma db view \
   object(CppFunction) \
-  object(CppVariable = Locals : CppFunction::locals)
+  object(CppVariable = Locals inner : CppFunction::locals)
 struct CppFunctionLocalTypeView
 {
 #pragma db column(CppFunction::astNodeId)

--- a/plugins/cpp_metrics/model/CMakeLists.txt
+++ b/plugins/cpp_metrics/model/CMakeLists.txt
@@ -5,7 +5,8 @@ include_directories(
 set(ODB_SOURCES
   include/model/cppastnodemetrics.h
   include/model/cppcohesionmetrics.h
-  include/model/cppfilemetrics.h)
+  include/model/cppfilemetrics.h
+  include/model/cpptypedependencymetrics.h)
 
 generate_odb_files("${ODB_SOURCES}" "cpp")
 

--- a/plugins/cpp_metrics/model/include/model/cppfilemetrics.h
+++ b/plugins/cpp_metrics/model/include/model/cppfilemetrics.h
@@ -13,7 +13,7 @@ struct CppFileMetrics
 {
   enum Type
   {
-    PLACEHOLDER
+    EFFERENT_MODULE
   };
 
   #pragma db id auto

--- a/plugins/cpp_metrics/model/include/model/cpptypedependencymetrics.h
+++ b/plugins/cpp_metrics/model/include/model/cpptypedependencymetrics.h
@@ -1,0 +1,70 @@
+#ifndef CC_MODEL_CPPTYPEDEPENDENCYMETRICS_H
+#define CC_MODEL_CPPTYPEDEPENDENCYMETRICS_H
+
+#include <cstdint>
+#include <string>
+#include <model/cppentity.h>
+#include <model/cpprecord.h>
+#include <model/cppastnode.h>
+#include <model/file.h>
+
+namespace cc
+{
+namespace model
+{
+
+#pragma db object
+struct CppTypeDependencyMetrics
+{
+  #pragma db id auto
+  std::uint64_t id;
+
+  #pragma db not_null
+  std::uint64_t entityHash;
+
+  #pragma db not_null
+  std::uint64_t dependencyHash;
+};
+
+#pragma db view \
+  object(CppTypeDependencyMetrics) \
+  object(CppAstNode = EntityAstNode : CppTypeDependencyMetrics::entityHash == EntityAstNode::entityHash \
+    && EntityAstNode::astType == cc::model::CppAstNode::AstType::Definition) \
+  object(File = EntityFile : EntityAstNode::location.file == EntityFile::id) \
+  object(CppAstNode = DependencyAstNode : CppTypeDependencyMetrics::dependencyHash == DependencyAstNode::entityHash \
+    && DependencyAstNode::astType == cc::model::CppAstNode::AstType::Definition) \
+  object(File = DependencyFile : DependencyAstNode::location.file == DependencyFile::id)
+struct CppTypeDependencyMetricsPathView
+{
+  #pragma db column(CppTypeDependencyMetrics::entityHash)
+  std::size_t entityHash;
+
+  #pragma db column(CppTypeDependencyMetrics::dependencyHash)
+  std::size_t dependencyHash;
+
+  #pragma db column(EntityFile::path)
+  std::string entityPath;
+
+  #pragma db column(DependencyFile::path)
+  std::string dependencyPath;
+};
+
+#pragma db view \
+  object(CppTypeDependencyMetrics) \
+  object(CppAstNode = EntityAstNode : CppTypeDependencyMetrics::entityHash == EntityAstNode::entityHash \
+    && EntityAstNode::astType == cc::model::CppAstNode::AstType::Definition) \
+  object(File = EntityFile : EntityAstNode::location.file == EntityFile::id) \
+  object(CppAstNode = DependencyAstNode : CppTypeDependencyMetrics::dependencyHash == DependencyAstNode::entityHash \
+    && DependencyAstNode::astType == cc::model::CppAstNode::AstType::Definition) \
+  object(File = DependencyFile : DependencyAstNode::location.file == DependencyFile::id) \
+  query((?), distinct)
+struct CppDistinctTypeDependencyMetricsPathView
+{
+  #pragma db column(CppTypeDependencyMetrics::dependencyHash)
+  std::size_t dependencyHash;
+};
+
+} // model
+} // cc
+
+#endif // CC_MODEL_CPPTYPEDEPENDENCYMETRICS_H

--- a/plugins/cpp_metrics/model/include/model/cpptypedependencymetrics.h
+++ b/plugins/cpp_metrics/model/include/model/cpptypedependencymetrics.h
@@ -56,12 +56,11 @@ struct CppTypeDependencyMetricsPathView
   object(File = EntityFile : EntityAstNode::location.file == EntityFile::id) \
   object(CppAstNode = DependencyAstNode : CppTypeDependencyMetrics::dependencyHash == DependencyAstNode::entityHash \
     && DependencyAstNode::astType == cc::model::CppAstNode::AstType::Definition) \
-  object(File = DependencyFile : DependencyAstNode::location.file == DependencyFile::id) \
-  query((?), distinct)
-struct CppDistinctTypeDependencyMetricsPathView
+  object(File = DependencyFile : DependencyAstNode::location.file == DependencyFile::id)
+struct CppTypeDependencyMetricsPathViewDistinctCount
 {
-  #pragma db column(CppTypeDependencyMetrics::dependencyHash)
-  std::size_t dependencyHash;
+  #pragma db column("count(distinct" + CppTypeDependencyMetrics::dependencyHash + ")")
+  std::size_t count;
 };
 
 } // model

--- a/plugins/cpp_metrics/parser/include/cppmetricsparser/cppmetricsparser.h
+++ b/plugins/cpp_metrics/parser/include/cppmetricsparser/cppmetricsparser.h
@@ -80,7 +80,10 @@ private:
   void efferentTypeLevel();
   // Calculate the afferent coupling of types.
   void afferentTypeLevel();
-
+  // Calculate the efferent coupling at module level.
+  void efferentModuleLevel();
+  // Returns module path query based on parser configuration.
+  odb::query<model::File> getModulePathsQuery();
 
   /// @brief Constructs an ODB query that you can use to filter only
   /// the database records of the given parameter type whose path
@@ -203,6 +206,7 @@ private:
   static const int lackOfCohesionPartitionMultiplier = 25;
   static const int efferentCouplingTypesPartitionMultiplier = 5;
   static const int afferentCouplingTypesPartitionMultiplier = 5;
+  static const int efferentCouplingModulesPartitionMultiplier = 5;
 };
   
 } // parser

--- a/plugins/cpp_metrics/test/sources/parser/CMakeLists.txt
+++ b/plugins/cpp_metrics/test/sources/parser/CMakeLists.txt
@@ -6,4 +6,5 @@ add_library(CppMetricsTestProject STATIC
   typemccabe.cpp
   lackofcohesion.cpp
   bumpyroad.cpp
-  afferentcoupling.cpp)
+  afferentcoupling.cpp
+  modulemetrics.cpp)

--- a/plugins/cpp_metrics/test/sources/parser/module_a/a1.h
+++ b/plugins/cpp_metrics/test/sources/parser/module_a/a1.h
@@ -1,0 +1,13 @@
+#ifndef CC_CPP_MODULE_METRICS_TEST_A1
+#define CC_CPP_MODULE_METRICS_TEST_A1
+
+#include "./a2.h"
+
+namespace CC_CPP_MODULE_METRICS_TEST
+{
+class A1 {
+  A2 a2;
+};
+}
+
+#endif

--- a/plugins/cpp_metrics/test/sources/parser/module_a/a2.h
+++ b/plugins/cpp_metrics/test/sources/parser/module_a/a2.h
@@ -1,0 +1,13 @@
+#ifndef CC_CPP_MODULE_METRICS_TEST_A2
+#define CC_CPP_MODULE_METRICS_TEST_A2
+
+#include "../module_b/b1.h"
+
+namespace CC_CPP_MODULE_METRICS_TEST
+{
+class A2 {
+  B1 b1;
+};
+}
+
+#endif

--- a/plugins/cpp_metrics/test/sources/parser/module_b/b1.h
+++ b/plugins/cpp_metrics/test/sources/parser/module_b/b1.h
@@ -1,0 +1,13 @@
+#ifndef CC_CPP_MODULE_METRICS_TEST_B1
+#define CC_CPP_MODULE_METRICS_TEST_B1
+
+#include "./b2.h"
+
+namespace CC_CPP_MODULE_METRICS_TEST
+{
+class B1 {
+  B2 b2;
+};
+}
+
+#endif

--- a/plugins/cpp_metrics/test/sources/parser/module_b/b2.h
+++ b/plugins/cpp_metrics/test/sources/parser/module_b/b2.h
@@ -1,0 +1,9 @@
+#ifndef CC_CPP_MODULE_METRICS_TEST_B2
+#define CC_CPP_MODULE_METRICS_TEST_B2
+
+namespace CC_CPP_MODULE_METRICS_TEST
+{
+class B2 {};
+}
+
+#endif

--- a/plugins/cpp_metrics/test/sources/parser/module_c/c1.h
+++ b/plugins/cpp_metrics/test/sources/parser/module_c/c1.h
@@ -1,0 +1,15 @@
+#ifndef CC_CPP_MODULE_METRICS_TEST_C1
+#define CC_CPP_MODULE_METRICS_TEST_C1
+
+#include "../module_b/b1.h"
+#include "./c2.h"
+
+namespace CC_CPP_MODULE_METRICS_TEST
+{
+class C1 {
+  B1 b1;
+  C2 c2;
+};
+}
+
+#endif

--- a/plugins/cpp_metrics/test/sources/parser/module_c/c2.h
+++ b/plugins/cpp_metrics/test/sources/parser/module_c/c2.h
@@ -2,11 +2,13 @@
 #define CC_CPP_MODULE_METRICS_TEST_C2
 
 #include "../module_a/a2.h"
+#include "../module_b/b1.h"
 
 namespace CC_CPP_MODULE_METRICS_TEST
 {
 class C2 {
   A2 a2;
+  B1 b1;
 };
 }
 

--- a/plugins/cpp_metrics/test/sources/parser/module_c/c2.h
+++ b/plugins/cpp_metrics/test/sources/parser/module_c/c2.h
@@ -1,0 +1,13 @@
+#ifndef CC_CPP_MODULE_METRICS_TEST_C2
+#define CC_CPP_MODULE_METRICS_TEST_C2
+
+#include "../module_a/a2.h"
+
+namespace CC_CPP_MODULE_METRICS_TEST
+{
+class C2 {
+  A2 a2;
+};
+}
+
+#endif

--- a/plugins/cpp_metrics/test/sources/parser/modulemetrics.cpp
+++ b/plugins/cpp_metrics/test/sources/parser/modulemetrics.cpp
@@ -1,0 +1,6 @@
+#include "./module_a/a1.h"
+#include "./module_a/a2.h"
+#include "./module_b/b1.h"
+#include "./module_b/b2.h"
+#include "./module_c/c1.h"
+#include "./module_c/c2.h"

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(util SHARED
   src/util.cpp)
 
 target_link_libraries(util
+  model
   gvc
   ${Boost_LIBRARIES})
 

--- a/util/include/util/dbutil.h
+++ b/util/include/util/dbutil.h
@@ -3,6 +3,8 @@
 
 #include <memory>
 #include <string>
+#include <model/file.h>
+#include <model/file-odb.hxx>
 
 #include <odb/database.hxx>
 
@@ -147,10 +149,15 @@ odb::query<TQueryParam> getFilterPathsQuery(
   TIter begin_,
   const TSentinel& end_)
 {
-  typedef typename odb::query<TQueryParam>::query_columns QParam;
-  const auto& QParamPath = QParam::File::path;
-  constexpr char ODBWildcard = '%';
+  const auto& QParamPath = [](){
+    if constexpr (std::is_same<TQueryParam, cc::model::File>::value) {
+      return odb::query<TQueryParam>::path;
+    } else {
+      return odb::query<TQueryParam>::query_columns::File::path;
+    }
+  }();
 
+  constexpr char ODBWildcard = '%';
   assert(begin_ != end_ && "At least one filter path must be provided.");
   odb::query<TQueryParam> query = QParamPath.like(*begin_ + ODBWildcard);
   while (++begin_ != end_)


### PR DESCRIPTION
Closes: https://github.com/Ericsson/CodeCompass/issues/674

- Fixed a bug in Efferent Coupling Type level calculation: by default, ODB uses left join, which resulted in incorrect results
- Added `CppTypeDependencyMetrics` table listing dependencies between individual types
- Extended Efferent Coupling Type level calculation to insert these dependency relations
- Implemented Efferent Coupling Module level calculation using this new table
- Added test cases