### PR TITLE
Mandatory database name clarification

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -122,8 +122,7 @@ CodeCompass_parser -w <workspace> -n <name> -i <input1> -i <input2> -d <connecti
   input parameters.
 - **Database**: The plugins can use an SQL database as storage. By the
   connection string the user can give the location of a running database
-  system. If the database name is not given in the connection string then the
-  project name will be used. The database name should be different for each parsed project.
+  system. The database name should be different for each parsed project.
 
 For full documentation see `CodeCompass_parser -h`.
 


### PR DESCRIPTION
Clarified in the documentation that the database name should be different for each project.