### PR TITLE
Install python3-venv dependency for docker builds

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -20,6 +20,7 @@ RUN set -x && apt-get update -qq \
   libboost-program-options-dev \
   libboost-regex-dev \
   libboost-python-dev \
+  python3-venv \
   libgit2-dev \
   libgraphviz-dev \
   libgtest-dev \

--- a/docker/runtime/Dockerfile
+++ b/docker/runtime/Dockerfile
@@ -57,6 +57,7 @@ RUN set -x && apt-get update -qq && \
     wget \
     llvm-15 \
     libboost-filesystem-dev libboost-log-dev libboost-program-options-dev libboost-python-dev \
+    python3-venv \
     default-jre \
     libgit2-dev \
     libssl3 \


### PR DESCRIPTION
The `python3-venv` package is needed for creating Python virtual environments.