### PR TITLE
Query paginated metrics efficiently

### DIFF
--- a/plugins/cpp_metrics/service/cxxmetrics.thrift
+++ b/plugins/cpp_metrics/service/cxxmetrics.thrift
@@ -109,7 +109,7 @@ service CppMetricsService
   map<common.AstNodeId, list<CppMetricsAstNodeSingle>> getPagedCppAstNodeMetricsForPath(
     1:string path
     2:i32 pageSize,
-    3:i32 pageNumber)
+    3:common.AstNodeId previousId)
 
   /**
    * This function returns all available C++ metrics
@@ -129,7 +129,7 @@ service CppMetricsService
   map<common.AstNodeId, CppMetricsAstNodeDetailed> getPagedCppAstNodeMetricsDetailedForPath(
     1:string path,
     2:i32 pageSize,
-    3:i32 pageNumber)
+    3:common.AstNodeId previousId)
 
   /**
    * This function returns all available C++ metrics
@@ -149,7 +149,7 @@ service CppMetricsService
   map<common.FileId, list<CppMetricsModuleSingle>> getPagedCppFileMetricsForPath(
     1:string path,
     2:i32 pageSize,
-    3:i32 pageNumber)
+    3:common.FileId previousId)
 
   /**
    * This function returns the names of the AST node-level C++ metrics.


### PR DESCRIPTION
Paginated metric querying introduced in #784 uses `LIMIT` + `OFFSET` SQL closures to select the appropriate AST Node IDs or File IDs.
However `DISTINCT` is also applied on the projected IDs, therefore the `OFFSET` does not provide any performance benefit: the database engine still needs to process (deduplicate) **all** offseted elements.

This PR introduces a new approach: *Keyset Pagination* (a.k.a. Seek Method); where instead of using `OFFSET`, we use a last / previous ID to start querying records "after" that.