### PR TITLE
Use language-service interface for diagram generation

### DIFF
--- a/plugins/python/service/include/service/pythonservice.h
+++ b/plugins/python/service/include/service/pythonservice.h
@@ -145,11 +145,11 @@ public:
 
   enum DiagramType
   {
-    FUNCTION_CALL,
-    MODULE_DEPENDENCY,
-    FUNCTION_USAGE,
-    CLASS_USAGE,
-    CLASS_OVERVIEW
+    FUNCTION_CALL = 0,
+    MODULE_DEPENDENCY = 10,
+    FUNCTION_USAGE = 11,
+    CLASS_USAGE = 12,
+    CLASS_OVERVIEW = 2
   };
 
 private:

--- a/webgui-new/src/components/diagrams/diagrams.tsx
+++ b/webgui-new/src/components/diagrams/diagrams.tsx
@@ -3,14 +3,14 @@ import { ZoomIn, ZoomOut } from '@mui/icons-material';
 import { FileName } from 'components/file-name/file-name';
 import React, { useContext, useEffect, useRef, useState, MouseEvent } from 'react';
 import {
-  getCppAstNodeInfo,
-  getCppDiagram,
-  getCppDiagramLegend,
-  getCppFileDiagram,
-  getCppFileDiagramLegend,
-  getCppReferenceTypes,
-  getCppReferences,
-} from 'service/cpp-service';
+  getAstNodeInfo,
+  getDiagram,
+  getDiagramLegend,
+  getFileDiagram,
+  getFileDiagramLegend,
+  getReferenceTypes,
+  getReferences,
+} from 'service/language-service';
 import { TransformWrapper, TransformComponent, ReactZoomPanPinchRef } from 'react-zoom-pan-pinch';
 import { FileInfo, AstNodeInfo } from '@thrift-generated';
 import { AppContext } from 'global-context/app-context';
@@ -44,17 +44,17 @@ export const Diagrams = (): JSX.Element => {
         appCtx.diagramType === 'file'
           ? await getFileInfo(appCtx.diagramGenId)
           : appCtx.diagramType === 'ast'
-          ? await getCppAstNodeInfo(appCtx.diagramGenId)
+          ? await getAstNodeInfo(appCtx.diagramGenId)
           : undefined;
 
       if (!initDiagramInfo) return;
 
       if (parseInt(appCtx.diagramTypeId) === 999) {
-        const refTypes = await getCppReferenceTypes(initDiagramInfo.id as string);
+        const refTypes = await getReferenceTypes(initDiagramInfo.id as string);
         if (refTypes.get('Definition') === undefined) return;
 
         const astNodeDef = (
-          await getCppReferences(initDiagramInfo.id as string, refTypes.get('Definition') as number, [])
+          await getReferences(initDiagramInfo.id as string, refTypes.get('Definition') as number, [])
         )[0];
 
         setDiagramInfo(astNodeDef);
@@ -64,9 +64,9 @@ export const Diagrams = (): JSX.Element => {
 
       const diagram =
         initDiagramInfo instanceof FileInfo
-          ? await getCppFileDiagram(appCtx.diagramGenId, parseInt(appCtx.diagramTypeId))
+          ? await getFileDiagram(appCtx.diagramGenId, parseInt(appCtx.diagramTypeId))
           : initDiagramInfo instanceof AstNodeInfo
-          ? await getCppDiagram(appCtx.diagramGenId, parseInt(appCtx.diagramTypeId))
+          ? await getDiagram(appCtx.diagramGenId, parseInt(appCtx.diagramTypeId))
           : '';
       
       sendGAEvent({
@@ -105,7 +105,7 @@ export const Diagrams = (): JSX.Element => {
       appCtx.diagramType === 'file'
         ? await getFileInfo(appCtx.diagramGenId)
         : appCtx.diagramType === 'ast'
-        ? await getCppAstNodeInfo(appCtx.diagramGenId)
+        ? await getAstNodeInfo(appCtx.diagramGenId)
         : undefined;
 
     if (!initDiagramInfo) return;
@@ -119,7 +119,7 @@ export const Diagrams = (): JSX.Element => {
         } as RouterQueryType,
       });
     } else if (initDiagramInfo instanceof AstNodeInfo) {
-      const astNodeInfo = await getCppAstNodeInfo(diagramGenId);
+      const astNodeInfo = await getAstNodeInfo(diagramGenId);
 
       router.push({
         pathname: '/project',
@@ -146,9 +146,9 @@ export const Diagrams = (): JSX.Element => {
 
     const diagramLegend =
       diagramInfo instanceof FileInfo
-        ? await getCppFileDiagramLegend(parseInt(appCtx.diagramTypeId))
+        ? await getFileDiagramLegend(parseInt(appCtx.diagramTypeId))
         : diagramInfo instanceof AstNodeInfo
-        ? await getCppDiagramLegend(parseInt(appCtx.diagramTypeId))
+        ? await getDiagramLegend(parseInt(appCtx.diagramTypeId))
         : '';
 
     const parser = new DOMParser();

--- a/webgui-new/src/components/file-context-menu/file-context-menu.tsx
+++ b/webgui-new/src/components/file-context-menu/file-context-menu.tsx
@@ -4,7 +4,7 @@ import MenuItem from '@mui/material/MenuItem';
 import { TabName } from 'enums/tab-enum';
 import { FileInfo } from '@thrift-generated';
 import { AppContext } from 'global-context/app-context';
-import { getCppFileDiagramTypes } from 'service/cpp-service';
+import { createClient, getFileDiagramTypes } from 'service/language-service';
 import { Tooltip } from '@mui/material';
 import { ChevronRight } from '@mui/icons-material';
 import { getBlameInfo, getRepositoryByProjectPath } from 'service/git-service';
@@ -40,7 +40,8 @@ export const FileContextMenu = ({
   useEffect(() => {
     if (!fileInfo) return;
     const init = async () => {
-      const initDiagramTypes = await getCppFileDiagramTypes(fileInfo.id as string);
+      createClient(appCtx.workspaceId, fileInfo?.type);
+      const initDiagramTypes = await getFileDiagramTypes(fileInfo.id as string);
       setDiagramTypes(initDiagramTypes);
     };
     init();

--- a/webgui-new/src/enums/entity-types.ts
+++ b/webgui-new/src/enums/entity-types.ts
@@ -48,6 +48,9 @@ const diagramTypeArray = [
   i18n.t('diagramTypes.INCLUDE_DEPENDENCY'),
   i18n.t('diagramTypes.INTERFACE'),
   i18n.t('diagramTypes.SUBSYSTEM_DEPENDENCY'),
+  i18n.t('diagramTypes.MODULE_DEPENDENCY'),
+  i18n.t('diagramTypes.FUNCTION_USAGE'),
+  i18n.t('diagramTypes.CLASS_USAGE'),
 ];
 
 export { referenceTypeArray, fileReferenceTypeArray, diagramTypeArray };

--- a/webgui-new/src/i18n/locales/en.json
+++ b/webgui-new/src/i18n/locales/en.json
@@ -354,7 +354,10 @@
     "EXTERNAL_USERS": "Users of this module",
     "INCLUDE_DEPENDENCY": "Include Dependency",
     "INTERFACE": "Interface Diagram",
-    "SUBSYSTEM_DEPENDENCY": "Internal architecture of this module"
+    "SUBSYSTEM_DEPENDENCY": "Internal architecture of this module",
+    "MODULE_DEPENDENCY": "Module dependency diagram",
+    "FUNCTION_USAGE": "Function usage diagram",
+    "CLASS_USAGE": "Class usage diagram"
   },
   "cookie": {
     "ACCEPT": "Accept",

--- a/webgui-new/src/service/language-service.ts
+++ b/webgui-new/src/service/language-service.ts
@@ -7,7 +7,7 @@ let client: LanguageService.Client | undefined;
 export const createClient = (workspace: string, fileType: string | undefined) => {
   if (!config || !fileType) return;
   
-  const service = () => 
+  const service = (() =>
   {
     switch(fileType)
     {
@@ -16,13 +16,15 @@ export const createClient = (workspace: string, fileType: string | undefined) =>
       case "PY":
         return "PythonService";
     }
-  };
+  })();
+
+  if (!service) return;
 
   const connection = thrift.createXHRConnection(config.webserver_host, config.webserver_port, {
     transport: thrift.TBufferedTransport,
     protocol: thrift.TJSONProtocol,
     https: config.webserver_https,
-    path: `${config.webserver_path}/${workspace}/${service()}`,
+    path: `${config.webserver_path}/${workspace}/${service}`,
   });
   client = thrift.createXHRClient(LanguageService, connection);
   return client;


### PR DESCRIPTION
Replaced CppService usage with the general language-service interface for generating diagrams in the new React WebGUI.

Also added new diagram names needed by the Python plugin.

Closes https://github.com/Ericsson/CodeCompass/issues/838

Example of a Python diagram that now works in the new WebGUI:

<img width="1906" height="930" alt="image" src="https://github.com/user-attachments/assets/43cd3616-db57-49ad-b39f-fe240b01f8f1" />
