### PR TITLE
Enhance DB indices on C++ metrics tables

### DIFF
--- a/plugins/cpp_metrics/model/include/model/cppastnodemetrics.h
+++ b/plugins/cpp_metrics/model/include/model/cppastnodemetrics.h
@@ -37,6 +37,8 @@ struct CppAstNodeMetrics
 
   #pragma db null
   double value;
+
+#pragma db index member(astNodeId)
 };
 
 #pragma db view \

--- a/plugins/cpp_metrics/model/include/model/cppfilemetrics.h
+++ b/plugins/cpp_metrics/model/include/model/cppfilemetrics.h
@@ -29,6 +29,8 @@ struct CppFileMetrics
 
   #pragma db not_null
   double value;
+
+#pragma db index member(file)
 };
 
 #pragma db view \

--- a/plugins/cpp_metrics/model/include/model/cpptypedependencymetrics.h
+++ b/plugins/cpp_metrics/model/include/model/cpptypedependencymetrics.h
@@ -24,6 +24,9 @@ struct CppTypeDependencyMetrics
 
   #pragma db not_null
   std::uint64_t dependencyHash;
+
+#pragma db index member(entityHash)
+#pragma db index member(dependencyHash)
 };
 
 #pragma db view \


### PR DESCRIPTION
These metrics are required for efficient querying of metrics in the service layer, especially for paginated queries for large project.