### PR TITLE
Gitignore clangd cache folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ nbproject/
 .vscode/
 # Vim
 *.swp
+# clangd cache directory
+.cache/
 
 
 ## Build folders


### PR DESCRIPTION
During development, `clangd` creates a cache folder in the root directory named `.cache/`, this should be gitignored.