### PR TITLE
Add option to skip C++ metrics calculations for lambdas and nested classes

### DIFF
--- a/plugins/cpp/model/include/model/cpprecord.h
+++ b/plugins/cpp/model/include/model/cpprecord.h
@@ -49,8 +49,21 @@ typedef std::shared_ptr<CppMemberType> CppMemberTypePtr;
 #pragma db object
 struct CppRecord : CppEntity
 {
+  enum Context {
+    TOP_LEVEL,
+    NAMESPACE,
+    RECORD,
+    FUNCTION,
+    OTHER
+  };
+
   bool isAbstract = false;
   bool isPOD = false;
+  bool isLambda = false;
+
+  // Context defines where the CppRecord is located in (e.g. in a namespace).
+  // Context = RECORD means it is nested within another record.
+  Context context = Context::OTHER;
 
   std::string toString() const
   {
@@ -71,6 +84,18 @@ struct CppRecord : CppEntity
     }
 
     return ret;
+  }
+
+  std::string getContextString() const
+  {
+    switch (context)
+    {
+      case Context::TOP_LEVEL: return "Top Level";
+      case Context::NAMESPACE: return "Namespace";
+      case Context::RECORD: return "Record";
+      case Context::FUNCTION: return "Function";
+      case Context::OTHER: return "Other";
+    }
   }
 };
 

--- a/plugins/cpp/parser/src/clangastvisitor.h
+++ b/plugins/cpp/parser/src/clangastvisitor.h
@@ -614,6 +614,20 @@ public:
     cppRecord->entityHash = astNode->entityHash;
     cppRecord->name = rd_->getNameAsString();
     cppRecord->qualifiedName = rd_->getQualifiedNameAsString();
+    cppRecord->isLambda = rd_->isLambda();
+
+    const clang::DeclContext* parentDecl = rd_->getParent();
+    if (parentDecl) {
+      if (parentDecl->isTranslationUnit()) {
+        cppRecord->context = model::CppRecord::Context::TOP_LEVEL;
+      } else if (parentDecl->isNamespace()) {
+        cppRecord->context = model::CppRecord::Context::NAMESPACE;
+      } else if (parentDecl->isRecord()) {
+        cppRecord->context = model::CppRecord::Context::RECORD;
+      } else if (parentDecl->isFunctionOrMethod()) {
+        cppRecord->context = model::CppRecord::Context::FUNCTION;
+      }
+    }
 
     if (const clang::CXXRecordDecl* crd
       = llvm::dyn_cast<clang::CXXRecordDecl>(rd_))

--- a/plugins/cpp/service/src/cppservice.cpp
+++ b/plugins/cpp/service/src/cppservice.cpp
@@ -333,9 +333,12 @@ void CppServiceHandler::getProperties(
             return_["Abstract type"] = "true";
           if (type.isPOD)
             return_["POD type"] = "true";
+          if(type.isLambda)
+            return_["Lambda"] = "true";
 
           return_["Name"] = type.name;
           return_["Qualified name"] = type.qualifiedName;
+          return_["Context"] = type.getContextString();
         }
         else
           LOG(warning)

--- a/plugins/cpp/test/src/cpppropertiesservicetest.cpp
+++ b/plugins/cpp/test/src/cpppropertiesservicetest.cpp
@@ -86,6 +86,7 @@ TEST_F(CppPropertiesServiceTest, ClassPropertiesTest)
     std::map<std::string, std::string> expected =
     {
       {"Name", "SimpleClass"},
+      {"Context", "Namespace"},
       {"Qualified name", "cc::test::SimpleClass"}
     };
 
@@ -96,6 +97,7 @@ TEST_F(CppPropertiesServiceTest, ClassPropertiesTest)
     std::map<std::string, std::string> expected =
     {
       {"Name", "NestedClass"},
+      {"Context", "Namespace"},
       {"Qualified name", "cc::test::NestedClass"},
       {"POD type", "true"}
     };
@@ -107,6 +109,7 @@ TEST_F(CppPropertiesServiceTest, ClassPropertiesTest)
     std::map<std::string, std::string> expected =
     {
       {"Name", "InnerClass"},
+      {"Context", "Record"},
       {"Qualified name", "cc::test::NestedClass::InnerClass"},
       {"POD type", "true"}
     };
@@ -121,6 +124,7 @@ TEST_F(CppPropertiesServiceTest, InheritancePropertiesTest)
     std::map<std::string, std::string> expected =
     {
       {"Name", "BaseClass1"},
+      {"Context", "Namespace"},
       {"Qualified name", "cc::test::BaseClass1"},
       {"Abstract type", "true"}
     };
@@ -132,6 +136,7 @@ TEST_F(CppPropertiesServiceTest, InheritancePropertiesTest)
     std::map<std::string, std::string> expected =
     {
       {"Name", "DerivedClass"},
+      {"Context", "Namespace"},
       {"Qualified name", "cc::test::DerivedClass"}
     };
 

--- a/plugins/cpp_metrics/parser/include/cppmetricsparser/cppmetricsparser.h
+++ b/plugins/cpp_metrics/parser/include/cppmetricsparser/cppmetricsparser.h
@@ -7,6 +7,9 @@
 #include <model/cppastnodemetrics.h>
 #include <model/cppastnodemetrics-odb.hxx>
 
+#include <model/cppcohesionmetrics.h>
+#include <model/cppcohesionmetrics-odb.hxx>
+
 #include <model/cppfunction.h>
 #include <model/cppfunction-odb.hxx>
 
@@ -88,6 +91,8 @@ private:
   void relationalCohesionModuleLevel();
   // Returns module path query based on parser configuration.
   odb::query<model::File> getModulePathsQuery();
+  // Returns cohesion record query based on parser configuration.
+  odb::query<model::CohesionCppRecordView> getCohesionRecordQuery();
 
   /// @brief Constructs an ODB query that you can use to filter only
   /// the database records of the given parameter type whose path


### PR DESCRIPTION
- Changed `CppRecord` parsing: we now also store an `isLambda` and `context` attribute
- Changed `CppServiceHandler::getProperties` to display the new attributes
- Added CLI options `--cppmetrics-ignore-lambdas` and `--cppmetrics-ignore-nested-classes` to skip C++ metrics calculations in those cases
- These new CLI options are considered when calculating: `lackOfCohesion`, `efferentTypeLevel`, `afferentTypeLevel`