### PR TITLE
Fix ignoring lambda expression in C++ plugin

### DIFF
--- a/model/include/model/buildaction.h
+++ b/model/include/model/buildaction.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <memory>
 #include <vector>
+#include <cstdint>
 
 #include <odb/core.hxx>
 #include <odb/lazy-ptr.hxx>

--- a/plugins/cpp/model/include/model/cppfunction.h
+++ b/plugins/cpp/model/include/model/cppfunction.h
@@ -23,6 +23,7 @@ struct CppFunction : CppTypedEntity
   unsigned int mccabe;
   unsigned int bumpiness;
   unsigned int statementCount;
+  bool inLambdaObject = false;
 
   // Hash of the record (e.g. class or struct) in which this function is declared
   // recordHash = 0 means this is a global function

--- a/plugins/cpp/model/include/model/cppinheritance.h
+++ b/plugins/cpp/model/include/model/cppinheritance.h
@@ -2,6 +2,7 @@
 #define CC_MODEL_CPPINHERITANCE_H
 
 #include <memory>
+#include <cstdint>
 #include "common.h"
 
 namespace cc

--- a/plugins/cpp/parser/src/clangastvisitor.h
+++ b/plugins/cpp/parser/src/clangastvisitor.h
@@ -940,6 +940,7 @@ public:
       if (const clang::CXXRecordDecl* parent = md->getParent())
       {
         cppFunction->recordHash = util::fnvHash(getUSR(parent));
+        cppFunction->inLambdaObject = parent->isLambda();
       }
 
       if (md->isVirtual())

--- a/plugins/cpp_metrics/parser/include/cppmetricsparser/cppmetricsparser.h
+++ b/plugins/cpp_metrics/parser/include/cppmetricsparser/cppmetricsparser.h
@@ -94,6 +94,19 @@ private:
   // Returns cohesion record query based on parser configuration.
   odb::query<model::CohesionCppRecordView> getCohesionRecordQuery();
 
+  // Returns metric function query based on parser configuration.
+  template<typename TQueryParam>
+  odb::query<TQueryParam> getFunctionQuery() const
+  {
+    odb::query<TQueryParam> query = getFilterPathsQuery<TQueryParam>();
+
+    if (_ctx.options.count("cppmetrics-ignore-lambdas")) {
+      query = query && odb::query<TQueryParam>::CppFunction::inLambdaObject == false;
+    }
+
+    return query;
+  }
+
   /// @brief Constructs an ODB query that you can use to filter only
   /// the database records of the given parameter type whose path
   /// is rooted under any of this parser's input paths.


### PR DESCRIPTION
Previously, we calculated metrics for functions inside anonymous lambda objects. This has now been fixed.