### PR TITLE
Fix Python plugin project reparse

### DIFF
--- a/plugins/python/parser/include/pythonparser/pythonparser.h
+++ b/plugins/python/parser/include/pythonparser/pythonparser.h
@@ -26,6 +26,7 @@ public:
   PythonParser(ParserContext& ctx_);
   virtual ~PythonParser();
   virtual bool parse() override;
+  virtual bool cleanupDatabase() override;
 private:
   struct ParseResultStats {
     std::uint32_t partial;

--- a/plugins/python/parser/src/pythonparser.cpp
+++ b/plugins/python/parser/src/pythonparser.cpp
@@ -182,6 +182,19 @@ bool PythonParser::parse()
   return true;
 }
 
+bool PythonParser::cleanupDatabase()
+{
+  LOG(info) << "[pythonparser] Incremental parsing unsupported, cleaning up previous analysis results from database ...";
+  odb::connection_ptr connection = _ctx.db->connection();
+#ifdef DATABASE_PGSQL
+  connection->execute("TRUNCATE TABLE \"PYName\";");
+#else
+  connection->execute("DELETE FROM \"PYName\";");
+#endif
+  LOG(info) << "[pythonparser] Cleanup finished!";
+  return true;
+}
+
 PythonParser::~PythonParser()
 {
 }


### PR DESCRIPTION
Currently, if we try to reparse a Python project,
the CodeCompass_parser exits with the following error:
"terminate called after throwing an instance of
'odb::object_already_persistent'".

As a fix, we perform a database cleanup in case of
incremental parsing.
Note: incremental parsing is not intended to work this
way and should be implemented properly in the future.